### PR TITLE
Define stable English message identifiers for future localization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,10 @@ jobs:
         shell: pwsh
         run: .\scripts\Restore-Dependencies.ps1
 
+      - name: Verify preview message catalogue
+        shell: pwsh
+        run: .\scripts\Verify-PreviewMessages.ps1 -ProjectRoot .\Phoenix_Translator
+
       - name: Build x64 release
         shell: pwsh
         run: msbuild .\PhoenixTranslator.sln /m /p:Configuration=Release /p:Platform=x64

--- a/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
+++ b/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
@@ -46,11 +46,23 @@
     <Compile Include="..\Phoenix_Translator\Application\AdvancedDictionaryQueryBuilder.cs">
       <Link>AdvancedDictionaryQueryBuilder.cs</Link>
     </Compile>
+    <Compile Include="..\Phoenix_Translator\Application\PreviewMessageCatalog.cs">
+      <Link>PreviewMessageCatalog.cs</Link>
+    </Compile>
     <Compile Include="..\Phoenix_Translator\Application\TranslationPresetService.cs">
       <Link>TranslationPresetService.cs</Link>
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Phoenix_Translator\Properties\Resources.Designer.cs">
+      <Link>Properties\Resources.Designer.cs</Link>
+    </Compile>
+    <EmbeddedResource Include="..\Phoenix_Translator\Properties\Resources.resx">
+      <Link>Properties\Resources.resx</Link>
+      <LogicalName>PhoenixTranslator.Properties.Resources.resources</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <Content Include="TestData\manifest.tsv">

--- a/PhoenixTranslator.PresetTests/Program.cs
+++ b/PhoenixTranslator.PresetTests/Program.cs
@@ -1,11 +1,16 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Resources;
 using System.Security.Cryptography;
+using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
 using PhoenixTranslator.ApplicationLayer;
+using PhoenixTranslator.Properties;
 
 namespace PhoenixTranslator.PresetTests
 {
@@ -23,7 +28,9 @@ namespace PhoenixTranslator.PresetTests
                 { nameof(BuildsLanguageFilteredDatabaseQuery), BuildsLanguageFilteredDatabaseQuery },
                 { nameof(ValidatesReferenceCorpusManifest), ValidatesReferenceCorpusManifest },
                 { nameof(ValidatesMcmFixtures), ValidatesMcmFixtures },
-                { nameof(ValidatesXmlFixtures), ValidatesXmlFixtures }
+                { nameof(ValidatesXmlFixtures), ValidatesXmlFixtures },
+                { nameof(ValidatesPreviewMessageIdentifiers), ValidatesPreviewMessageIdentifiers },
+                { nameof(FormatsPreviewMessages), FormatsPreviewMessages }
             };
             int failures = 0;
             foreach (KeyValuePair<string, Action> test in tests)
@@ -220,6 +227,72 @@ namespace PhoenixTranslator.PresetTests
             }
 
             return false;
+        }
+
+        private static void ValidatesPreviewMessageIdentifiers()
+        {
+            var entries = new Dictionary<string, string>();
+            ResourceSet resourceSet = Resources.ResourceManager.GetResourceSet(
+                CultureInfo.InvariantCulture,
+                true,
+                true);
+            foreach (DictionaryEntry entry in resourceSet)
+            {
+                entries.Add((string)entry.Key, (string)entry.Value);
+            }
+
+            AssertEqual(true, entries.Count >= 70, "The preview source catalogue must retain its baseline coverage.");
+            foreach (KeyValuePair<string, string> entry in entries)
+            {
+                AssertEqual(true,
+                    Regex.IsMatch(entry.Key, "^[A-Z][A-Za-z0-9]*(?:_[A-Z][A-Za-z0-9]*)+$"),
+                    entry.Key + " must use stable PascalCase segments separated by underscores.");
+                AssertEqual(false, string.IsNullOrWhiteSpace(entry.Value), entry.Key + " must have English source text.");
+
+                MatchCollection placeholders = Regex.Matches(entry.Value, "\\{(\\d+)(?:[^}]*)\\}");
+                if (placeholders.Count > 0)
+                {
+                    int[] indexes = placeholders.Cast<Match>()
+                        .Select(match => int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture))
+                        .Distinct()
+                        .OrderBy(index => index)
+                        .ToArray();
+                    AssertEqual(
+                        string.Join(",", Enumerable.Range(0, indexes[indexes.Length - 1] + 1)),
+                        string.Join(",", indexes),
+                        entry.Key + " placeholders must be contiguous from zero.");
+                }
+            }
+
+            foreach (string prefix in new[] { "Common_", "Shell_", "Workspace_", "Settings_", "Accessibility_" })
+            {
+                AssertEqual(true, entries.Keys.Any(id => id.StartsWith(prefix, StringComparison.Ordinal)),
+                    "The source catalogue must cover " + prefix.TrimEnd('_') + ".");
+            }
+        }
+
+        private static void FormatsPreviewMessages()
+        {
+            AssertEqual(
+                "Opening project: 42%",
+                PreviewMessageCatalog.Format("Shell_ProjectOpen_OpeningProgress", 42),
+                "Project progress must format with the current UI culture.");
+            AssertEqual(
+                "Translating 3 of 10 entries",
+                PreviewMessageCatalog.Format("Workspace_Operation_TranslatingProgress", 3, 10),
+                "Workspace progress must preserve both documented placeholders.");
+
+            bool rejected = false;
+            try
+            {
+                PreviewMessageCatalog.Get("Unknown_Message_Id");
+            }
+            catch (InvalidOperationException)
+            {
+                rejected = true;
+            }
+
+            AssertEqual(true, rejected, "Unknown preview message identifiers must fail explicitly.");
         }
 
         private static TranslationPresetCoordinator CreateCoordinator(RecordingStore store)

--- a/Phoenix_Translator/Application/PreviewMessageCatalog.cs
+++ b/Phoenix_Translator/Application/PreviewMessageCatalog.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Globalization;
+using PhoenixTranslator.Properties;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Resolves stable preview message identifiers from the compiled source catalogue.
+    /// </summary>
+    internal static class PreviewMessageCatalog
+    {
+        /// <summary>
+        /// Resolves the English source text for a stable identifier.
+        /// </summary>
+        /// <param name="id">The semantic message identifier stored in the source catalogue.</param>
+        /// <returns>The localized message for the current UI culture.</returns>
+        /// <exception cref="ArgumentException"><paramref name="id"/> is empty.</exception>
+        /// <exception cref="InvalidOperationException">The catalogue does not contain <paramref name="id"/>.</exception>
+        internal static string Get(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentException("A message identifier is required.", nameof(id));
+            }
+
+            string value = Resources.ResourceManager.GetString(id, Resources.Culture);
+            if (value == null)
+            {
+                throw new InvalidOperationException(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "The preview message identifier '{0}' is not registered.",
+                    id));
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Formats a catalogue message with values using the current UI culture.
+        /// </summary>
+        /// <param name="id">The semantic message identifier stored in the source catalogue.</param>
+        /// <param name="arguments">The values for the documented composite-format placeholders.</param>
+        /// <returns>The formatted localized message.</returns>
+        /// <exception cref="ArgumentException"><paramref name="id"/> is empty.</exception>
+        /// <exception cref="InvalidOperationException">The catalogue does not contain <paramref name="id"/>.</exception>
+        /// <exception cref="FormatException">The arguments do not match the catalogue message placeholders.</exception>
+        internal static string Format(string id, params object[] arguments)
+        {
+            return string.Format(
+                CultureInfo.CurrentUICulture,
+                Get(id),
+                arguments ?? new object[0]);
+        }
+    }
+}

--- a/Phoenix_Translator/PhoenixTranslator.csproj
+++ b/Phoenix_Translator/PhoenixTranslator.csproj
@@ -107,6 +107,7 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Application\AdvancedDictionaryQueryBuilder.cs" />
+    <Compile Include="Application\PreviewMessageCatalog.cs" />
     <Compile Include="Application\LegacyTranslationPresetStore.cs" />
     <Compile Include="Application\TranslationPresetService.cs" />
     <Compile Include="FileManagement\ZipHelper.cs" />
@@ -192,6 +193,7 @@
     </Compile>
     <Compile Include="UIManagement\UIHelper.cs" />
     <Compile Include="UIManagement\UILanguageHelper.cs" />
+    <Compile Include="UIManagement\Localization\PreviewMessageExtension.cs" />
     <Compile Include="UIManagement\YDListView.cs" />
     <Compile Include="UIManagement\Setting\LexTranslatorRadarChart.xaml.cs">
       <DependentUpon>LexTranslatorRadarChart.xaml</DependentUpon>
@@ -296,6 +298,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="UIManagement\Translate\TranslateView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="UIManagement\Preview\PreviewMessageExamples.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Phoenix_Translator/Properties/AssemblyInfo.cs
+++ b/Phoenix_Translator/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Windows;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.0.0.5")]
-[assembly: AssemblyFileVersion("2.0.0.5")]
+[assembly: AssemblyVersion("2.0.0.6")]
+[assembly: AssemblyFileVersion("2.0.0.6")]

--- a/Phoenix_Translator/Properties/Resources.resx
+++ b/Phoenix_Translator/Properties/Resources.resx
@@ -114,4 +114,85 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Common_Action_Apply" xml:space="preserve"><value>Apply</value><comment>Shared action that commits staged changes.</comment></data>
+  <data name="Common_Action_Back" xml:space="preserve"><value>Back</value><comment>Shared wizard or navigation action.</comment></data>
+  <data name="Common_Action_Browse" xml:space="preserve"><value>Browse</value><comment>Shared action that opens a file or folder picker.</comment></data>
+  <data name="Common_Action_Cancel" xml:space="preserve"><value>Cancel</value><comment>Shared action that cancels a dialog or operation.</comment></data>
+  <data name="Common_Action_Clear" xml:space="preserve"><value>Clear</value><comment>Shared action that clears user-controlled content or filters.</comment></data>
+  <data name="Common_Action_Close" xml:space="preserve"><value>Close</value><comment>Shared action that closes the current surface.</comment></data>
+  <data name="Common_Action_Discard" xml:space="preserve"><value>Discard</value><comment>Shared action that abandons staged or unsaved changes.</comment></data>
+  <data name="Common_Action_Next" xml:space="preserve"><value>Next</value><comment>Shared wizard or entry-navigation action.</comment></data>
+  <data name="Common_Action_Retry" xml:space="preserve"><value>Retry</value><comment>Shared action that repeats a failed operation.</comment></data>
+  <data name="Common_Action_Save" xml:space="preserve"><value>Save</value><comment>Shared action that persists project state.</comment></data>
+  <data name="Common_State_Available" xml:space="preserve"><value>Available</value><comment>Positive status for a reachable provider or feature.</comment></data>
+  <data name="Common_State_Modified" xml:space="preserve"><value>Modified</value><comment>State label for staged or unsaved changes.</comment></data>
+  <data name="Common_State_Ready" xml:space="preserve"><value>Ready</value><comment>State label for an idle surface that can accept work.</comment></data>
+  <data name="Shell_Product_Name" xml:space="preserve"><value>Phoenix Translator</value><comment>Product name in the preview shell title area.</comment></data>
+  <data name="Shell_Project_None" xml:space="preserve"><value>No project open</value><comment>Shell project-identity text when no project is loaded.</comment></data>
+  <data name="Shell_ProjectOpen_Title" xml:space="preserve"><value>Open a localization project</value><comment>Heading for the empty project picker.</comment></data>
+  <data name="Shell_ProjectOpen_SupportedFormats" xml:space="preserve"><value>ESP, ESM, PEX, MCM, XML, or an existing Phoenix project</value><comment>Supported-format hint below the project picker heading.</comment></data>
+  <data name="Shell_ProjectOpen_DropPrompt" xml:space="preserve"><value>Drop files here to start</value><comment>Drop-zone instruction in the empty project picker.</comment></data>
+  <data name="Shell_ProjectOpen_BrowseAction" xml:space="preserve"><value>Browse projects</value><comment>Primary action in the empty project picker.</comment></data>
+  <data name="Shell_ProjectOpen_OpeningProgress" xml:space="preserve"><value>Opening project: {0}%</value><comment>Project-loading progress. Placeholders: {0}=integer percentage from 0 through 100.</comment></data>
+  <data name="Shell_ProjectOpen_Failed" xml:space="preserve"><value>The project could not be opened.</value><comment>Safe heading for a project-open failure; technical details appear separately.</comment></data>
+  <data name="Shell_RecentProjects_Title" xml:space="preserve"><value>Recent projects</value><comment>Heading above the recent-project list.</comment></data>
+  <data name="Shell_RecentProjects_Empty" xml:space="preserve"><value>No recent projects</value><comment>Empty-state heading for the recent-project list.</comment></data>
+  <data name="Shell_RecentProjects_EmptyHint" xml:space="preserve"><value>Opened projects will appear here with their last status.</value><comment>Empty-state explanation for the recent-project list.</comment></data>
+  <data name="Shell_Navigation_Projects" xml:space="preserve"><value>Projects</value><comment>Primary shell navigation destination.</comment></data>
+  <data name="Shell_Navigation_Translate" xml:space="preserve"><value>Translate</value><comment>Primary shell navigation destination.</comment></data>
+  <data name="Shell_Navigation_Review" xml:space="preserve"><value>Review</value><comment>Primary shell navigation destination.</comment></data>
+  <data name="Shell_Navigation_Quality" xml:space="preserve"><value>Quality</value><comment>Primary shell navigation destination.</comment></data>
+  <data name="Shell_Navigation_History" xml:space="preserve"><value>History</value><comment>Primary shell navigation destination.</comment></data>
+  <data name="Shell_Navigation_ProjectUpdate" xml:space="preserve"><value>Project update</value><comment>Primary shell navigation destination for comparing a newer source revision.</comment></data>
+  <data name="Shell_Navigation_Settings" xml:space="preserve"><value>Settings</value><comment>Primary shell navigation destination.</comment></data>
+  <data name="Shell_Navigation_AdvancedTools" xml:space="preserve"><value>Advanced tools</value><comment>Shell navigation destination for progressively disclosed expert tools.</comment></data>
+  <data name="Shell_Unsaved_ClosePrompt_Title" xml:space="preserve"><value>Save changes before closing?</value><comment>Heading for the modified-project close confirmation.</comment></data>
+  <data name="Shell_Unsaved_ClosePrompt_Body" xml:space="preserve"><value>Your project contains changes that have not been saved.</value><comment>Body for the modified-project close confirmation.</comment></data>
+  <data name="Workspace_Title" xml:space="preserve"><value>Translation workspace</value><comment>Accessible workflow title for the translation workspace.</comment></data>
+  <data name="Workspace_Search_Placeholder" xml:space="preserve"><value>Search entries</value><comment>Placeholder in the workspace entry search field.</comment></data>
+  <data name="Workspace_Filter_AllStates" xml:space="preserve"><value>All states</value><comment>Default state-filter option in the workspace.</comment></data>
+  <data name="Workspace_Filter_AllTypes" xml:space="preserve"><value>All types</value><comment>Default record-type filter option in the workspace.</comment></data>
+  <data name="Workspace_TranslateScope_Action" xml:space="preserve"><value>Translate scope</value><comment>Starts translation for the currently selected or filtered scope.</comment></data>
+  <data name="Workspace_Entry_Count" xml:space="preserve"><value>{0} entries</value><comment>Workspace entry count. Placeholders: {0}=non-negative integer count.</comment></data>
+  <data name="Workspace_Entry_DraftCount" xml:space="preserve"><value>{0} draft</value><comment>Workspace draft count. Placeholders: {0}=non-negative integer count.</comment></data>
+  <data name="Workspace_Entry_SourceText_Label" xml:space="preserve"><value>Source text</value><comment>Label above the read-only source editor.</comment></data>
+  <data name="Workspace_Entry_TargetText_Label" xml:space="preserve"><value>Target text</value><comment>Label above the editable target editor.</comment></data>
+  <data name="Workspace_Entry_Previous_Action" xml:space="preserve"><value>Previous entry</value><comment>Moves to the previous entry without changing text.</comment></data>
+  <data name="Workspace_Entry_Apply_Action" xml:space="preserve"><value>Apply translation</value><comment>Applies the current target text to the selected entry.</comment></data>
+  <data name="Workspace_Context_Title" xml:space="preserve"><value>Context</value><comment>Heading for the workspace context inspector.</comment></data>
+  <data name="Workspace_Context_Record_Label" xml:space="preserve"><value>Record</value><comment>Metadata label in the workspace context inspector.</comment></data>
+  <data name="Workspace_Context_RelatedNpc_Label" xml:space="preserve"><value>Related NPC</value><comment>Metadata label in the workspace context inspector.</comment></data>
+  <data name="Workspace_Context_Provenance_Label" xml:space="preserve"><value>Provenance</value><comment>Metadata label for translation origin in the context inspector.</comment></data>
+  <data name="Workspace_Operation_TranslatingProgress" xml:space="preserve"><value>Translating {0} of {1} entries</value><comment>Batch progress. Placeholders: {0}=completed integer count; {1}=total integer count.</comment></data>
+  <data name="Workspace_Operation_Cancelling" xml:space="preserve"><value>Cancelling translation…</value><comment>Operation status while cooperative cancellation is pending.</comment></data>
+  <data name="Workspace_Operation_CompletedWithFailures" xml:space="preserve"><value>Translation completed with {0} failed entries.</value><comment>Batch completion summary. Placeholders: {0}=non-negative integer failure count.</comment></data>
+  <data name="Workspace_Save_Failed" xml:space="preserve"><value>The project could not be saved. Your changes are still available.</value><comment>Safe save-failure message that confirms recoverable user input.</comment></data>
+  <data name="Settings_Title" xml:space="preserve"><value>Settings</value><comment>Settings workflow title.</comment></data>
+  <data name="Settings_Navigation_Providers" xml:space="preserve"><value>Providers</value><comment>Settings navigation destination.</comment></data>
+  <data name="Settings_Navigation_TranslationBehavior" xml:space="preserve"><value>Translation behavior</value><comment>Settings navigation destination.</comment></data>
+  <data name="Settings_Navigation_ProjectFormats" xml:space="preserve"><value>Project formats</value><comment>Settings navigation destination.</comment></data>
+  <data name="Settings_Navigation_AppearanceAccessibility" xml:space="preserve"><value>Appearance &amp; accessibility</value><comment>Settings navigation destination.</comment></data>
+  <data name="Settings_Navigation_Advanced" xml:space="preserve"><value>Advanced</value><comment>Settings navigation destination for expert configuration.</comment></data>
+  <data name="Settings_Providers_Description" xml:space="preserve"><value>Choose translation services and test their configuration without saving changes.</value><comment>Description at the top of Provider settings.</comment></data>
+  <data name="Settings_Providers_Cloud_Title" xml:space="preserve"><value>Cloud provider</value><comment>Settings card heading.</comment></data>
+  <data name="Settings_Providers_Local_Title" xml:space="preserve"><value>Local provider</value><comment>Settings card heading.</comment></data>
+  <data name="Settings_Providers_Provider_Label" xml:space="preserve"><value>Provider</value><comment>Field label for provider selection.</comment></data>
+  <data name="Settings_Providers_Model_Label" xml:space="preserve"><value>Model</value><comment>Field label for provider model selection.</comment></data>
+  <data name="Settings_Providers_ApiKey_Label" xml:space="preserve"><value>API key</value><comment>Field label for a secret provider credential.</comment></data>
+  <data name="Settings_Providers_ApiKey_Stored" xml:space="preserve"><value>Stored securely</value><comment>Status shown instead of exposing a stored provider credential.</comment></data>
+  <data name="Settings_Providers_Endpoint_Label" xml:space="preserve"><value>Endpoint</value><comment>Field label for a local or custom provider endpoint.</comment></data>
+  <data name="Settings_Providers_Test_Action" xml:space="preserve"><value>Test provider</value><comment>Explicit action that tests staged provider settings without saving them.</comment></data>
+  <data name="Settings_Providers_Test_Running" xml:space="preserve"><value>Testing provider…</value><comment>Status while a provider test is running.</comment></data>
+  <data name="Settings_Providers_Test_Succeeded" xml:space="preserve"><value>The provider responded successfully.</value><comment>Provider-test success message; does not imply settings were saved.</comment></data>
+  <data name="Settings_Providers_Test_Failed" xml:space="preserve"><value>The provider test failed: {0}</value><comment>Safe provider-test failure. Placeholders: {0}=sanitized failure reason without credentials or private content.</comment></data>
+  <data name="Settings_ProviderPipeline_Title" xml:space="preserve"><value>Provider pipeline</value><comment>Settings card heading for the ordered provider pipeline.</comment></data>
+  <data name="Settings_ProviderPipeline_EditAdvanced_Action" xml:space="preserve"><value>Edit advanced pipeline</value><comment>Opens progressively disclosed provider-pipeline configuration.</comment></data>
+  <data name="Settings_Modified_Hint" xml:space="preserve"><value>Changes are not applied until you choose Apply.</value><comment>Persistent settings footer hint while staged changes exist.</comment></data>
+  <data name="Settings_Validation_Required" xml:space="preserve"><value>{0} is required.</value><comment>Required-field validation. Placeholders: {0}=localized field label.</comment></data>
+  <data name="Settings_Validation_InvalidEndpoint" xml:space="preserve"><value>Enter a valid HTTP or HTTPS endpoint.</value><comment>Provider endpoint validation message.</comment></data>
+  <data name="Accessibility_Shell_Navigation_Name" xml:space="preserve"><value>Primary workflows</value><comment>Accessible name for the shell navigation region.</comment></data>
+  <data name="Accessibility_Shell_ProjectStatus_Name" xml:space="preserve"><value>Project status</value><comment>Accessible name for the persistent shell status region.</comment></data>
+  <data name="Accessibility_Workspace_EntryList_Name" xml:space="preserve"><value>Translation entries</value><comment>Accessible name for the workspace entry list.</comment></data>
+  <data name="Accessibility_Workspace_ContextInspector_Name" xml:space="preserve"><value>Entry context</value><comment>Accessible name for the workspace context inspector.</comment></data>
+  <data name="Accessibility_Settings_Navigation_Name" xml:space="preserve"><value>Settings categories</value><comment>Accessible name for the settings navigation region.</comment></data>
 </root>

--- a/Phoenix_Translator/UIManagement/Localization/PreviewMessageExtension.cs
+++ b/Phoenix_Translator/UIManagement/Localization/PreviewMessageExtension.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Windows.Markup;
+using PhoenixTranslator.ApplicationLayer;
+
+namespace PhoenixTranslator.UIManagement.Localization
+{
+    /// <summary>
+    /// Resolves a stable preview message identifier from XAML.
+    /// </summary>
+    [MarkupExtensionReturnType(typeof(string))]
+    public sealed class PreviewMessageExtension : MarkupExtension
+    {
+        /// <summary>
+        /// Creates a message extension for the specified semantic identifier.
+        /// </summary>
+        /// <param name="id">The identifier stored in the compiled source catalogue.</param>
+        /// <exception cref="ArgumentException"><paramref name="id"/> is empty.</exception>
+        public PreviewMessageExtension(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentException("A message identifier is required.", nameof(id));
+            }
+
+            Id = id;
+        }
+
+        /// <summary>
+        /// Gets the semantic source-catalogue identifier.
+        /// </summary>
+        public string Id { get; private set; }
+
+        /// <summary>
+        /// Resolves the message for the current UI culture.
+        /// </summary>
+        /// <param name="serviceProvider">The XAML service provider for this markup-extension invocation.</param>
+        /// <returns>The localized string registered for <see cref="Id"/>.</returns>
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return PreviewMessageCatalog.Get(Id);
+        }
+    }
+}

--- a/Phoenix_Translator/UIManagement/Preview/PreviewMessageExamples.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewMessageExamples.xaml
@@ -1,0 +1,11 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:localization="clr-namespace:PhoenixTranslator.UIManagement.Localization">
+    <DataTemplate x:Key="PreviewLocalizedProjectOpenExample">
+        <StackPanel AutomationProperties.Name="{localization:PreviewMessage Accessibility_Shell_ProjectStatus_Name}">
+            <TextBlock Text="{localization:PreviewMessage Shell_ProjectOpen_Title}" />
+            <TextBlock Text="{localization:PreviewMessage Shell_ProjectOpen_SupportedFormats}" />
+            <Button Content="{localization:PreviewMessage Shell_ProjectOpen_BrowseAction}" />
+        </StackPanel>
+    </DataTemplate>
+</ResourceDictionary>

--- a/docs/localization/README.md
+++ b/docs/localization/README.md
@@ -1,0 +1,75 @@
+# Preview message catalogue
+
+Phoenix Translator uses the compiled `Properties/Resources.resx` file as the English source catalogue for all
+redesigned preview workflows. Stable identifiers describe product intent rather than English wording or control
+position.
+
+## Identifier convention
+
+Identifiers use PascalCase segments separated by underscores:
+
+`Area_Feature_Element_Purpose`
+
+Examples:
+
+- `Shell_ProjectOpen_Title`
+- `Workspace_Entry_TargetText_Label`
+- `Settings_Providers_Test_Succeeded`
+- `Accessibility_Workspace_ContextInspector_Name`
+
+The identifier remains stable when English wording, layout, or control type changes. Avoid directional terms such
+as `Left`, visual terms such as `YellowButton`, numbered names, and complete English sentences as identifiers.
+
+## Ownership
+
+- `Properties/Resources.resx` is the authoritative English catalogue.
+- Every entry has a translator comment describing location, intent, and placeholders where applicable.
+- `PreviewMessageExtension` resolves identifiers in preview XAML.
+- `UIManagement/Preview/PreviewMessageExamples.xaml` compiles representative localized controls without loading
+  a runtime preview view.
+- `PreviewMessageCatalog.Format` formats messages with documented composite-format placeholders.
+- `scripts/Verify-PreviewMessages.ps1` rejects literal visible text and unknown identifiers below
+  `UIManagement/Preview`.
+- The GitHub build runs the verifier before compilation.
+
+Legacy views are migrated only when their workflow enters preview. Existing literal strings outside the preview
+directory are intentionally out of scope.
+
+## XAML usage
+
+```xml
+<TextBlock Text="{localization:PreviewMessage Shell_ProjectOpen_Title}" />
+```
+
+The preview XAML root declares:
+
+```xml
+xmlns:localization="clr-namespace:PhoenixTranslator.UIManagement.Localization"
+```
+
+## Code usage
+
+Use `PreviewMessageCatalog.Get` for messages without placeholders and `PreviewMessageCatalog.Format` for
+composite messages. Do not concatenate localized fragments. Pass complete values such as counts, names, and
+durations through documented placeholders.
+
+## Placeholder rules
+
+- Placeholders use zero-based composite-format indexes such as `{0}`.
+- Resource comments define the meaning and expected type of every placeholder.
+- A sentence owns its punctuation; callers do not append localized punctuation.
+- Identifiers with different grammar or plurality remain separate until the exchange format and target language
+  rules support an agreed plural model.
+- User content is never used as a format string.
+
+## Accessibility text
+
+Accessibility names and help text use the same catalogue with the `Accessibility_` area. An icon-only action must
+have a stable accessibility identifier even when its tooltip uses a separate message.
+
+## Weblate exchange
+
+Weblate imports the RESX file with identifiers preserved as source keys and comments preserved as translator
+context. A translated resource uses the normal satellite naming convention, for example `Resources.de.resx`.
+Before import or export, validation checks unique identifiers, placeholder parity, non-empty values, and source
+comments. Generated satellite assemblies remain build artifacts and are not committed.

--- a/scripts/Verify-PreviewMessages.ps1
+++ b/scripts/Verify-PreviewMessages.ps1
@@ -1,0 +1,53 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ProjectRoot
+)
+
+$resolvedRoot = (Resolve-Path -LiteralPath $ProjectRoot).Path
+$resourcePath = Join-Path $resolvedRoot 'Properties\Resources.resx'
+$previewPath = Join-Path $resolvedRoot 'UIManagement\Preview'
+
+[xml]$resources = Get-Content -LiteralPath $resourcePath -Raw
+$catalogueIds = @{}
+foreach ($entry in $resources.root.data) {
+    $catalogueIds[$entry.name] = $true
+}
+
+if (-not (Test-Path -LiteralPath $previewPath)) {
+    Write-Output 'Preview message verification passed: no preview views exist yet.'
+    exit 0
+}
+
+$errors = New-Object System.Collections.Generic.List[string]
+$visibleAttributePattern = '(?i)\b(?:Text|Content|Header|ToolTip|AutomationProperties\.Name)="(?!\{)([^"]*[A-Za-z][^"]*)"'
+$messagePattern = '\{(?:[^{}]+:)?PreviewMessage\s+([A-Za-z][A-Za-z0-9_]*)\}'
+
+foreach ($file in Get-ChildItem -LiteralPath $previewPath -Recurse -File -Filter '*.xaml') {
+    $content = Get-Content -LiteralPath $file.FullName -Raw
+    foreach ($match in [regex]::Matches($content, $visibleAttributePattern)) {
+        $errors.Add("$($file.FullName): untracked visible XAML text '$($match.Groups[1].Value)'.")
+    }
+
+    foreach ($match in [regex]::Matches($content, $messagePattern)) {
+        $id = $match.Groups[1].Value
+        if (-not $catalogueIds.ContainsKey($id)) {
+            $errors.Add("$($file.FullName): unknown preview message identifier '$id'.")
+        }
+    }
+}
+
+$codePattern = '(?i)(?:MessageBox\.Show|\.Content\s*=|\.Text\s*=|\.Header\s*=|\.ToolTip\s*=)\s*"[^"\r\n]*[A-Za-z][^"\r\n]*"'
+foreach ($file in Get-ChildItem -LiteralPath $previewPath -Recurse -File -Filter '*.cs') {
+    $content = Get-Content -LiteralPath $file.FullName -Raw
+    foreach ($match in [regex]::Matches($content, $codePattern)) {
+        $errors.Add("$($file.FullName): untracked visible code string '$($match.Value)'.")
+    }
+}
+
+if ($errors.Count -gt 0) {
+    $errors | ForEach-Object { Write-Error $_ }
+    throw "Preview message verification failed with $($errors.Count) error(s)."
+}
+
+Write-Output 'Preview message verification passed.'


### PR DESCRIPTION
## Summary

- define stable semantic message identifiers for preview shell, workspace, settings, and accessibility text
- populate the compiled English RESX source catalogue with translator context and documented placeholders
- add a C# catalogue resolver and XAML markup extension compatible with .NET Framework 4.8.1
- compile representative localized preview controls without enabling a runtime preview
- enforce catalogue usage for future preview XAML and visible code strings in the GitHub build
- document identifier ownership, placeholder rules, and Weblate RESX exchange
- bump Phoenix Translator to 2.0.0.6

## Validation

- full MSBuild Release x64 build succeeded
- preview message verification passed
- negative verifier probe rejected an untracked visible literal
- PhoenixTranslator.PresetTests: 11 passed, 0 failed
- git diff --check

The build retains six pre-existing warnings in untouched legacy files.

Fixes #28