### PR TITLE
Redesign the application shell and navigation

### DIFF
--- a/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
+++ b/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
@@ -41,6 +41,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Phoenix_Translator\Application\AdvancedDictionaryQueryBuilder.cs">
@@ -48,6 +49,12 @@
     </Compile>
     <Compile Include="..\Phoenix_Translator\Application\PreviewMessageCatalog.cs">
       <Link>PreviewMessageCatalog.cs</Link>
+    </Compile>
+    <Compile Include="..\Phoenix_Translator\Application\PreviewShellCommand.cs">
+      <Link>PreviewShellCommand.cs</Link>
+    </Compile>
+    <Compile Include="..\Phoenix_Translator\Application\PreviewShellViewModel.cs">
+      <Link>PreviewShellViewModel.cs</Link>
     </Compile>
     <Compile Include="..\Phoenix_Translator\Application\TranslationPresetService.cs">
       <Link>TranslationPresetService.cs</Link>

--- a/PhoenixTranslator.PresetTests/Program.cs
+++ b/PhoenixTranslator.PresetTests/Program.cs
@@ -30,7 +30,9 @@ namespace PhoenixTranslator.PresetTests
                 { nameof(ValidatesMcmFixtures), ValidatesMcmFixtures },
                 { nameof(ValidatesXmlFixtures), ValidatesXmlFixtures },
                 { nameof(ValidatesPreviewMessageIdentifiers), ValidatesPreviewMessageIdentifiers },
-                { nameof(FormatsPreviewMessages), FormatsPreviewMessages }
+                { nameof(FormatsPreviewMessages), FormatsPreviewMessages },
+                { nameof(NavigatesPreviewShell), NavigatesPreviewShell },
+                { nameof(TracksPreviewShellStatus), TracksPreviewShellStatus }
             };
             int failures = 0;
             foreach (KeyValuePair<string, Action> test in tests)
@@ -293,6 +295,72 @@ namespace PhoenixTranslator.PresetTests
             }
 
             AssertEqual(true, rejected, "Unknown preview message identifiers must fail explicitly.");
+        }
+
+        private static void NavigatesPreviewShell()
+        {
+            int legacyOpenCalls = 0;
+            var viewModel = new PreviewShellViewModel(() => legacyOpenCalls++);
+
+            AssertEqual(PreviewShellDestination.Projects, viewModel.CurrentDestination,
+                "The preview shell must start at Projects.");
+            AssertEqual("Projects", viewModel.CurrentTitle,
+                "The initial destination must expose its localized title.");
+
+            viewModel.NavigateCommand.Execute("Review");
+
+            AssertEqual(PreviewShellDestination.Review, viewModel.CurrentDestination,
+                "A keyboard command parameter must select the matching destination.");
+            AssertEqual("Review", viewModel.CurrentTitle,
+                "Navigation must update the localized destination title.");
+
+            viewModel.OpenLegacyWorkspaceCommand.Execute(null);
+            AssertEqual(1, legacyOpenCalls,
+                "The fallback command must delegate to the legacy workspace integration exactly once.");
+        }
+
+        private static void TracksPreviewShellStatus()
+        {
+            var viewModel = new PreviewShellViewModel(() => { });
+
+            AssertEqual("No project open", viewModel.ProjectIdentity,
+                "The shell must expose an explicit no-project state.");
+            AssertEqual("Ready", viewModel.StatusText,
+                "The shell must start with an explicit idle status.");
+
+            viewModel.SetProject("Example.esp", true);
+            viewModel.SetWarningCount(3);
+            viewModel.SetOperation("Shell_ProjectOpen_OpeningProgress", 42, 42);
+
+            AssertEqual("Example.esp", viewModel.ProjectIdentity,
+                "The shell must retain the safe project display name.");
+            AssertEqual(true, viewModel.IsModified,
+                "The shell must retain the unsaved project state.");
+            AssertEqual("3 warnings", viewModel.WarningText,
+                "The shell must format the persistent warning count.");
+            AssertEqual("Opening project: 42%", viewModel.StatusText,
+                "An active operation must replace the idle status.");
+            AssertEqual(42d, viewModel.OperationProgress,
+                "The shell must retain bounded operation progress.");
+
+            viewModel.ShowNotification(
+                PreviewShellNotificationSeverity.Error,
+                "Shell_ProjectOpen_Failed");
+            AssertEqual(true, viewModel.HasNotification,
+                "The shell must expose a persistent error boundary.");
+            AssertEqual(PreviewShellNotificationSeverity.Error, viewModel.NotificationSeverity,
+                "The shell must retain notification severity independently from its text.");
+            AssertEqual("The project could not be opened.", viewModel.NotificationMessage,
+                "The error boundary must expose registered user-safe text.");
+            viewModel.DismissNotificationCommand.Execute(null);
+            AssertEqual(false, viewModel.HasNotification,
+                "A non-blocking notification must be dismissible by command.");
+
+            viewModel.CompleteOperation();
+            AssertEqual("Ready", viewModel.StatusText,
+                "Completing an operation must restore the idle status.");
+            AssertEqual(0d, viewModel.OperationProgress,
+                "Completing an operation must clear stale progress.");
         }
 
         private static TranslationPresetCoordinator CreateCoordinator(RecordingStore store)

--- a/Phoenix_Translator/Application/PreviewShellCommand.cs
+++ b/Phoenix_Translator/Application/PreviewShellCommand.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Windows.Input;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Adapts a synchronous shell action to the WPF command contract.
+    /// </summary>
+    internal sealed class PreviewShellCommand : ICommand
+    {
+        private readonly Action<object> _execute;
+        private readonly Predicate<object> _canExecute;
+
+        /// <summary>
+        /// Creates a command with an optional availability predicate.
+        /// </summary>
+        /// <param name="execute">The action invoked with the command parameter.</param>
+        /// <param name="canExecute">The optional predicate that controls command availability.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="execute"/> is <see langword="null"/>.</exception>
+        internal PreviewShellCommand(Action<object> execute, Predicate<object> canExecute = null)
+        {
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+            _canExecute = canExecute;
+        }
+
+        /// <inheritdoc />
+        public event EventHandler CanExecuteChanged;
+
+        /// <inheritdoc />
+        public bool CanExecute(object parameter)
+        {
+            return _canExecute == null || _canExecute(parameter);
+        }
+
+        /// <inheritdoc />
+        public void Execute(object parameter)
+        {
+            _execute(parameter);
+        }
+
+        /// <summary>
+        /// Notifies WPF that command availability may have changed.
+        /// </summary>
+        internal void RaiseCanExecuteChanged()
+        {
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/Phoenix_Translator/Application/PreviewShellViewModel.cs
+++ b/Phoenix_Translator/Application/PreviewShellViewModel.cs
@@ -1,0 +1,370 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Identifies a primary destination hosted by the preview shell.
+    /// </summary>
+    internal enum PreviewShellDestination
+    {
+        Projects,
+        Translate,
+        Review,
+        Quality,
+        History,
+        ProjectUpdate,
+        Settings,
+        AdvancedTools
+    }
+
+    /// <summary>
+    /// Identifies the visual and semantic severity of a shell notification.
+    /// </summary>
+    internal enum PreviewShellNotificationSeverity
+    {
+        Information,
+        Success,
+        Warning,
+        Error
+    }
+
+    /// <summary>
+    /// Describes one keyboard-addressable preview navigation destination.
+    /// </summary>
+    internal sealed class PreviewShellNavigationItem
+    {
+        /// <summary>
+        /// Creates a navigation item.
+        /// </summary>
+        /// <param name="destination">The destination selected by the item.</param>
+        /// <param name="label">The localized visible label.</param>
+        internal PreviewShellNavigationItem(PreviewShellDestination destination, string label)
+        {
+            Destination = destination;
+            Label = label;
+        }
+
+        /// <summary>
+        /// Gets the destination selected by this item.
+        /// </summary>
+        public PreviewShellDestination Destination { get; private set; }
+
+        /// <summary>
+        /// Gets the localized navigation label.
+        /// </summary>
+        public string Label { get; private set; }
+    }
+
+    /// <summary>
+    /// Owns preview-shell navigation and user-visible project and operation status.
+    /// </summary>
+    internal sealed class PreviewShellViewModel : INotifyPropertyChanged
+    {
+        private readonly Action _openLegacyWorkspace;
+        private PreviewShellDestination _currentDestination;
+        private string _projectName;
+        private bool _isModified;
+        private int _warningCount;
+        private bool _isOperationRunning;
+        private string _operationText;
+        private double _operationProgress;
+        private string _notificationMessage;
+        private PreviewShellNotificationSeverity _notificationSeverity;
+
+        /// <summary>
+        /// Creates the initial no-project shell state.
+        /// </summary>
+        /// <param name="openLegacyWorkspace">The integration action that opens the legacy workspace.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="openLegacyWorkspace"/> is <see langword="null"/>.</exception>
+        internal PreviewShellViewModel(Action openLegacyWorkspace)
+        {
+            _openLegacyWorkspace = openLegacyWorkspace ?? throw new ArgumentNullException(nameof(openLegacyWorkspace));
+            _currentDestination = PreviewShellDestination.Projects;
+            _operationText = string.Empty;
+
+            NavigationItems = new[]
+            {
+                CreateNavigationItem(PreviewShellDestination.Projects, "Shell_Navigation_Projects"),
+                CreateNavigationItem(PreviewShellDestination.Translate, "Shell_Navigation_Translate"),
+                CreateNavigationItem(PreviewShellDestination.Review, "Shell_Navigation_Review"),
+                CreateNavigationItem(PreviewShellDestination.Quality, "Shell_Navigation_Quality"),
+                CreateNavigationItem(PreviewShellDestination.History, "Shell_Navigation_History"),
+                CreateNavigationItem(PreviewShellDestination.ProjectUpdate, "Shell_Navigation_ProjectUpdate"),
+                CreateNavigationItem(PreviewShellDestination.Settings, "Shell_Navigation_Settings"),
+                CreateNavigationItem(PreviewShellDestination.AdvancedTools, "Shell_Navigation_AdvancedTools")
+            };
+
+            NavigateCommand = new PreviewShellCommand(NavigateFromParameter);
+            OpenLegacyWorkspaceCommand = new PreviewShellCommand(parameter => _openLegacyWorkspace());
+            DismissNotificationCommand = new PreviewShellCommand(parameter => ClearNotification());
+        }
+
+        /// <inheritdoc />
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Gets the stable ordered primary navigation items.
+        /// </summary>
+        public IReadOnlyList<PreviewShellNavigationItem> NavigationItems { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the selected preview destination.
+        /// </summary>
+        public PreviewShellDestination CurrentDestination
+        {
+            get => _currentDestination;
+            set
+            {
+                if (_currentDestination == value)
+                {
+                    return;
+                }
+
+                _currentDestination = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(CurrentTitle));
+                OnPropertyChanged(nameof(CurrentDescription));
+            }
+        }
+
+        /// <summary>
+        /// Gets the localized heading for the selected destination.
+        /// </summary>
+        public string CurrentTitle => PreviewMessageCatalog.Get(GetDestinationMessageId("Title"));
+
+        /// <summary>
+        /// Gets the localized rollout description for the selected destination.
+        /// </summary>
+        public string CurrentDescription => PreviewMessageCatalog.Get(GetDestinationMessageId("Description"));
+
+        /// <summary>
+        /// Gets the product version shown independently from dependency versions.
+        /// </summary>
+        public string ProductVersion => typeof(PreviewShellViewModel).Assembly.GetName().Version.ToString();
+
+        /// <summary>
+        /// Gets the current project identity or the localized no-project label.
+        /// </summary>
+        public string ProjectIdentity => string.IsNullOrWhiteSpace(_projectName)
+            ? PreviewMessageCatalog.Get("Shell_Project_None")
+            : _projectName;
+
+        /// <summary>
+        /// Gets whether a project identity is available.
+        /// </summary>
+        public bool HasProject => !string.IsNullOrWhiteSpace(_projectName);
+
+        /// <summary>
+        /// Gets whether the current project contains unsaved changes.
+        /// </summary>
+        public bool IsModified => _isModified;
+
+        /// <summary>
+        /// Gets the localized modified-state label.
+        /// </summary>
+        public string ModifiedText => PreviewMessageCatalog.Get("Common_State_Modified");
+
+        /// <summary>
+        /// Gets whether the shell has one or more project warnings.
+        /// </summary>
+        public bool HasWarnings => _warningCount > 0;
+
+        /// <summary>
+        /// Gets the localized warning-count summary.
+        /// </summary>
+        public string WarningText => PreviewMessageCatalog.Format("Shell_Status_WarningCount", _warningCount);
+
+        /// <summary>
+        /// Gets whether a long-running shell operation is active.
+        /// </summary>
+        public bool IsOperationRunning => _isOperationRunning;
+
+        /// <summary>
+        /// Gets the localized active-operation description.
+        /// </summary>
+        public string OperationText => _operationText;
+
+        /// <summary>
+        /// Gets the current operation progress from zero through one hundred.
+        /// </summary>
+        public double OperationProgress => _operationProgress;
+
+        /// <summary>
+        /// Gets the localized idle or active shell status.
+        /// </summary>
+        public string StatusText => _isOperationRunning
+            ? _operationText
+            : PreviewMessageCatalog.Get("Common_State_Ready");
+
+        /// <summary>
+        /// Gets the command that selects a preview destination by enum or enum name.
+        /// </summary>
+        public ICommand NavigateCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that opens the complete legacy workspace.
+        /// </summary>
+        public ICommand OpenLegacyWorkspaceCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that dismisses the current non-blocking notification.
+        /// </summary>
+        public ICommand DismissNotificationCommand { get; private set; }
+
+        /// <summary>
+        /// Gets whether a non-blocking shell notification is visible.
+        /// </summary>
+        public bool HasNotification => !string.IsNullOrWhiteSpace(_notificationMessage);
+
+        /// <summary>
+        /// Gets the localized and user-safe notification message.
+        /// </summary>
+        public string NotificationMessage => _notificationMessage;
+
+        /// <summary>
+        /// Gets the semantic severity of the current notification.
+        /// </summary>
+        public PreviewShellNotificationSeverity NotificationSeverity => _notificationSeverity;
+
+        /// <summary>
+        /// Updates the project identity and unsaved state visible throughout the shell.
+        /// </summary>
+        /// <param name="projectName">The safe display name, or <see langword="null"/> to clear the project.</param>
+        /// <param name="isModified">Whether the project contains unsaved changes.</param>
+        internal void SetProject(string projectName, bool isModified)
+        {
+            _projectName = projectName;
+            _isModified = !string.IsNullOrWhiteSpace(projectName) && isModified;
+            OnPropertyChanged(nameof(ProjectIdentity));
+            OnPropertyChanged(nameof(HasProject));
+            OnPropertyChanged(nameof(IsModified));
+        }
+
+        /// <summary>
+        /// Updates the warning count visible throughout the shell.
+        /// </summary>
+        /// <param name="warningCount">The non-negative project warning count.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="warningCount"/> is negative.</exception>
+        internal void SetWarningCount(int warningCount)
+        {
+            if (warningCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(warningCount));
+            }
+
+            _warningCount = warningCount;
+            OnPropertyChanged(nameof(HasWarnings));
+            OnPropertyChanged(nameof(WarningText));
+        }
+
+        /// <summary>
+        /// Starts or updates a localized long-running operation.
+        /// </summary>
+        /// <param name="messageId">The registered operation message identifier.</param>
+        /// <param name="progress">Progress from zero through one hundred.</param>
+        /// <param name="arguments">Values for the message's documented placeholders.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="progress"/> is outside zero through one hundred.</exception>
+        internal void SetOperation(string messageId, double progress, params object[] arguments)
+        {
+            if (progress < 0 || progress > 100)
+            {
+                throw new ArgumentOutOfRangeException(nameof(progress));
+            }
+
+            _operationText = arguments == null || arguments.Length == 0
+                ? PreviewMessageCatalog.Get(messageId)
+                : PreviewMessageCatalog.Format(messageId, arguments);
+            _operationProgress = progress;
+            _isOperationRunning = true;
+            OnPropertyChanged(nameof(IsOperationRunning));
+            OnPropertyChanged(nameof(OperationText));
+            OnPropertyChanged(nameof(OperationProgress));
+            OnPropertyChanged(nameof(StatusText));
+        }
+
+        /// <summary>
+        /// Returns the shell to its idle operation state.
+        /// </summary>
+        internal void CompleteOperation()
+        {
+            _isOperationRunning = false;
+            _operationText = string.Empty;
+            _operationProgress = 0;
+            OnPropertyChanged(nameof(IsOperationRunning));
+            OnPropertyChanged(nameof(OperationText));
+            OnPropertyChanged(nameof(OperationProgress));
+            OnPropertyChanged(nameof(StatusText));
+        }
+
+        /// <summary>
+        /// Shows a localized non-blocking notification in the persistent shell boundary.
+        /// </summary>
+        /// <param name="severity">The semantic notification severity.</param>
+        /// <param name="messageId">The registered user-safe message identifier.</param>
+        /// <param name="arguments">Values for the message's documented placeholders.</param>
+        internal void ShowNotification(
+            PreviewShellNotificationSeverity severity,
+            string messageId,
+            params object[] arguments)
+        {
+            _notificationSeverity = severity;
+            _notificationMessage = arguments == null || arguments.Length == 0
+                ? PreviewMessageCatalog.Get(messageId)
+                : PreviewMessageCatalog.Format(messageId, arguments);
+            OnPropertyChanged(nameof(HasNotification));
+            OnPropertyChanged(nameof(NotificationMessage));
+            OnPropertyChanged(nameof(NotificationSeverity));
+        }
+
+        /// <summary>
+        /// Clears the current non-blocking shell notification.
+        /// </summary>
+        internal void ClearNotification()
+        {
+            _notificationMessage = string.Empty;
+            OnPropertyChanged(nameof(HasNotification));
+            OnPropertyChanged(nameof(NotificationMessage));
+        }
+
+        private static PreviewShellNavigationItem CreateNavigationItem(
+            PreviewShellDestination destination,
+            string messageId)
+        {
+            return new PreviewShellNavigationItem(destination, PreviewMessageCatalog.Get(messageId));
+        }
+
+        private void NavigateFromParameter(object parameter)
+        {
+            if (parameter is PreviewShellDestination)
+            {
+                CurrentDestination = (PreviewShellDestination)parameter;
+                return;
+            }
+
+            PreviewShellDestination destination;
+            if (parameter != null && Enum.TryParse(parameter.ToString(), true, out destination))
+            {
+                CurrentDestination = destination;
+            }
+        }
+
+        private string GetDestinationMessageId(string suffix)
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "Shell_Page_{0}_{1}",
+                _currentDestination,
+                suffix);
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/Phoenix_Translator/DeFine.cs
+++ b/Phoenix_Translator/DeFine.cs
@@ -36,7 +36,7 @@ namespace PhoenixTranslator
 
         public static string BackupPath = @"\BackUpData\";
 
-        public static string CurrentVersion = "5.1.5.9";
+        public static string CurrentVersion = typeof(DeFine).Assembly.GetName().Version.ToString();
         public static LocalSetting GlobalLocalSetting = new LocalSetting();
 
         public static RowStyleWin RowStyleWin = new RowStyleWin();

--- a/Phoenix_Translator/PhoenixTranslator.csproj
+++ b/Phoenix_Translator/PhoenixTranslator.csproj
@@ -108,6 +108,8 @@
     </ApplicationDefinition>
     <Compile Include="Application\AdvancedDictionaryQueryBuilder.cs" />
     <Compile Include="Application\PreviewMessageCatalog.cs" />
+    <Compile Include="Application\PreviewShellCommand.cs" />
+    <Compile Include="Application\PreviewShellViewModel.cs" />
     <Compile Include="Application\LegacyTranslationPresetStore.cs" />
     <Compile Include="Application\TranslationPresetService.cs" />
     <Compile Include="FileManagement\ZipHelper.cs" />
@@ -194,6 +196,9 @@
     <Compile Include="UIManagement\UIHelper.cs" />
     <Compile Include="UIManagement\UILanguageHelper.cs" />
     <Compile Include="UIManagement\Localization\PreviewMessageExtension.cs" />
+    <Compile Include="UIManagement\Preview\PreviewShellWindow.xaml.cs">
+      <DependentUpon>PreviewShellWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="UIManagement\YDListView.cs" />
     <Compile Include="UIManagement\Setting\LexTranslatorRadarChart.xaml.cs">
       <DependentUpon>LexTranslatorRadarChart.xaml</DependentUpon>
@@ -302,6 +307,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="UIManagement\Preview\PreviewMessageExamples.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="UIManagement\Preview\PreviewShellWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Phoenix_Translator/Properties/AssemblyInfo.cs
+++ b/Phoenix_Translator/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Windows;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.0.0.6")]
-[assembly: AssemblyFileVersion("2.0.0.6")]
+[assembly: AssemblyVersion("2.0.0.7")]
+[assembly: AssemblyFileVersion("2.0.0.7")]

--- a/Phoenix_Translator/Properties/Resources.resx
+++ b/Phoenix_Translator/Properties/Resources.resx
@@ -118,6 +118,7 @@
   <data name="Common_Action_Back" xml:space="preserve"><value>Back</value><comment>Shared wizard or navigation action.</comment></data>
   <data name="Common_Action_Browse" xml:space="preserve"><value>Browse</value><comment>Shared action that opens a file or folder picker.</comment></data>
   <data name="Common_Action_Cancel" xml:space="preserve"><value>Cancel</value><comment>Shared action that cancels a dialog or operation.</comment></data>
+  <data name="Common_Action_Dismiss" xml:space="preserve"><value>Dismiss</value><comment>Closes a non-blocking notification without changing project state.</comment></data>
   <data name="Common_Action_Clear" xml:space="preserve"><value>Clear</value><comment>Shared action that clears user-controlled content or filters.</comment></data>
   <data name="Common_Action_Close" xml:space="preserve"><value>Close</value><comment>Shared action that closes the current surface.</comment></data>
   <data name="Common_Action_Discard" xml:space="preserve"><value>Discard</value><comment>Shared action that abandons staged or unsaved changes.</comment></data>
@@ -148,6 +149,28 @@
   <data name="Shell_Navigation_AdvancedTools" xml:space="preserve"><value>Advanced tools</value><comment>Shell navigation destination for progressively disclosed expert tools.</comment></data>
   <data name="Shell_Unsaved_ClosePrompt_Title" xml:space="preserve"><value>Save changes before closing?</value><comment>Heading for the modified-project close confirmation.</comment></data>
   <data name="Shell_Unsaved_ClosePrompt_Body" xml:space="preserve"><value>Your project contains changes that have not been saved.</value><comment>Body for the modified-project close confirmation.</comment></data>
+  <data name="Shell_Preview_Badge" xml:space="preserve"><value>Preview</value><comment>Badge that distinguishes the incremental preview shell from the legacy workspace.</comment></data>
+  <data name="Shell_Legacy_Open_Action" xml:space="preserve"><value>Open legacy workspace</value><comment>Global fallback action that opens the complete legacy PhoenixGui window.</comment></data>
+  <data name="Shell_Legacy_Shortcut_Hint" xml:space="preserve"><value>Ctrl+L opens the legacy workspace.</value><comment>Keyboard hint below the workflow fallback action.</comment></data>
+  <data name="Shell_Navigation_Shortcuts_Hint" xml:space="preserve"><value>Ctrl+1–8 navigate</value><comment>Compact shell footer hint for direct workflow navigation.</comment></data>
+  <data name="Shell_Status_WarningCount" xml:space="preserve"><value>{0} warnings</value><comment>Persistent shell warning summary. Placeholders: {0}=non-negative integer warning count.</comment></data>
+  <data name="Shell_Page_PreviewFallback_Description" xml:space="preserve"><value>This workflow is still provided by the legacy workspace while its preview replacement is developed and validated.</value><comment>Shared explanation in a preview destination that still delegates its workflow to PhoenixGui.</comment></data>
+  <data name="Shell_Page_Projects_Title" xml:space="preserve"><value>Projects</value><comment>Preview shell heading for project selection and recent projects.</comment></data>
+  <data name="Shell_Page_Projects_Description" xml:space="preserve"><value>Open a supported file, return to a recent project, or continue in the legacy workspace.</value><comment>Preview shell description for the Projects destination.</comment></data>
+  <data name="Shell_Page_Translate_Title" xml:space="preserve"><value>Translate</value><comment>Preview shell heading for the translation workspace.</comment></data>
+  <data name="Shell_Page_Translate_Description" xml:space="preserve"><value>Work through source and target entries with persistent project context and operation status.</value><comment>Preview shell description for the Translate destination.</comment></data>
+  <data name="Shell_Page_Review_Title" xml:space="preserve"><value>Review</value><comment>Preview shell heading for the review workflow.</comment></data>
+  <data name="Shell_Page_Review_Description" xml:space="preserve"><value>Inspect translation context and provenance before recording a durable review decision.</value><comment>Preview shell description for the Review destination.</comment></data>
+  <data name="Shell_Page_Quality_Title" xml:space="preserve"><value>Quality</value><comment>Preview shell heading for quality validation.</comment></data>
+  <data name="Shell_Page_Quality_Description" xml:space="preserve"><value>Run project checks, inspect findings, and determine export readiness.</value><comment>Preview shell description for the Quality destination.</comment></data>
+  <data name="Shell_Page_History_Title" xml:space="preserve"><value>History</value><comment>Preview shell heading for project and entry history.</comment></data>
+  <data name="Shell_Page_History_Description" xml:space="preserve"><value>Compare revisions, understand their origin, and restore without discarding provenance.</value><comment>Preview shell description for the History destination.</comment></data>
+  <data name="Shell_Page_ProjectUpdate_Title" xml:space="preserve"><value>Project update</value><comment>Preview shell heading for comparing a newer source revision.</comment></data>
+  <data name="Shell_Page_ProjectUpdate_Description" xml:space="preserve"><value>Compare source revisions, resolve ambiguous identities, and apply updates safely.</value><comment>Preview shell description for the Project update destination.</comment></data>
+  <data name="Shell_Page_Settings_Title" xml:space="preserve"><value>Settings</value><comment>Preview shell heading for intent-based settings.</comment></data>
+  <data name="Shell_Page_Settings_Description" xml:space="preserve"><value>Configure providers, translation behavior, formats, appearance, and accessibility with staged changes.</value><comment>Preview shell description for the Settings destination.</comment></data>
+  <data name="Shell_Page_AdvancedTools_Title" xml:space="preserve"><value>Advanced tools</value><comment>Preview shell heading for progressively disclosed expert capabilities.</comment></data>
+  <data name="Shell_Page_AdvancedTools_Description" xml:space="preserve"><value>Access terminology data, provider pipelines, context inspectors, and diagnostics.</value><comment>Preview shell description for the Advanced tools destination.</comment></data>
   <data name="Workspace_Title" xml:space="preserve"><value>Translation workspace</value><comment>Accessible workflow title for the translation workspace.</comment></data>
   <data name="Workspace_Search_Placeholder" xml:space="preserve"><value>Search entries</value><comment>Placeholder in the workspace entry search field.</comment></data>
   <data name="Workspace_Filter_AllStates" xml:space="preserve"><value>All states</value><comment>Default state-filter option in the workspace.</comment></data>

--- a/Phoenix_Translator/SplashWindow.xaml.cs
+++ b/Phoenix_Translator/SplashWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Windows;
 using System.Windows.Input;
 using PhoenixEngine;
+using PhoenixTranslator.UIManagement.Preview;
 
 namespace PhoenixTranslator
 {
@@ -53,7 +54,7 @@ namespace PhoenixTranslator
         }
 
         public Thread LoadingTrd = null;
-        public static PhoenixGui Main = null;
+        public static Window Main = null;
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
@@ -145,7 +146,7 @@ namespace PhoenixTranslator
                
                 Application.Current.Dispatcher.Invoke(new Action(() =>
                 {
-                    SplashWindow.Main = new PhoenixGui();
+                    SplashWindow.Main = new PreviewShellWindow();
                     SplashWindow.Main.Show();
                     CanExit = false;
 

--- a/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml
@@ -1,0 +1,220 @@
+<Window x:Class="PhoenixTranslator.UIManagement.Preview.PreviewShellWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:localization="clr-namespace:PhoenixTranslator.UIManagement.Localization"
+        Title="{localization:PreviewMessage Shell_Product_Name}"
+        Width="1280" Height="800" MinWidth="1100" MinHeight="700"
+        WindowStartupLocation="CenterScreen" Background="#FF1A1A1A"
+        Closing="Window_Closing"
+        TextOptions.TextFormattingMode="Display" TextOptions.TextRenderingMode="ClearType">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Themes/PreviewControlStyles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <BooleanToVisibilityConverter x:Key="BooleanToVisibility" />
+            <Style x:Key="PreviewNavigationItem" TargetType="ListBoxItem">
+                <Setter Property="Height" Value="38" />
+                <Setter Property="Margin" Value="8,2" />
+                <Setter Property="Padding" Value="16,0" />
+                <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextSecondary}" />
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                <Setter Property="VerticalContentAlignment" Value="Center" />
+                <Setter Property="FocusVisualStyle" Value="{StaticResource PreviewFocusVisual}" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ListBoxItem">
+                            <Border x:Name="Chrome" Background="{TemplateBinding Background}"
+                                    CornerRadius="{StaticResource PreviewRadiusMedium}">
+                                <Grid>
+                                    <Border x:Name="CurrentMark" Width="3" HorizontalAlignment="Left"
+                                            Background="{StaticResource PreviewBrushAccentGold}"
+                                            Visibility="Collapsed" />
+                                    <ContentPresenter Margin="{TemplateBinding Padding}" />
+                                </Grid>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="Chrome" Property="Background" Value="{StaticResource PreviewBrushSurfaceInteractive}" />
+                                </Trigger>
+                                <Trigger Property="IsSelected" Value="True">
+                                    <Setter TargetName="Chrome" Property="Background" Value="{StaticResource PreviewBrushSurfaceInteractive}" />
+                                    <Setter TargetName="CurrentMark" Property="Visibility" Value="Visible" />
+                                    <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Window.InputBindings>
+        <KeyBinding Modifiers="Control" Key="D1" Command="{Binding NavigateCommand}" CommandParameter="Projects" />
+        <KeyBinding Modifiers="Control" Key="D2" Command="{Binding NavigateCommand}" CommandParameter="Translate" />
+        <KeyBinding Modifiers="Control" Key="D3" Command="{Binding NavigateCommand}" CommandParameter="Review" />
+        <KeyBinding Modifiers="Control" Key="D4" Command="{Binding NavigateCommand}" CommandParameter="Quality" />
+        <KeyBinding Modifiers="Control" Key="D5" Command="{Binding NavigateCommand}" CommandParameter="History" />
+        <KeyBinding Modifiers="Control" Key="D6" Command="{Binding NavigateCommand}" CommandParameter="ProjectUpdate" />
+        <KeyBinding Modifiers="Control" Key="D7" Command="{Binding NavigateCommand}" CommandParameter="Settings" />
+        <KeyBinding Modifiers="Control" Key="D8" Command="{Binding NavigateCommand}" CommandParameter="AdvancedTools" />
+        <KeyBinding Modifiers="Control" Key="L" Command="{Binding OpenLegacyWorkspaceCommand}" />
+    </Window.InputBindings>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="52" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="36" />
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0" Background="{StaticResource PreviewBrushSurfacePrimary}"
+                BorderBrush="{StaticResource PreviewBrushBorder}" BorderThickness="0,0,0,1">
+            <Grid Margin="20,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="24" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="16" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <TextBlock VerticalAlignment="Center" FontSize="20" FontWeight="Bold"
+                           Foreground="{StaticResource PreviewBrushAccentGold}"
+                           Text="{localization:PreviewMessage Shell_Product_Name}" />
+                <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
+                    <TextBlock VerticalAlignment="Center" FontSize="14" FontWeight="SemiBold"
+                               Foreground="{StaticResource PreviewBrushTextPrimary}" Text="{Binding ProjectIdentity}" />
+                    <Border Margin="10,0,0,0" Padding="7,2" CornerRadius="3"
+                            Background="{StaticResource PreviewBrushSurfaceInteractive}">
+                        <TextBlock FontSize="11" Foreground="{StaticResource PreviewBrushAccentGold}"
+                                   Text="{localization:PreviewMessage Shell_Preview_Badge}" />
+                    </Border>
+                    <TextBlock Margin="10,0,0,0" VerticalAlignment="Center"
+                               Foreground="{StaticResource PreviewBrushWarning}" Text="{Binding ModifiedText}"
+                               Visibility="{Binding IsModified, Converter={StaticResource BooleanToVisibility}}" />
+                </StackPanel>
+                <Button Grid.Column="3" Style="{StaticResource PreviewButtonSecondary}"
+                        Command="{Binding OpenLegacyWorkspaceCommand}"
+                        Content="{localization:PreviewMessage Shell_Legacy_Open_Action}" />
+                <TextBlock Grid.Column="5" VerticalAlignment="Center" Foreground="{StaticResource PreviewBrushTextMuted}"
+                           Text="{Binding ProductVersion}" />
+            </Grid>
+        </Border>
+
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="216" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Border Grid.Column="0" Background="{StaticResource PreviewBrushSurfaceRaised}"
+                    BorderBrush="{StaticResource PreviewBrushBorder}" BorderThickness="0,0,1,0">
+                <ListBox Margin="0,14" ItemsSource="{Binding NavigationItems}"
+                         SelectedValuePath="Destination" SelectedValue="{Binding CurrentDestination}"
+                         ItemContainerStyle="{StaticResource PreviewNavigationItem}"
+                         AutomationProperties.Name="{localization:PreviewMessage Accessibility_Shell_Navigation_Name}"
+                         Background="Transparent" BorderThickness="0">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock VerticalAlignment="Center" Text="{Binding Label}" />
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Border>
+
+            <Grid Grid.Column="1" Margin="32">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+                <StackPanel>
+                    <TextBlock FontSize="24" FontWeight="SemiBold" Foreground="{StaticResource PreviewBrushTextPrimary}"
+                               Text="{Binding CurrentTitle}" />
+                    <TextBlock Margin="0,8,0,0" FontSize="13" Foreground="{StaticResource PreviewBrushTextMuted}"
+                               Text="{Binding CurrentDescription}" TextWrapping="Wrap" />
+                </StackPanel>
+                <Border Grid.Row="1" Margin="0,16,0,16" Padding="12,8"
+                        Background="{StaticResource PreviewBrushSurfaceInteractive}"
+                        Visibility="{Binding HasNotification, Converter={StaticResource BooleanToVisibility}}"
+                        AutomationProperties.LiveSetting="Polite">
+                    <Border.Style>
+                        <Style TargetType="Border">
+                            <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushInformation}" />
+                            <Setter Property="BorderThickness" Value="3,0,0,0" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding NotificationSeverity}" Value="Success">
+                                    <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushSuccess}" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding NotificationSeverity}" Value="Warning">
+                                    <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushWarning}" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding NotificationSeverity}" Value="Error">
+                                    <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushError}" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Border.Style>
+                    <DockPanel>
+                        <Button DockPanel.Dock="Right" Margin="16,0,0,0"
+                                Style="{StaticResource PreviewButtonSecondary}"
+                                Command="{Binding DismissNotificationCommand}"
+                                Content="{localization:PreviewMessage Common_Action_Dismiss}" />
+                        <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"
+                                   Foreground="{StaticResource PreviewBrushTextPrimary}"
+                                   Text="{Binding NotificationMessage}" />
+                    </DockPanel>
+                </Border>
+                <Border Grid.Row="2" Background="{StaticResource PreviewBrushSurfacePrimary}"
+                        BorderBrush="{StaticResource PreviewBrushBorder}" BorderThickness="1"
+                        CornerRadius="{StaticResource PreviewRadiusLarge}">
+                    <Grid Margin="32">
+                        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" MaxWidth="560">
+                            <TextBlock HorizontalAlignment="Center" FontSize="18" FontWeight="SemiBold"
+                                       Foreground="{StaticResource PreviewBrushTextPrimary}"
+                                       Text="{Binding CurrentTitle}" />
+                            <TextBlock Margin="0,12,0,24" TextAlignment="Center" TextWrapping="Wrap"
+                                       Foreground="{StaticResource PreviewBrushTextSecondary}"
+                                       Text="{localization:PreviewMessage Shell_Page_PreviewFallback_Description}" />
+                            <Button HorizontalAlignment="Center" Style="{StaticResource PreviewButtonPrimary}"
+                                    Command="{Binding OpenLegacyWorkspaceCommand}"
+                                    Content="{localization:PreviewMessage Shell_Legacy_Open_Action}" />
+                            <TextBlock Margin="0,16,0,0" HorizontalAlignment="Center"
+                                       Foreground="{StaticResource PreviewBrushTextMuted}"
+                                       Text="{localization:PreviewMessage Shell_Legacy_Shortcut_Hint}" />
+                        </StackPanel>
+                    </Grid>
+                </Border>
+            </Grid>
+        </Grid>
+
+        <Border Grid.Row="2" Background="{StaticResource PreviewBrushSurfacePrimary}"
+                BorderBrush="{StaticResource PreviewBrushBorder}" BorderThickness="0,1,0,0"
+                AutomationProperties.Name="{localization:PreviewMessage Accessibility_Shell_ProjectStatus_Name}">
+            <Grid Margin="16,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="16" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="24" />
+                    <ColumnDefinition Width="220" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <Ellipse Width="8" Height="8" VerticalAlignment="Center" Fill="{StaticResource PreviewBrushSuccess}" />
+                <TextBlock Grid.Column="2" VerticalAlignment="Center" Foreground="{StaticResource PreviewBrushTextSecondary}"
+                           Text="{Binding StatusText}" />
+                <ProgressBar Grid.Column="4" Height="5" VerticalAlignment="Center" Minimum="0" Maximum="100"
+                             Value="{Binding OperationProgress, Mode=OneWay}"
+                             Visibility="{Binding IsOperationRunning, Converter={StaticResource BooleanToVisibility}}" />
+                <TextBlock Grid.Column="5" Margin="16,0,0,0" VerticalAlignment="Center"
+                           Foreground="{StaticResource PreviewBrushWarning}" Text="{Binding WarningText}"
+                           Visibility="{Binding HasWarnings, Converter={StaticResource BooleanToVisibility}}" />
+                <TextBlock Grid.Column="6" VerticalAlignment="Center" Foreground="{StaticResource PreviewBrushTextMuted}"
+                           Text="{localization:PreviewMessage Shell_Navigation_Shortcuts_Hint}" />
+            </Grid>
+        </Border>
+    </Grid>
+</Window>

--- a/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml.cs
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml.cs
@@ -1,0 +1,52 @@
+using System;
+using System.ComponentModel;
+using System.Windows;
+using PhoenixTranslator.ApplicationLayer;
+
+namespace PhoenixTranslator.UIManagement.Preview
+{
+    /// <summary>
+    /// Hosts preview workflow navigation while retaining the complete legacy workspace as a fallback.
+    /// </summary>
+    public partial class PreviewShellWindow : Window
+    {
+        private PhoenixGui _legacyWorkspace;
+
+        /// <summary>
+        /// Creates the preview application shell in its no-project state.
+        /// </summary>
+        public PreviewShellWindow()
+        {
+            InitializeComponent();
+            DataContext = new PreviewShellViewModel(OpenLegacyWorkspace);
+        }
+
+        private void OpenLegacyWorkspace()
+        {
+            if (_legacyWorkspace == null)
+            {
+                _legacyWorkspace = new PhoenixGui();
+                _legacyWorkspace.Closed += LegacyWorkspaceClosed;
+                _legacyWorkspace.Show();
+            }
+
+            if (_legacyWorkspace.WindowState == WindowState.Minimized)
+            {
+                _legacyWorkspace.WindowState = WindowState.Normal;
+            }
+
+            _legacyWorkspace.Activate();
+        }
+
+        private void LegacyWorkspaceClosed(object sender, EventArgs e)
+        {
+            _legacyWorkspace.Closed -= LegacyWorkspaceClosed;
+            _legacyWorkspace = null;
+        }
+
+        private void Window_Closing(object sender, CancelEventArgs e)
+        {
+            DeFine.CloseAny();
+        }
+    }
+}

--- a/docs/preview-shell.md
+++ b/docs/preview-shell.md
@@ -1,0 +1,41 @@
+# Preview shell
+
+The preview shell is the incremental entry point for the Phoenix Translator UI redesign. It preserves the
+existing WPF, .NET Framework 4.8.1, and C# 7.3 runtime while workflow screens are replaced one at a time.
+
+## Startup and fallback
+
+The splash window opens `PreviewShellWindow` after normal application initialization. Every preview destination
+currently exposes the complete legacy workspace through a global action and `Ctrl+L`. The legacy window is created
+only when requested, reused while open, and remains the functional owner of project workflows until their dedicated
+preview issues are completed.
+
+## Navigation
+
+The primary destinations have stable order and keyboard access:
+
+1. Projects (`Ctrl+1`)
+2. Translate (`Ctrl+2`)
+3. Review (`Ctrl+3`)
+4. Quality (`Ctrl+4`)
+5. History (`Ctrl+5`)
+6. Project update (`Ctrl+6`)
+7. Settings (`Ctrl+7`)
+8. Advanced tools (`Ctrl+8`)
+
+`PreviewShellViewModel` owns the selected destination, safe project identity, modified state, warning summary,
+long-running operation status, and the non-blocking notification boundary. Notifications retain semantic severity,
+resolve user-safe text from the source catalogue, and remain dismissible without stealing focus. Workflow
+implementations should update shell state rather than introduce local copies in individual views.
+
+## Layout contract
+
+The shell enforces a minimum effective size of 1100 by 700 WPF DIPs. Product identity, project identity, preview
+state, version, global fallback, navigation, and operation status remain visible independently of the selected
+destination. Visible preview copy is resolved through stable source-catalog identifiers.
+
+## Rollout boundary
+
+The shell establishes information architecture and navigation only. Project opening, translation, review, quality,
+history, update, and settings behavior remains in `PhoenixGui` until the corresponding workflow issue supplies a
+preview implementation and migration tests.


### PR DESCRIPTION
## Summary

- introduce the preview application shell as the post-splash entry point
- add keyboard-first navigation for the eight approved workflow destinations
- keep project identity, version, unsaved state, warnings, progress, and notifications in persistent shell regions
- retain the complete legacy workspace behind a global action and `Ctrl+L`
- enforce the 1100 by 700 WPF DIP minimum and document the incremental rollout boundary
- bump Phoenix Translator to 2.0.0.7

## Acceptance coverage

- [x] Primary workflows follow the approved information architecture.
- [x] Project identity, progress, warnings, unsaved state, and user-safe notifications have persistent shell state.
- [x] `Ctrl+1` through `Ctrl+8` operate all primary navigation destinations.
- [x] Advanced tools remain available as the final progressively disclosed destination.
- [x] The shell preserves critical actions at 1100 by 700 effective DIPs.
- [x] `Ctrl+L` and both visible fallback actions open and reuse the legacy workspace independently.

## Validation

- Release x64 solution build with Visual Studio MSBuild
- preview message catalogue verification
- 13 deterministic preset and shell-state tests
- automated WPF checks for all eight keyboard destinations
- automated minimum-size check at 1100 by 700
- automated legacy fallback reuse and clean shutdown checks

The build retains six pre-existing legacy compiler warnings and introduces no new warning category.

Closes #29