### PR TITLE
Prevent database viewer crash without a project

### DIFF
--- a/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
+++ b/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
@@ -40,6 +40,9 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Phoenix_Translator\Application\AdvancedDictionaryQueryBuilder.cs">
+      <Link>AdvancedDictionaryQueryBuilder.cs</Link>
+    </Compile>
     <Compile Include="..\Phoenix_Translator\Application\TranslationPresetService.cs">
       <Link>TranslationPresetService.cs</Link>
     </Compile>

--- a/PhoenixTranslator.PresetTests/Program.cs
+++ b/PhoenixTranslator.PresetTests/Program.cs
@@ -13,7 +13,9 @@ namespace PhoenixTranslator.PresetTests
                 { nameof(PreservesCustomSettingsOnLoad), PreservesCustomSettingsOnLoad },
                 { nameof(AppliesNamedPresetOnce), AppliesNamedPresetOnce },
                 { nameof(MarksManualEditsAsCustom), MarksManualEditsAsCustom },
-                { nameof(BoundsAndValidatesPresetValues), BoundsAndValidatesPresetValues }
+                { nameof(BoundsAndValidatesPresetValues), BoundsAndValidatesPresetValues },
+                { nameof(BuildsProjectIndependentDatabaseQuery), BuildsProjectIndependentDatabaseQuery },
+                { nameof(BuildsLanguageFilteredDatabaseQuery), BuildsLanguageFilteredDatabaseQuery }
             };
             int failures = 0;
             foreach (KeyValuePair<string, Action> test in tests)
@@ -102,6 +104,22 @@ namespace PhoenixTranslator.PresetTests
             AssertEqual(false, service.IsValid(
                 new TranslationPresetSettings(0, 3900, false, false, false)),
                 "Zero context length must be rejected.");
+        }
+
+        private static void BuildsProjectIndependentDatabaseQuery()
+        {
+            AssertEqual(
+                "Select * From AdvancedDictionary Limit 100000",
+                AdvancedDictionaryQueryBuilder.Build(null, null),
+                "Opening the database without a project must use a bounded query.");
+        }
+
+        private static void BuildsLanguageFilteredDatabaseQuery()
+        {
+            AssertEqual(
+                "Select * From AdvancedDictionary Where [From] = 1 And [To] = 2 Limit 100000",
+                AdvancedDictionaryQueryBuilder.Build(1, 2),
+                "Opening the database with a project must retain its language filter.");
         }
 
         private static TranslationPresetCoordinator CreateCoordinator(RecordingStore store)

--- a/Phoenix_Translator/Application/AdvancedDictionaryQueryBuilder.cs
+++ b/Phoenix_Translator/Application/AdvancedDictionaryQueryBuilder.cs
@@ -1,0 +1,21 @@
+namespace PhoenixTranslator.ApplicationLayer
+{
+    internal static class AdvancedDictionaryQueryBuilder
+    {
+        private const int MaximumRowCount = 100000;
+
+        internal static string Build(int? sourceLanguage, int? targetLanguage)
+        {
+            if (!sourceLanguage.HasValue || !targetLanguage.HasValue)
+            {
+                return "Select * From AdvancedDictionary Limit " + MaximumRowCount;
+            }
+
+            return string.Format(
+                "Select * From AdvancedDictionary Where [From] = {0} And [To] = {1} Limit {2}",
+                sourceLanguage.Value,
+                targetLanguage.Value,
+                MaximumRowCount);
+        }
+    }
+}

--- a/Phoenix_Translator/PhoenixTranslator.csproj
+++ b/Phoenix_Translator/PhoenixTranslator.csproj
@@ -106,6 +106,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Application\AdvancedDictionaryQueryBuilder.cs" />
     <Compile Include="Application\LegacyTranslationPresetStore.cs" />
     <Compile Include="Application\TranslationPresetService.cs" />
     <Compile Include="FileManagement\ZipHelper.cs" />

--- a/Phoenix_Translator/Properties/AssemblyInfo.cs
+++ b/Phoenix_Translator/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Windows;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.0.0.1")]
-[assembly: AssemblyFileVersion("2.0.0.1")]
+[assembly: AssemblyVersion("2.0.0.2")]
+[assembly: AssemblyFileVersion("2.0.0.2")]

--- a/Phoenix_Translator/UIManagement/Main/TranslateConfig.xaml.cs
+++ b/Phoenix_Translator/UIManagement/Main/TranslateConfig.xaml.cs
@@ -17,6 +17,7 @@ using PhoenixEngine.Language;
 using PhoenixEngine;
 using PhoenixEngine.P_Delegate;
 using PhoenixEngine.Common;
+using PhoenixTranslator.ApplicationLayer;
 
 namespace PhoenixTranslator
 {
@@ -910,7 +911,13 @@ namespace PhoenixTranslator
 
             //Results are capped at 100,000 rows via LIMIT to prevent memory exhaustion, as databases may scale to GB/TB levels. This tool is intended for SQL-proficient users to manually execute conditional queries for specific records or perform bulk modifications across multiple entries using custom SQL logic.
             //Select * From AdvancedDictionary Where Source Like '%[pagebreak]%' or  Source Like '%<font' (I just threw this together to match the content of all the books.) - > Compared to using regular expressions for pattern matching, utilizing the `LIKE` and `GLOB` commands in SQL operates directly at the database engine level, enabling millisecond-level query performance.
-            DeFine.OpenDataBaseView(this,$"Select * From AdvancedDictionary Where [From] = {(int)DeFine.WorkWin.ActiveTab.Mod.P_Translator.From} And [To] = {(int)DeFine.WorkWin.ActiveTab.Mod.P_Translator.To} Limit 100000");
+            var translator = _Owner?.ActiveTab?.Mod?.P_Translator;
+            int? sourceLanguage = translator == null ? (int?)null : (int)translator.From;
+            int? targetLanguage = translator == null ? (int?)null : (int)translator.To;
+
+            DeFine.OpenDataBaseView(
+                this,
+                AdvancedDictionaryQueryBuilder.Build(sourceLanguage, targetLanguage));
         }
 
         private void DetectFrom(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
## Problem
Opening the Database Viewer from LocalConfig without an active project dereferenced the missing translation tab and terminated the application.

## Changes
- use a bounded project-independent AdvancedDictionary query when no project is open
- preserve source and target language filtering when a project is active
- add deterministic regression coverage for both query paths
- bump the Translator assembly and file version to 2.0.0.2

## Validation
- Release x64 solution build with Visual Studio 2022 MSBuild
- PhoenixTranslator.PresetTests: 6 passed, 0 failed
- manual no-project Database Viewer test completed successfully

Closes #38