### PR TITLE
Harden translation configuration presets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,3 +36,7 @@ jobs:
       - name: Build x64 release
         shell: pwsh
         run: msbuild .\PhoenixTranslator.sln /m /p:Configuration=Release /p:Platform=x64
+
+      - name: Test translation presets
+        shell: pwsh
+        run: .\PhoenixTranslator.PresetTests\bin\x64\Release\PhoenixTranslator.PresetTests.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,9 @@ jobs:
           fetch-depth: 0
 
       - name: Validate release context
-        id: release
         shell: pwsh
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          NEXUSMODS_API_KEY: ${{ secrets.NEXUSMODS_API_KEY }}
-          NEXUSMODS_FILE_ID: ${{ secrets.NEXUSMODS_FILE_ID }}
         run: |
           git fetch --no-tags origin `
             "+refs/heads/${env:DEFAULT_BRANCH}:refs/remotes/origin/${env:DEFAULT_BRANCH}"
@@ -41,21 +38,6 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
               throw "The tag must point to a commit contained in '$env:DEFAULT_BRANCH'."
           }
-
-          $version = $env:GITHUB_REF_NAME -replace '^v', ''
-          if ([string]::IsNullOrWhiteSpace($version)) {
-              throw "The tag must contain a version after the 'v' prefix."
-          }
-
-          if ([string]::IsNullOrWhiteSpace($env:NEXUSMODS_API_KEY)) {
-              throw "The NEXUSMODS_API_KEY Actions secret is not configured."
-          }
-
-          if ([string]::IsNullOrWhiteSpace($env:NEXUSMODS_FILE_ID)) {
-              throw "The NEXUSMODS_FILE_ID Actions secret is not configured."
-          }
-
-          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Configure NuGet
         uses: NuGet/setup-nuget@v2
@@ -107,13 +89,3 @@ jobs:
             --generate-notes `
             --verify-tag
 
-      - name: Publish Nexus Mods release
-        uses: Nexus-Mods/upload-action@c96019556046053aa26044b44396cd38929daf23 # v1.0.0-beta.10
-        with:
-          api_key: ${{ secrets.NEXUSMODS_API_KEY }}
-          file_id: ${{ secrets.NEXUSMODS_FILE_ID }}
-          filename: .\artifacts\PhoenixTranslator-win-x64.zip
-          version: ${{ steps.release.outputs.version }}
-          display_name: Phoenix Translator ${{ steps.release.outputs.version }}
-          category: main
-          update_mod_version: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,4 +88,3 @@ jobs:
             ".\artifacts\PhoenixTranslator-win-x64.zip.sha256" `
             --generate-notes `
             --verify-tag
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,10 @@ jobs:
         shell: pwsh
         run: msbuild .\PhoenixTranslator.sln /m /p:Configuration=Release /p:Platform=x64
 
+      - name: Test translation presets
+        shell: pwsh
+        run: .\PhoenixTranslator.PresetTests\bin\x64\Release\PhoenixTranslator.PresetTests.exe
+
       - name: Package release
         shell: pwsh
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 dependencies/
 packages/
 artifacts/
+.test-results/
 *.pdb
 *.suo
 *.user

--- a/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
+++ b/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4BDAF33C-ECC7-4C72-8545-9266CA76A3D2}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>PhoenixTranslator.PresetTests</RootNamespace>
+    <AssemblyName>PhoenixTranslator.PresetTests</AssemblyName>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <LangVersion>7.3</LangVersion>
+    <Deterministic>true</Deterministic>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Phoenix_Translator\Application\TranslationPresetService.cs">
+      <Link>TranslationPresetService.cs</Link>
+    </Compile>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/PhoenixTranslator.PresetTests/Program.cs
+++ b/PhoenixTranslator.PresetTests/Program.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using PhoenixTranslator.ApplicationLayer;
+
+namespace PhoenixTranslator.PresetTests
+{
+    internal static class Program
+    {
+        private static int Main()
+        {
+            var tests = new Dictionary<string, Action>
+            {
+                { nameof(PreservesCustomSettingsOnLoad), PreservesCustomSettingsOnLoad },
+                { nameof(AppliesNamedPresetOnce), AppliesNamedPresetOnce },
+                { nameof(MarksManualEditsAsCustom), MarksManualEditsAsCustom },
+                { nameof(BoundsAndValidatesPresetValues), BoundsAndValidatesPresetValues }
+            };
+            int failures = 0;
+            foreach (KeyValuePair<string, Action> test in tests)
+            {
+                try
+                {
+                    test.Value();
+                    Console.WriteLine("Passed {0}", test.Key);
+                }
+                catch (Exception exception)
+                {
+                    failures++;
+                    Console.Error.WriteLine("Failed {0}: {1}", test.Key, exception);
+                }
+            }
+
+            Console.WriteLine("{0} tests passed; {1} failed.", tests.Count - failures, failures);
+            return failures == 0 ? 0 : 1;
+        }
+
+        private static void PreservesCustomSettingsOnLoad()
+        {
+            var store = new RecordingStore(
+                TranslationPreset.Custom,
+                new TranslationPresetSettings(777, 4321, true, true, false));
+            var coordinator = CreateCoordinator(store);
+
+            TranslationPresetSelection selection = coordinator.Load();
+
+            AssertEqual(TranslationPreset.Custom, selection.Preset, "Existing values must remain custom.");
+            AssertEqual(777, store.Settings.ContextLimit, "Loading must preserve the context limit.");
+            AssertEqual(0, store.SaveCalls, "Loading must not save configuration.");
+        }
+
+        private static void AppliesNamedPresetOnce()
+        {
+            var store = new RecordingStore(
+                TranslationPreset.Custom,
+                new TranslationPresetSettings(777, 4321, true, true, false));
+            var coordinator = CreateCoordinator(store);
+            TranslationPresetSelection selection;
+
+            AssertEqual(true, coordinator.TrySelect(TranslationPreset.Balanced, out selection),
+                "Balanced must be selectable.");
+            AssertEqual(200, store.Settings.ContextLimit, "Balanced must apply the complete context limit.");
+            AssertEqual(3900, store.Settings.BucketLengthLimit, "Balanced must apply the complete bucket limit.");
+            AssertEqual(1, store.SaveCalls, "One selection must save exactly once.");
+        }
+
+        private static void MarksManualEditsAsCustom()
+        {
+            var store = new RecordingStore(
+                TranslationPreset.Balanced,
+                new TranslationPresetSettings(200, 3900, false, false, false));
+            var coordinator = CreateCoordinator(store);
+            TranslationPresetSelection selection;
+
+            AssertEqual(true, coordinator.TryApplyCustomSettings(
+                new TranslationPresetSettings(250, 3900, false, false, false),
+                false,
+                out selection),
+                "A valid manual edit must be applied.");
+            AssertEqual(TranslationPreset.Custom, store.Preset, "A manual edit must select Custom.");
+            AssertEqual(0, store.SaveCalls, "A text edit may use the existing shutdown save.");
+        }
+
+        private static void BoundsAndValidatesPresetValues()
+        {
+            var service = new TranslationPresetService();
+            foreach (TranslationPreset preset in new[]
+            {
+                TranslationPreset.Balanced,
+                TranslationPreset.QualityFirst,
+                TranslationPreset.SpeedFirst
+            })
+            {
+                TranslationPresetProfile profile;
+                AssertEqual(true, service.TryGetProfile(preset, out profile),
+                    preset + " must define a complete profile.");
+                AssertEqual(true, profile.TranslationQuality >= 0 && profile.TranslationQuality <= 100,
+                    preset + " quality must stay within the radar range.");
+                AssertEqual(true, profile.TranslationSpeed >= 0 && profile.TranslationSpeed <= 100,
+                    preset + " speed must stay within the radar range.");
+            }
+
+            AssertEqual(false, service.IsValid(
+                new TranslationPresetSettings(0, 3900, false, false, false)),
+                "Zero context length must be rejected.");
+        }
+
+        private static TranslationPresetCoordinator CreateCoordinator(RecordingStore store)
+        {
+            return new TranslationPresetCoordinator(new TranslationPresetService(), store);
+        }
+
+        private static void AssertEqual<T>(T expected, T actual, string message)
+        {
+            if (!EqualityComparer<T>.Default.Equals(expected, actual))
+            {
+                throw new InvalidOperationException(string.Format(
+                    "{0} Expected <{1}> but received <{2}>.",
+                    message,
+                    expected,
+                    actual));
+            }
+        }
+
+        private sealed class RecordingStore : ITranslationPresetStore
+        {
+            internal RecordingStore(TranslationPreset preset, TranslationPresetSettings settings)
+            {
+                Preset = preset;
+                Settings = settings;
+            }
+
+            public TranslationPreset Preset { get; set; }
+
+            internal TranslationPresetSettings Settings { get; private set; }
+
+            internal int SaveCalls { get; private set; }
+
+            public TranslationPresetSettings ReadSettings()
+            {
+                return Settings;
+            }
+
+            public void ApplySettings(TranslationPresetSettings settings)
+            {
+                Settings = settings;
+            }
+
+            public void Save()
+            {
+                SaveCalls++;
+            }
+        }
+    }
+}

--- a/PhoenixTranslator.PresetTests/Properties/AssemblyInfo.cs
+++ b/PhoenixTranslator.PresetTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,15 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("PhoenixTranslator.PresetTests")]
+[assembly: AssemblyDescription("Windowless translation preset regression tests")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("PhoenixTranslator.PresetTests")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: ComVisible(false)]
+[assembly: Guid("9f516a27-dbe6-4c84-8480-e1cc7938a696")]
+[assembly: AssemblyVersion("2.0.0.1")]
+[assembly: AssemblyFileVersion("2.0.0.1")]

--- a/PhoenixTranslator.sln
+++ b/PhoenixTranslator.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.13.35931.197
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhoenixTranslator", "Phoenix_Translator\PhoenixTranslator.csproj", "{51385157-5E4E-4271-B9A6-298B567C7935}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhoenixTranslator.PresetTests", "PhoenixTranslator.PresetTests\PhoenixTranslator.PresetTests.csproj", "{4BDAF33C-ECC7-4C72-8545-9266CA76A3D2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,14 @@ Global
 		{51385157-5E4E-4271-B9A6-298B567C7935}.Release|Any CPU.Build.0 = Release|Any CPU
 		{51385157-5E4E-4271-B9A6-298B567C7935}.Release|x64.ActiveCfg = Release|x64
 		{51385157-5E4E-4271-B9A6-298B567C7935}.Release|x64.Build.0 = Release|x64
+		{4BDAF33C-ECC7-4C72-8545-9266CA76A3D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BDAF33C-ECC7-4C72-8545-9266CA76A3D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4BDAF33C-ECC7-4C72-8545-9266CA76A3D2}.Debug|x64.ActiveCfg = Debug|x64
+		{4BDAF33C-ECC7-4C72-8545-9266CA76A3D2}.Debug|x64.Build.0 = Debug|x64
+		{4BDAF33C-ECC7-4C72-8545-9266CA76A3D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4BDAF33C-ECC7-4C72-8545-9266CA76A3D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4BDAF33C-ECC7-4C72-8545-9266CA76A3D2}.Release|x64.ActiveCfg = Release|x64
+		{4BDAF33C-ECC7-4C72-8545-9266CA76A3D2}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Phoenix_Translator/Application/LegacyTranslationPresetStore.cs
+++ b/Phoenix_Translator/Application/LegacyTranslationPresetStore.cs
@@ -1,0 +1,48 @@
+using System;
+using PhoenixEngine;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>Adapts existing engine and local settings persistence to preset coordination.</summary>
+    internal sealed class LegacyTranslationPresetStore : ITranslationPresetStore
+    {
+        /// <inheritdoc />
+        public TranslationPreset Preset
+        {
+            get => DeFine.GlobalLocalSetting.Preset;
+            set => DeFine.GlobalLocalSetting.Preset = value;
+        }
+
+        /// <inheritdoc />
+        public TranslationPresetSettings ReadSettings()
+        {
+            return new TranslationPresetSettings(
+                Phoenix.Config.ContextLimit,
+                Phoenix.Config.BucketLengthLimit,
+                Phoenix.Config.PreserveConversationContext,
+                Phoenix.Config.ForceContextDeduplication,
+                Phoenix.Config.StrictLinkBucketPurity);
+        }
+
+        /// <inheritdoc />
+        public void ApplySettings(TranslationPresetSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            Phoenix.Config.ContextLimit = settings.ContextLimit;
+            Phoenix.Config.BucketLengthLimit = settings.BucketLengthLimit;
+            Phoenix.Config.PreserveConversationContext = settings.PreserveConversationContext;
+            Phoenix.Config.ForceContextDeduplication = settings.ForceContextDeduplication;
+            Phoenix.Config.StrictLinkBucketPurity = settings.StrictLinkBucketPurity;
+        }
+
+        /// <inheritdoc />
+        public void Save()
+        {
+            DeFine.GlobalLocalSetting.SaveConfig();
+        }
+    }
+}

--- a/Phoenix_Translator/Application/TranslationPresetService.cs
+++ b/Phoenix_Translator/Application/TranslationPresetService.cs
@@ -1,0 +1,332 @@
+using System;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Identifies a reusable translation-engine configuration or an explicitly customized configuration.
+    /// </summary>
+    public enum TranslationPreset
+    {
+        /// <summary>Preserves values selected individually by the user.</summary>
+        Custom = 0,
+
+        /// <summary>Balances translation quality, speed, and context size.</summary>
+        Balanced = 1,
+
+        /// <summary>Prioritizes context completeness and translation quality.</summary>
+        QualityFirst = 2,
+
+        /// <summary>Prioritizes throughput and reduced context overhead.</summary>
+        SpeedFirst = 3
+    }
+
+    /// <summary>Contains the engine values controlled together by a translation preset.</summary>
+    internal sealed class TranslationPresetSettings
+    {
+        /// <summary>Creates one complete preset-controlled settings snapshot.</summary>
+        internal TranslationPresetSettings(
+            int contextLimit,
+            int bucketLengthLimit,
+            bool preserveConversationContext,
+            bool forceContextDeduplication,
+            bool strictLinkBucketPurity)
+        {
+            ContextLimit = contextLimit;
+            BucketLengthLimit = bucketLengthLimit;
+            PreserveConversationContext = preserveConversationContext;
+            ForceContextDeduplication = forceContextDeduplication;
+            StrictLinkBucketPurity = strictLinkBucketPurity;
+        }
+
+        /// <summary>Gets the maximum generated context length in characters.</summary>
+        internal int ContextLimit { get; }
+
+        /// <summary>Gets the maximum translation bucket length in characters.</summary>
+        internal int BucketLengthLimit { get; }
+
+        /// <summary>Gets whether translated conversation lines remain in subsequent context.</summary>
+        internal bool PreserveConversationContext { get; }
+
+        /// <summary>Gets whether confirmed relationship contexts remove duplicate lines.</summary>
+        internal bool ForceContextDeduplication { get; }
+
+        /// <summary>Gets whether link buckets reject unrelated capacity backfill.</summary>
+        internal bool StrictLinkBucketPurity { get; }
+    }
+
+    /// <summary>Combines one validated settings snapshot with bounded values for its visual summary.</summary>
+    internal sealed class TranslationPresetProfile
+    {
+        /// <summary>Creates one immutable preset profile.</summary>
+        internal TranslationPresetProfile(
+            TranslationPresetSettings settings,
+            double translationQuality,
+            double translationSpeed)
+        {
+            Settings = settings ?? throw new ArgumentNullException(nameof(settings));
+            TranslationQuality = translationQuality;
+            TranslationSpeed = translationSpeed;
+        }
+
+        /// <summary>Gets the complete engine settings controlled by the profile.</summary>
+        internal TranslationPresetSettings Settings { get; }
+
+        /// <summary>Gets the visual quality score in the inclusive range from zero to one hundred.</summary>
+        internal double TranslationQuality { get; }
+
+        /// <summary>Gets the visual speed score in the inclusive range from zero to one hundred.</summary>
+        internal double TranslationSpeed { get; }
+    }
+
+    /// <summary>Defines the engine and persistence boundary used by preset coordination.</summary>
+    internal interface ITranslationPresetStore
+    {
+        /// <summary>Gets or sets the persisted preset identity.</summary>
+        TranslationPreset Preset { get; set; }
+
+        /// <summary>Reads a complete snapshot of the current engine values.</summary>
+        /// <returns>The current preset-controlled engine values.</returns>
+        TranslationPresetSettings ReadSettings();
+
+        /// <summary>Applies a complete validated settings snapshot to the engine.</summary>
+        /// <param name="settings">The complete settings snapshot to apply.</param>
+        void ApplySettings(TranslationPresetSettings settings);
+
+        /// <summary>Persists the current preset identity and engine configuration.</summary>
+        void Save();
+    }
+
+    /// <summary>Represents the complete preset state projected to the settings view.</summary>
+    internal sealed class TranslationPresetSelection
+    {
+        /// <summary>Creates one immutable settings-view projection.</summary>
+        internal TranslationPresetSelection(
+            TranslationPreset preset,
+            TranslationPresetSettings settings,
+            TranslationPresetProfile profile)
+        {
+            Preset = preset;
+            Settings = settings ?? throw new ArgumentNullException(nameof(settings));
+            Profile = profile ?? throw new ArgumentNullException(nameof(profile));
+        }
+
+        /// <summary>Gets the reconciled preset identity.</summary>
+        internal TranslationPreset Preset { get; }
+
+        /// <summary>Gets the current complete engine settings.</summary>
+        internal TranslationPresetSettings Settings { get; }
+
+        /// <summary>Gets the bounded visual profile.</summary>
+        internal TranslationPresetProfile Profile { get; }
+    }
+
+    /// <summary>
+    /// Creates, validates, and reconciles translation configuration presets without UI or persistence access.
+    /// </summary>
+    internal sealed class TranslationPresetService
+    {
+        private const int MinimumLength = 1;
+        private const int MaximumLength = 100000;
+
+        /// <summary>Gets a validated profile for a named preset.</summary>
+        /// <param name="preset">The named preset to resolve.</param>
+        /// <param name="profile">Receives the complete profile when the preset is named and supported.</param>
+        /// <returns><c>true</c> when a complete named profile was returned.</returns>
+        internal bool TryGetProfile(TranslationPreset preset, out TranslationPresetProfile profile)
+        {
+            switch (preset)
+            {
+                case TranslationPreset.Balanced:
+                    profile = CreateProfile(200, 3900, false, false, false, 88, 75);
+                    return true;
+                case TranslationPreset.QualityFirst:
+                    profile = CreateProfile(1000, 3900, true, false, true, 100, 60);
+                    return true;
+                case TranslationPreset.SpeedFirst:
+                    profile = CreateProfile(200, 5000, false, true, false, 68, 95);
+                    return true;
+                default:
+                    profile = null;
+                    return false;
+            }
+        }
+
+        /// <summary>Reconciles persisted preset identity with the current engine values.</summary>
+        /// <param name="persistedPreset">The preset identity stored with local settings.</param>
+        /// <param name="settings">The current engine settings.</param>
+        /// <returns>
+        /// The persisted preset when all values still match; otherwise <see cref="TranslationPreset.Custom"/>.
+        /// </returns>
+        internal TranslationPreset Reconcile(
+            TranslationPreset persistedPreset,
+            TranslationPresetSettings settings)
+        {
+            if (settings == null || persistedPreset == TranslationPreset.Custom)
+            {
+                return TranslationPreset.Custom;
+            }
+
+            TranslationPresetProfile profile;
+            return TryGetProfile(persistedPreset, out profile) && AreEquivalent(profile.Settings, settings)
+                ? persistedPreset
+                : TranslationPreset.Custom;
+        }
+
+        /// <summary>Checks whether numeric preset values are within supported application bounds.</summary>
+        /// <param name="settings">The settings snapshot to validate.</param>
+        /// <returns><c>true</c> when both length limits are supported.</returns>
+        internal bool IsValid(TranslationPresetSettings settings)
+        {
+            return settings != null &&
+                IsValidLength(settings.ContextLimit) &&
+                IsValidLength(settings.BucketLengthLimit);
+        }
+
+        private static TranslationPresetProfile CreateProfile(
+            int contextLimit,
+            int bucketLengthLimit,
+            bool preserveConversationContext,
+            bool forceContextDeduplication,
+            bool strictLinkBucketPurity,
+            double translationQuality,
+            double translationSpeed)
+        {
+            return new TranslationPresetProfile(
+                new TranslationPresetSettings(
+                    contextLimit,
+                    bucketLengthLimit,
+                    preserveConversationContext,
+                    forceContextDeduplication,
+                    strictLinkBucketPurity),
+                ClampScore(translationQuality),
+                ClampScore(translationSpeed));
+        }
+
+        private static bool AreEquivalent(
+            TranslationPresetSettings left,
+            TranslationPresetSettings right)
+        {
+            return left.ContextLimit == right.ContextLimit &&
+                left.BucketLengthLimit == right.BucketLengthLimit &&
+                left.PreserveConversationContext == right.PreserveConversationContext &&
+                left.ForceContextDeduplication == right.ForceContextDeduplication &&
+                left.StrictLinkBucketPurity == right.StrictLinkBucketPurity;
+        }
+
+        private static bool IsValidLength(int value)
+        {
+            return value >= MinimumLength && value <= MaximumLength;
+        }
+
+        private static double ClampScore(double value)
+        {
+            return Math.Max(0, Math.Min(100, value));
+        }
+    }
+
+    /// <summary>Coordinates preset selection, custom edits, and persistence without exposing them to WPF.</summary>
+    internal sealed class TranslationPresetCoordinator
+    {
+        private readonly TranslationPresetService _service;
+        private readonly ITranslationPresetStore _store;
+
+        /// <summary>Creates a coordinator for the supplied preset rules and storage boundary.</summary>
+        internal TranslationPresetCoordinator(
+            TranslationPresetService service,
+            ITranslationPresetStore store)
+        {
+            _service = service ?? throw new ArgumentNullException(nameof(service));
+            _store = store ?? throw new ArgumentNullException(nameof(store));
+        }
+
+        /// <summary>Loads current values without applying or persisting replacement settings.</summary>
+        /// <returns>The reconciled state to display.</returns>
+        internal TranslationPresetSelection Load()
+        {
+            TranslationPresetSettings settings = _store.ReadSettings();
+            TranslationPreset preset = _service.Reconcile(_store.Preset, settings);
+            _store.Preset = preset;
+            return CreateSelection(preset, settings);
+        }
+
+        /// <summary>Gets the current engine values without changing preset identity.</summary>
+        /// <returns>The current complete settings snapshot.</returns>
+        internal TranslationPresetSettings GetCurrentSettings()
+        {
+            return _store.ReadSettings();
+        }
+
+        /// <summary>Applies and persists one explicitly selected preset.</summary>
+        /// <param name="preset">The preset selected by the user.</param>
+        /// <param name="selection">Receives the complete resulting view state.</param>
+        /// <returns><c>true</c> when the preset is supported and was persisted.</returns>
+        internal bool TrySelect(
+            TranslationPreset preset,
+            out TranslationPresetSelection selection)
+        {
+            TranslationPresetSettings settings;
+            if (preset == TranslationPreset.Custom)
+            {
+                settings = _store.ReadSettings();
+            }
+            else
+            {
+                TranslationPresetProfile profile;
+                if (!_service.TryGetProfile(preset, out profile) ||
+                    !_service.IsValid(profile.Settings))
+                {
+                    selection = null;
+                    return false;
+                }
+
+                settings = profile.Settings;
+                _store.ApplySettings(settings);
+            }
+
+            _store.Preset = preset;
+            _store.Save();
+            selection = CreateSelection(preset, settings);
+            return true;
+        }
+
+        /// <summary>Applies a complete manual edit and changes the preset identity to custom.</summary>
+        /// <param name="settings">The complete edited settings snapshot.</param>
+        /// <param name="persistImmediately">Indicates whether the complete state must be saved immediately.</param>
+        /// <param name="selection">Receives the complete resulting view state.</param>
+        /// <returns><c>true</c> when the edited values are valid and were applied.</returns>
+        internal bool TryApplyCustomSettings(
+            TranslationPresetSettings settings,
+            bool persistImmediately,
+            out TranslationPresetSelection selection)
+        {
+            if (!_service.IsValid(settings))
+            {
+                selection = null;
+                return false;
+            }
+
+            _store.ApplySettings(settings);
+            _store.Preset = TranslationPreset.Custom;
+            if (persistImmediately)
+            {
+                _store.Save();
+            }
+
+            selection = CreateSelection(TranslationPreset.Custom, settings);
+            return true;
+        }
+
+        private TranslationPresetSelection CreateSelection(
+            TranslationPreset preset,
+            TranslationPresetSettings settings)
+        {
+            TranslationPresetProfile profile;
+            if (!_service.TryGetProfile(preset, out profile))
+            {
+                _service.TryGetProfile(TranslationPreset.Balanced, out profile);
+            }
+
+            return new TranslationPresetSelection(preset, settings, profile);
+        }
+    }
+}

--- a/Phoenix_Translator/DeFine.cs
+++ b/Phoenix_Translator/DeFine.cs
@@ -11,6 +11,7 @@ using PhoenixEngine;
 using PhoenixEngine.Language;
 using PhoenixEngine.ADO;
 using PhoenixEngine.Engine.ADO;
+using PhoenixTranslator.ApplicationLayer;
 
 namespace PhoenixTranslator
 {
@@ -159,14 +160,11 @@ namespace PhoenixTranslator
         }
     }
 
-    public enum GlobalPresets
-    {
-        Custom = 0, Balanced = 1, QualityFirst = 2, SpeedFirst = 3
-    }
-
     public class LocalSetting
     {
-        public GlobalPresets Preset = GlobalPresets.Balanced;
+        /// <summary>Provides the explicitly selected translation configuration preset.</summary>
+        /// <remarks>Settings created before presets existed migrate safely to <c>Custom</c>.</remarks>
+        public TranslationPreset Preset { get; set; } = TranslationPreset.Custom;
         public int Style { get; set; } = 1;
         public double FormHeight { get; set; } = 850;
         public double FormWidth { get; set; } = 1200;

--- a/Phoenix_Translator/PhoenixGui.xaml.cs
+++ b/Phoenix_Translator/PhoenixGui.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Media.Animation;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using PhoenixTranslator.FileManagement;
+using PhoenixTranslator.ApplicationLayer;
 using PhoenixTranslator.SkyrimManagement;
 using PhoenixTranslator.TranslateManage;
 using PhoenixTranslator.UIManage;
@@ -33,8 +34,14 @@ namespace PhoenixTranslator
     /// </summary>
     public partial class PhoenixGui : Window
     {
+        private readonly TranslationPresetCoordinator _translationPresetCoordinator;
+        private bool _isUpdatingTranslationPresetControls;
+
         public PhoenixGui()
         {
+            _translationPresetCoordinator = new TranslationPresetCoordinator(
+                new TranslationPresetService(),
+                new LegacyTranslationPresetStore());
             InitializeComponent();
         }
 
@@ -1303,45 +1310,7 @@ namespace PhoenixTranslator
             else
             if (Name.Equals("Engine Configs"))
             {
-                Presets.Items.Clear();
-
-                foreach (GlobalPresets Preset in Enum.GetValues(typeof(GlobalPresets)))
-                {
-                    Presets.Items.Add(Preset.ToString());
-                }
-
-                Presets.SelectedValue = DeFine.GlobalLocalSetting.Preset.ToString();
-
-                BucketLengthLimit.Text = Phoenix.Config.BucketLengthLimit.ToString();
-
-                if (Phoenix.Config.PreserveConversationContext)
-                {
-                    PreserveConversationContext.IsChecked = true;
-                }
-                else
-                {
-                    PreserveConversationContext.IsChecked = false;
-                }
-
-                if (Phoenix.Config.ForceContextDeduplication)
-                {
-                    ForceContextDeduplication.IsChecked = true;
-                }
-                else
-                {
-                    ForceContextDeduplication.IsChecked = false;
-                }
-
-                if (Phoenix.Config.StrictLinkBucketPurity)
-                {
-                    StrictLinkBucketPurity.IsChecked = true;
-                }
-                else
-                {
-                    StrictLinkBucketPurity.IsChecked = false;
-                }
-
-                SContextLimit.Text = Phoenix.Config.ContextLimit.ToString();
+                LoadTranslationPresetControls();
 
                 if (Phoenix.Config.ContextEnable)
                 {
@@ -1629,7 +1598,25 @@ namespace PhoenixTranslator
 
         private void SContextLimit_TextChanged(object sender, TextChangedEventArgs e)
         {
-            Phoenix.Config.ContextLimit = P_Convert.ObjToInt(SContextLimit.Text);
+            int value;
+            if (_isUpdatingTranslationPresetControls ||
+                !int.TryParse(SContextLimit.Text, out value))
+            {
+                return;
+            }
+
+            TranslationPresetSettings current = _translationPresetCoordinator.GetCurrentSettings();
+            var settings = new TranslationPresetSettings(
+                value,
+                current.BucketLengthLimit,
+                current.PreserveConversationContext,
+                current.ForceContextDeduplication,
+                current.StrictLinkBucketPurity);
+            TranslationPresetSelection selection;
+            if (_translationPresetCoordinator.TryApplyCustomSettings(settings, false, out selection))
+            {
+                ApplyTranslationPresetSelection(selection, false);
+            }
         }
 
         private void SAIKeyword_TextChanged(object sender, TextChangedEventArgs e)
@@ -1694,131 +1681,161 @@ namespace PhoenixTranslator
             }
         }
 
+        private void LoadTranslationPresetControls()
+        {
+            _isUpdatingTranslationPresetControls = true;
+            try
+            {
+                Presets.Items.Clear();
+                foreach (TranslationPreset preset in Enum.GetValues(typeof(TranslationPreset)))
+                {
+                    Presets.Items.Add(preset.ToString());
+                }
+
+                ApplyTranslationPresetSelection(_translationPresetCoordinator.Load(), true);
+            }
+            finally
+            {
+                _isUpdatingTranslationPresetControls = false;
+            }
+        }
+
+        private void ApplyTranslationPresetSelection(
+            TranslationPresetSelection selection,
+            bool applySettingsToControls)
+        {
+            bool wasUpdating = _isUpdatingTranslationPresetControls;
+            _isUpdatingTranslationPresetControls = true;
+            try
+            {
+                if (applySettingsToControls)
+                {
+                    SContextLimit.Text = selection.Settings.ContextLimit.ToString();
+                    BucketLengthLimit.Text = selection.Settings.BucketLengthLimit.ToString();
+                    PreserveConversationContext.IsChecked =
+                        selection.Settings.PreserveConversationContext;
+                    ForceContextDeduplication.IsChecked =
+                        selection.Settings.ForceContextDeduplication;
+                    StrictLinkBucketPurity.IsChecked = selection.Settings.StrictLinkBucketPurity;
+                }
+
+                Presets.SelectedValue = selection.Preset.ToString();
+                RadarChart.TranslationQuality = selection.Profile.TranslationQuality;
+                RadarChart.TranslationSpeed = selection.Profile.TranslationSpeed;
+            }
+            finally
+            {
+                _isUpdatingTranslationPresetControls = wasUpdating;
+            }
+        }
+
         private void Presets_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            string GetPreset = P_Convert.ObjToStr(Presets.SelectedValue);
-            if (!Enum.TryParse<GlobalPresets>(GetPreset, out var Preset))
-                return;
-            switch (Preset)
+            if (_isUpdatingTranslationPresetControls)
             {
-                case GlobalPresets.Custom:
-                    {
-                        RadarChart.TranslationQuality = 88;
-                        RadarChart.TranslationSpeed = 75;
-                    }
-                    break;
-                case GlobalPresets.QualityFirst:
-                    {
-                        StrictLinkBucketPurity.IsChecked = true;
-                        Phoenix.Config.StrictLinkBucketPurity = true;
-
-                        ForceContextDeduplication.IsChecked = false;
-                        Phoenix.Config.ForceContextDeduplication = false;
-
-                        PreserveConversationContext.IsChecked = true;
-                        Phoenix.Config.PreserveConversationContext = true;
-
-                        SContextLimit.Text = "1000";
-
-                        BucketLengthLimit.Text = "3900";
-
-                        RadarChart.TranslationQuality = 88 + 15;
-                        RadarChart.TranslationSpeed = 75 - 15;
-                    }
-                    break;
-                case GlobalPresets.Balanced:
-                    {
-                        StrictLinkBucketPurity.IsChecked = false;
-                        Phoenix.Config.StrictLinkBucketPurity = false;
-
-                        ForceContextDeduplication.IsChecked = false;
-                        Phoenix.Config.ForceContextDeduplication = false;
-
-                        PreserveConversationContext.IsChecked = false;
-                        Phoenix.Config.PreserveConversationContext = false;
-
-                        SContextLimit.Text = "200";
-
-                        BucketLengthLimit.Text = "3900";
-
-                        RadarChart.TranslationQuality = 88;
-                        RadarChart.TranslationSpeed = 75;
-                    }
-                    break;
-                case GlobalPresets.SpeedFirst:
-                    {
-                        StrictLinkBucketPurity.IsChecked = false;
-                        Phoenix.Config.StrictLinkBucketPurity = false;
-
-                        ForceContextDeduplication.IsChecked = true;
-                        Phoenix.Config.ForceContextDeduplication = true;
-
-                        PreserveConversationContext.IsChecked = false;
-                        Phoenix.Config.PreserveConversationContext = false;
-
-                        SContextLimit.Text = "200";
-
-                        BucketLengthLimit.Text = "5000";
-
-                        RadarChart.TranslationQuality = 88 - 20;
-                        RadarChart.TranslationSpeed = 75 + 20;
-                    }
-                    break;
+                return;
             }
 
-            if (DeFine.GlobalLocalSetting.Preset != Preset)
+            TranslationPreset preset;
+            if (!Enum.TryParse(P_Convert.ObjToStr(Presets.SelectedValue), out preset))
             {
-                DeFine.GlobalLocalSetting.Preset = Preset;
-                Phoenix.SaveConfig();
-                DeFine.GlobalLocalSetting.SaveConfig();
+                return;
+            }
+
+            TranslationPresetSelection selection;
+            if (_translationPresetCoordinator.TrySelect(preset, out selection))
+            {
+                ApplyTranslationPresetSelection(
+                    selection,
+                    preset != TranslationPreset.Custom);
             }
         }
 
         private void BucketLengthLimit_TextChanged(object sender, TextChangedEventArgs e)
         {
-            Phoenix.Config.BucketLengthLimit = P_Convert.ObjToInt(BucketLengthLimit.Text);
+            int value;
+            if (_isUpdatingTranslationPresetControls ||
+                !int.TryParse(BucketLengthLimit.Text, out value))
+            {
+                return;
+            }
+
+            TranslationPresetSettings current = _translationPresetCoordinator.GetCurrentSettings();
+            var settings = new TranslationPresetSettings(
+                current.ContextLimit,
+                value,
+                current.PreserveConversationContext,
+                current.ForceContextDeduplication,
+                current.StrictLinkBucketPurity);
+            ApplyCustomTranslationPresetSettings(settings, false);
         }
 
         private void PreserveConversationContext_Click(object sender, RoutedEventArgs e)
         {
-            if (PreserveConversationContext.IsChecked == true)
+            if (_isUpdatingTranslationPresetControls)
             {
-                Phoenix.Config.PreserveConversationContext = true;
-            }
-            else
-            {
-                Phoenix.Config.PreserveConversationContext = false;
+                return;
             }
 
-            Phoenix.SaveConfig();
+            TranslationPresetSettings current = _translationPresetCoordinator.GetCurrentSettings();
+            ApplyCustomTranslationPresetSettings(
+                new TranslationPresetSettings(
+                    current.ContextLimit,
+                    current.BucketLengthLimit,
+                    PreserveConversationContext.IsChecked == true,
+                    current.ForceContextDeduplication,
+                    current.StrictLinkBucketPurity),
+                true);
         }
 
         private void ForceContextDeduplication_Click(object sender, RoutedEventArgs e)
         {
-            if (ForceContextDeduplication.IsChecked == true)
+            if (_isUpdatingTranslationPresetControls)
             {
-                Phoenix.Config.ForceContextDeduplication = true;
-            }
-            else
-            {
-                Phoenix.Config.ForceContextDeduplication = false;
+                return;
             }
 
-            Phoenix.SaveConfig();
+            TranslationPresetSettings current = _translationPresetCoordinator.GetCurrentSettings();
+            ApplyCustomTranslationPresetSettings(
+                new TranslationPresetSettings(
+                    current.ContextLimit,
+                    current.BucketLengthLimit,
+                    current.PreserveConversationContext,
+                    ForceContextDeduplication.IsChecked == true,
+                    current.StrictLinkBucketPurity),
+                true);
         }
 
         private void StrictLinkBucketPurity_Click(object sender, RoutedEventArgs e)
         {
-            if (StrictLinkBucketPurity.IsChecked == true)
+            if (_isUpdatingTranslationPresetControls)
             {
-                Phoenix.Config.StrictLinkBucketPurity = true;
-            }
-            else
-            {
-                Phoenix.Config.StrictLinkBucketPurity = false;
+                return;
             }
 
-            Phoenix.SaveConfig();
+            TranslationPresetSettings current = _translationPresetCoordinator.GetCurrentSettings();
+            ApplyCustomTranslationPresetSettings(
+                new TranslationPresetSettings(
+                    current.ContextLimit,
+                    current.BucketLengthLimit,
+                    current.PreserveConversationContext,
+                    current.ForceContextDeduplication,
+                    StrictLinkBucketPurity.IsChecked == true),
+                true);
+        }
+
+        private void ApplyCustomTranslationPresetSettings(
+            TranslationPresetSettings settings,
+            bool persistImmediately)
+        {
+            TranslationPresetSelection selection;
+            if (_translationPresetCoordinator.TryApplyCustomSettings(
+                settings,
+                persistImmediately,
+                out selection))
+            {
+                ApplyTranslationPresetSelection(selection, false);
+            }
         }
 
 

--- a/Phoenix_Translator/PhoenixTranslator.csproj
+++ b/Phoenix_Translator/PhoenixTranslator.csproj
@@ -106,6 +106,8 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Application\LegacyTranslationPresetStore.cs" />
+    <Compile Include="Application\TranslationPresetService.cs" />
     <Compile Include="FileManagement\ZipHelper.cs" />
     <Compile Include="SkyrimManagement\BackupManager.cs" />
     <Compile Include="SkyrimManagement\Base26Helper.cs" />

--- a/Phoenix_Translator/Properties/AssemblyInfo.cs
+++ b/Phoenix_Translator/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Windows;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.0.0.1")]
+[assembly: AssemblyFileVersion("2.0.0.1")]

--- a/dependencies.json
+++ b/dependencies.json
@@ -3,21 +3,21 @@
     {
       "name": "EspReader",
       "repository": "YD525/EspReader",
-      "tag": "v1.0.0",
+      "tag": "v1.0.0.6",
       "asset": "EspReader.dll",
       "checksumAsset": "EspReader.dll.sha256"
     },
     {
       "name": "PexReader",
       "repository": "YD525/PexReader",
-      "tag": "v1.0.0",
+      "tag": "v1.0.1.6",
       "asset": "PEX.Interop.dll",
       "checksumAsset": "PEX.Interop.dll.sha256"
     },
     {
       "name": "PexInterface",
       "repository": "YD525/PexInterface",
-      "tag": "v1.0.0",
+      "tag": "v1.0.0.5",
       "asset": "PexInterface.dll",
       "checksumAsset": "PexInterface.dll.sha256"
     }
@@ -26,7 +26,7 @@
     {
       "name": "PhoenixEngine",
       "repository": "YD525/Phoenix-Engine",
-      "tag": "v1.0.0",
+      "tag": "v1.0.0.8",
       "asset": "PhoenixEngine-win-x64.zip",
       "checksumAsset": "PhoenixEngine-win-x64.zip.sha256",
       "destination": "PhoenixEngine"


### PR DESCRIPTION
## Summary

- move translation preset rules and persistence behind a validated application service
- preserve existing custom settings when loading legacy or missing preset data
- mark manual edits as `Custom` and persist named presets exactly once
- keep radar values within their supported range
- add deterministic .NET Framework 4.8.1 regression tests to build and release workflows
- bump the application version from `2.0.0.0` to `2.0.0.1`

## Dependency paths

All dependencies reference the upstream YD525 repositories. The manifest pins the release versions planned by the related upstream pull requests:

- `YD525/EspReader` `v1.0.0.6`
- `YD525/PexReader` `v1.0.1.6`
- `YD525/PexInterface` `v1.0.0.5`
- `YD525/Phoenix-Engine` `v1.0.0.8`

No fork dependency URLs are introduced.

## Validation

- Release x64 solution build passed with Visual Studio MSBuild
- 4 preset regression tests passed
- `git diff --check` passed

## Merge dependency

The dependency releases listed above must be published by YD525 before this pull request can restore dependencies in CI. The current restore failure is caused by those release assets not existing yet.

Closes #23