### PR TITLE
Build the preview translation workspace

### DIFF
--- a/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
+++ b/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
@@ -47,6 +47,9 @@
     <Compile Include="..\Phoenix_Translator\Application\AdvancedDictionaryQueryBuilder.cs">
       <Link>AdvancedDictionaryQueryBuilder.cs</Link>
     </Compile>
+    <Compile Include="..\Phoenix_Translator\Application\IPreviewTranslationProject.cs">
+      <Link>IPreviewTranslationProject.cs</Link>
+    </Compile>
     <Compile Include="..\Phoenix_Translator\Application\PreviewMessageCatalog.cs">
       <Link>PreviewMessageCatalog.cs</Link>
     </Compile>
@@ -55,6 +58,12 @@
     </Compile>
     <Compile Include="..\Phoenix_Translator\Application\PreviewShellViewModel.cs">
       <Link>PreviewShellViewModel.cs</Link>
+    </Compile>
+    <Compile Include="..\Phoenix_Translator\Application\PreviewTranslationEntry.cs">
+      <Link>PreviewTranslationEntry.cs</Link>
+    </Compile>
+    <Compile Include="..\Phoenix_Translator\Application\PreviewTranslationWorkspaceViewModel.cs">
+      <Link>PreviewTranslationWorkspaceViewModel.cs</Link>
     </Compile>
     <Compile Include="..\Phoenix_Translator\Application\TranslationPresetService.cs">
       <Link>TranslationPresetService.cs</Link>

--- a/PhoenixTranslator.PresetTests/Program.cs
+++ b/PhoenixTranslator.PresetTests/Program.cs
@@ -32,7 +32,10 @@ namespace PhoenixTranslator.PresetTests
                 { nameof(ValidatesPreviewMessageIdentifiers), ValidatesPreviewMessageIdentifiers },
                 { nameof(FormatsPreviewMessages), FormatsPreviewMessages },
                 { nameof(NavigatesPreviewShell), NavigatesPreviewShell },
-                { nameof(TracksPreviewShellStatus), TracksPreviewShellStatus }
+                { nameof(TracksPreviewShellStatus), TracksPreviewShellStatus },
+                { nameof(FiltersPreviewTranslationWorkspace), FiltersPreviewTranslationWorkspace },
+                { nameof(HandlesPreviewTranslationFailures), HandlesPreviewTranslationFailures },
+                { nameof(CancelsPreviewTranslationWork), CancelsPreviewTranslationWork }
             };
             int failures = 0;
             foreach (KeyValuePair<string, Action> test in tests)
@@ -363,6 +366,110 @@ namespace PhoenixTranslator.PresetTests
                 "Completing an operation must clear stale progress.");
         }
 
+        private static void FiltersPreviewTranslationWorkspace()
+        {
+            var shell = new PreviewShellViewModel(() => { });
+            var project = new FakePreviewTranslationProject(new[]
+            {
+                new PreviewTranslationEntry("1", "MCM", "GREETING", "Hello Dragonborn", "", 100),
+                new PreviewTranslationEntry("2", "MCM", "FAREWELL", "Goodbye", "Auf Wiedersehen", 100),
+                new PreviewTranslationEntry("3", "XML", "NOTICE", "Read this", "", 100)
+            });
+            var viewModel = new PreviewTranslationWorkspaceViewModel(
+                () => "fixture",
+                () => { },
+                shell,
+                path => project);
+
+            viewModel.OpenProjectAsync("fixture").GetAwaiter().GetResult();
+
+            AssertEqual(3, viewModel.Entries.Count,
+                "Opening a project must expose every normalized entry.");
+            AssertEqual("fixture.xml", shell.ProjectIdentity,
+                "The shell must receive only the safe project display name.");
+            AssertEqual(false, viewModel.SaveCommand.CanExecute(null),
+                "An unchanged project must not offer a redundant save.");
+
+            viewModel.SearchText = "dragonborn";
+            AssertEqual(1, viewModel.Entries.Count,
+                "Search must filter source text without changing project data.");
+
+            viewModel.SearchText = string.Empty;
+            viewModel.SelectedTypeFilter = "MCM";
+            AssertEqual(2, viewModel.Entries.Count,
+                "The type filter must retain matching normalized entries.");
+
+            viewModel.SelectedEntry.TargetText = "Willkommen";
+            AssertEqual(true, shell.IsModified,
+                "Editing a target must update persistent shell unsaved state.");
+            AssertEqual(true, viewModel.SaveCommand.CanExecute(null),
+                "A staged target edit must enable persistence.");
+            viewModel.Dispose();
+        }
+
+        private static void HandlesPreviewTranslationFailures()
+        {
+            var shell = new PreviewShellViewModel(() => { });
+            var project = new FakePreviewTranslationProject(new[]
+            {
+                new PreviewTranslationEntry("1", "MCM", "ONE", "First", "", 100),
+                new PreviewTranslationEntry("2", "MCM", "TWO", "Second", "", 100)
+            })
+            {
+                FailedKey = "2"
+            };
+            var viewModel = new PreviewTranslationWorkspaceViewModel(
+                () => "fixture",
+                () => { },
+                shell,
+                path => project);
+            viewModel.OpenProjectAsync("fixture").GetAwaiter().GetResult();
+
+            viewModel.TranslateEntriesAsync(viewModel.Entries.ToList()).GetAwaiter().GetResult();
+
+            AssertEqual("Translated First", project.Entries[0].TargetText,
+                "A successful provider result must remain staged.");
+            AssertEqual(string.Empty, project.Entries[1].TargetText,
+                "A failed entry must preserve its previous target.");
+            AssertEqual(PreviewShellNotificationSeverity.Warning, shell.NotificationSeverity,
+                "Partial provider failure must use a warning rather than discard successful edits.");
+            AssertEqual("Translation completed with 1 failed entries.", shell.NotificationMessage,
+                "Partial failure must expose a user-safe bounded summary.");
+            viewModel.Dispose();
+        }
+
+        private static void CancelsPreviewTranslationWork()
+        {
+            var shell = new PreviewShellViewModel(() => { });
+            var project = new FakePreviewTranslationProject(new[]
+            {
+                new PreviewTranslationEntry("1", "MCM", "ONE", "First", "", 100)
+            })
+            {
+                BlockUntilCancelled = true
+            };
+            var viewModel = new PreviewTranslationWorkspaceViewModel(
+                () => "fixture",
+                () => { },
+                shell,
+                path => project);
+            viewModel.OpenProjectAsync("fixture").GetAwaiter().GetResult();
+
+            System.Threading.Tasks.Task operation = viewModel.TranslateEntriesAsync(viewModel.Entries.ToList());
+            AssertEqual(true, System.Threading.SpinWait.SpinUntil(() => project.TranslateStarted, 2000),
+                "The synthetic provider must start before cancellation is requested.");
+            viewModel.CancelOperationCommand.Execute(null);
+            operation.GetAwaiter().GetResult();
+
+            AssertEqual(false, viewModel.IsBusy,
+                "Cooperative cancellation must return the workspace to its idle state.");
+            AssertEqual(string.Empty, project.Entries[0].TargetText,
+                "Cancellation must not replace an entry with a partial provider result.");
+            AssertEqual("Ready", shell.StatusText,
+                "Cooperative cancellation must restore persistent shell status.");
+            viewModel.Dispose();
+        }
+
         private static TranslationPresetCoordinator CreateCoordinator(RecordingStore store)
         {
             return new TranslationPresetCoordinator(new TranslationPresetService(), store);
@@ -407,6 +514,55 @@ namespace PhoenixTranslator.PresetTests
             public void Save()
             {
                 SaveCalls++;
+            }
+        }
+
+        private sealed class FakePreviewTranslationProject : IPreviewTranslationProject
+        {
+            internal FakePreviewTranslationProject(IReadOnlyList<PreviewTranslationEntry> entries)
+            {
+                Entries = entries;
+            }
+
+            public string Path => "fixture.xml";
+
+            public string DisplayName => "fixture.xml";
+
+            public IReadOnlyList<PreviewTranslationEntry> Entries { get; private set; }
+
+            internal string FailedKey { get; set; }
+
+            internal bool BlockUntilCancelled { get; set; }
+
+            internal bool TranslateStarted { get; private set; }
+
+            public string Translate(PreviewTranslationEntry entry, System.Threading.CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                TranslateStarted = true;
+                if (BlockUntilCancelled)
+                {
+                    while (true)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        System.Threading.Thread.Sleep(5);
+                    }
+                }
+
+                if (string.Equals(entry.Key, FailedKey, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException("Synthetic provider failure.");
+                }
+
+                return "Translated " + entry.SourceText;
+            }
+
+            public void Save()
+            {
+            }
+
+            public void Dispose()
+            {
             }
         }
     }

--- a/PhoenixTranslator.PresetTests/Program.cs
+++ b/PhoenixTranslator.PresetTests/Program.cs
@@ -35,7 +35,8 @@ namespace PhoenixTranslator.PresetTests
                 { nameof(TracksPreviewShellStatus), TracksPreviewShellStatus },
                 { nameof(FiltersPreviewTranslationWorkspace), FiltersPreviewTranslationWorkspace },
                 { nameof(HandlesPreviewTranslationFailures), HandlesPreviewTranslationFailures },
-                { nameof(CancelsPreviewTranslationWork), CancelsPreviewTranslationWork }
+                { nameof(CancelsPreviewTranslationWork), CancelsPreviewTranslationWork },
+                { nameof(FiltersLargePreviewTranslationProject), FiltersLargePreviewTranslationProject }
             };
             int failures = 0;
             foreach (KeyValuePair<string, Action> test in tests)
@@ -467,6 +468,42 @@ namespace PhoenixTranslator.PresetTests
                 "Cancellation must not replace an entry with a partial provider result.");
             AssertEqual("Ready", shell.StatusText,
                 "Cooperative cancellation must restore persistent shell status.");
+            viewModel.Dispose();
+        }
+
+        private static void FiltersLargePreviewTranslationProject()
+        {
+            var entries = Enumerable.Range(0, 25000)
+                .Select(index => new PreviewTranslationEntry(
+                    index.ToString(CultureInfo.InvariantCulture),
+                    index % 2 == 0 ? "MCM" : "XML",
+                    "RECORD_" + index.ToString(CultureInfo.InvariantCulture),
+                    "Synthetic source " + index.ToString(CultureInfo.InvariantCulture),
+                    index % 3 == 0 ? "Synthetic target" : string.Empty,
+                    100))
+                .ToList();
+            var shell = new PreviewShellViewModel(() => { });
+            var project = new FakePreviewTranslationProject(entries);
+            var viewModel = new PreviewTranslationWorkspaceViewModel(
+                () => "fixture",
+                () => { },
+                shell,
+                path => project);
+
+            viewModel.OpenProjectAsync("fixture").GetAwaiter().GetResult();
+            AssertEqual(25000, viewModel.Entries.Count,
+                "A large project must load as one complete virtualized list snapshot.");
+
+            viewModel.SearchText = "source 24999";
+            AssertEqual(1, viewModel.Entries.Count,
+                "Search must isolate one record in a large synthetic project.");
+            AssertEqual("24999", viewModel.Entries[0].Key,
+                "Large-project filtering must retain stable record identity.");
+
+            viewModel.SearchText = string.Empty;
+            viewModel.SelectedTypeFilter = "MCM";
+            AssertEqual(12500, viewModel.Entries.Count,
+                "Large-project type filtering must retain every matching record.");
             viewModel.Dispose();
         }
 

--- a/Phoenix_Translator/Application/IPreviewTranslationProject.cs
+++ b/Phoenix_Translator/Application/IPreviewTranslationProject.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Defines the parser, provider, and persistence boundary consumed by the preview workspace.
+    /// </summary>
+    internal interface IPreviewTranslationProject : IDisposable
+    {
+        /// <summary>
+        /// Gets the private absolute path used only at parser and persistence boundaries.
+        /// </summary>
+        string Path { get; }
+
+        /// <summary>
+        /// Gets the safe project display name.
+        /// </summary>
+        string DisplayName { get; }
+
+        /// <summary>
+        /// Gets the normalized editable project records.
+        /// </summary>
+        IReadOnlyList<PreviewTranslationEntry> Entries { get; }
+
+        /// <summary>
+        /// Translates one entry through the configured provider pipeline.
+        /// </summary>
+        /// <param name="entry">The entry to translate.</param>
+        /// <param name="cancellationToken">Cancels provider work cooperatively.</param>
+        /// <returns>The provider-produced target text.</returns>
+        string Translate(PreviewTranslationEntry entry, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Persists staged targets through the format-specific writer and backup boundary.
+        /// </summary>
+        void Save();
+    }
+}

--- a/Phoenix_Translator/Application/PreviewShellViewModel.cs
+++ b/Phoenix_Translator/Application/PreviewShellViewModel.cs
@@ -129,6 +129,8 @@ namespace PhoenixTranslator.ApplicationLayer
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(CurrentTitle));
                 OnPropertyChanged(nameof(CurrentDescription));
+                OnPropertyChanged(nameof(IsTranslationWorkspaceVisible));
+                OnPropertyChanged(nameof(IsPreviewFallbackVisible));
             }
         }
 
@@ -141,6 +143,16 @@ namespace PhoenixTranslator.ApplicationLayer
         /// Gets the localized rollout description for the selected destination.
         /// </summary>
         public string CurrentDescription => PreviewMessageCatalog.Get(GetDestinationMessageId("Description"));
+
+        /// <summary>
+        /// Gets whether the preview translation workspace owns the current page.
+        /// </summary>
+        public bool IsTranslationWorkspaceVisible => _currentDestination == PreviewShellDestination.Translate;
+
+        /// <summary>
+        /// Gets whether the selected destination still uses the shared preview fallback page.
+        /// </summary>
+        public bool IsPreviewFallbackVisible => !IsTranslationWorkspaceVisible;
 
         /// <summary>
         /// Gets the product version shown independently from dependency versions.
@@ -279,6 +291,28 @@ namespace PhoenixTranslator.ApplicationLayer
             _operationText = arguments == null || arguments.Length == 0
                 ? PreviewMessageCatalog.Get(messageId)
                 : PreviewMessageCatalog.Format(messageId, arguments);
+            _operationProgress = progress;
+            _isOperationRunning = true;
+            OnPropertyChanged(nameof(IsOperationRunning));
+            OnPropertyChanged(nameof(OperationText));
+            OnPropertyChanged(nameof(OperationProgress));
+            OnPropertyChanged(nameof(StatusText));
+        }
+
+        /// <summary>
+        /// Starts or updates a long-running operation with already localized user-safe text.
+        /// </summary>
+        /// <param name="message">The localized user-safe operation message.</param>
+        /// <param name="progress">Progress from zero through one hundred.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="progress"/> is outside zero through one hundred.</exception>
+        internal void SetOperationText(string message, double progress)
+        {
+            if (progress < 0 || progress > 100)
+            {
+                throw new ArgumentOutOfRangeException(nameof(progress));
+            }
+
+            _operationText = message ?? string.Empty;
             _operationProgress = progress;
             _isOperationRunning = true;
             OnPropertyChanged(nameof(IsOperationRunning));

--- a/Phoenix_Translator/Application/PreviewTranslationEntry.cs
+++ b/Phoenix_Translator/Application/PreviewTranslationEntry.cs
@@ -1,0 +1,124 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Represents one editable translation record independently from WPF controls and parser implementations.
+    /// </summary>
+    internal sealed class PreviewTranslationEntry : INotifyPropertyChanged
+    {
+        private string _targetText;
+        private string _savedTargetText;
+
+        /// <summary>
+        /// Creates an entry from a normalized project record.
+        /// </summary>
+        /// <param name="key">The stable project-local record key.</param>
+        /// <param name="type">The source format or record type.</param>
+        /// <param name="record">The user-safe technical record identity.</param>
+        /// <param name="sourceText">The source text.</param>
+        /// <param name="targetText">The current target text.</param>
+        /// <param name="score">The parser or heuristic confidence score.</param>
+        internal PreviewTranslationEntry(
+            string key,
+            string type,
+            string record,
+            string sourceText,
+            string targetText,
+            double score)
+        {
+            Key = key ?? throw new ArgumentNullException(nameof(key));
+            Type = type ?? string.Empty;
+            Record = record ?? string.Empty;
+            SourceText = sourceText ?? string.Empty;
+            _targetText = targetText ?? string.Empty;
+            _savedTargetText = _targetText;
+            Score = score;
+        }
+
+        /// <inheritdoc />
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Gets the stable project-local record key.
+        /// </summary>
+        public string Key { get; private set; }
+
+        /// <summary>
+        /// Gets the source format or record type.
+        /// </summary>
+        public string Type { get; private set; }
+
+        /// <summary>
+        /// Gets the user-safe technical record identity.
+        /// </summary>
+        public string Record { get; private set; }
+
+        /// <summary>
+        /// Gets the immutable source text.
+        /// </summary>
+        public string SourceText { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the staged target text.
+        /// </summary>
+        public string TargetText
+        {
+            get => _targetText;
+            set
+            {
+                string normalizedValue = value ?? string.Empty;
+                if (string.Equals(_targetText, normalizedValue, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                _targetText = normalizedValue;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(IsDraft));
+                OnPropertyChanged(nameof(IsModified));
+                OnPropertyChanged(nameof(StateText));
+            }
+        }
+
+        /// <summary>
+        /// Gets the parser or heuristic confidence score.
+        /// </summary>
+        public double Score { get; private set; }
+
+        /// <summary>
+        /// Gets whether the entry has no target text.
+        /// </summary>
+        public bool IsDraft => string.IsNullOrWhiteSpace(_targetText);
+
+        /// <summary>
+        /// Gets whether the staged target differs from the last persisted value.
+        /// </summary>
+        public bool IsModified => !string.Equals(_targetText, _savedTargetText, StringComparison.Ordinal);
+
+        /// <summary>
+        /// Gets the localized entry state label.
+        /// </summary>
+        public string StateText => PreviewMessageCatalog.Get(
+            IsModified
+                ? "Workspace_State_Modified"
+                : IsDraft ? "Workspace_State_Draft" : "Workspace_State_Translated");
+
+        /// <summary>
+        /// Marks the current target text as persisted.
+        /// </summary>
+        internal void MarkSaved()
+        {
+            _savedTargetText = _targetText;
+            OnPropertyChanged(nameof(IsModified));
+            OnPropertyChanged(nameof(StateText));
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/Phoenix_Translator/Application/PreviewTranslationProject.cs
+++ b/Phoenix_Translator/Application/PreviewTranslationProject.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using PhoenixEngine;
+using PhoenixEngine.Memory;
+using PhoenixEngine.Translate;
+using PhoenixEngine.Unit;
+using PhoenixTranslator.SkyrimManagement;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Owns a loaded parser project and exposes normalized records to the preview workspace.
+    /// </summary>
+    internal sealed class PreviewTranslationProject : IPreviewTranslationProject
+    {
+        private const long MaximumProjectBytes = 512L * 1024L * 1024L;
+        private const int MaximumEntryCount = 500000;
+        private readonly ModFile _modFile;
+        private bool _disposed;
+
+        private PreviewTranslationProject(string path, ModFile modFile, IReadOnlyList<PreviewTranslationEntry> entries)
+        {
+            Path = path;
+            DisplayName = System.IO.Path.GetFileName(path);
+            _modFile = modFile;
+            Entries = entries;
+        }
+
+        /// <summary>
+        /// Gets the private absolute path used only at the file boundary.
+        /// </summary>
+        public string Path { get; private set; }
+
+        /// <summary>
+        /// Gets the safe project display name.
+        /// </summary>
+        public string DisplayName { get; private set; }
+
+        /// <summary>
+        /// Gets the normalized project records.
+        /// </summary>
+        public IReadOnlyList<PreviewTranslationEntry> Entries { get; private set; }
+
+        /// <summary>
+        /// Opens and normalizes a supported translation project.
+        /// </summary>
+        /// <param name="path">The selected project path.</param>
+        /// <returns>The loaded project.</returns>
+        /// <exception cref="InvalidDataException">The path, size, format, or record count is unsupported.</exception>
+        internal static PreviewTranslationProject Open(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            {
+                throw new InvalidDataException("The selected project is unavailable.");
+            }
+
+            var fileInfo = new FileInfo(path);
+            if (fileInfo.Length > MaximumProjectBytes)
+            {
+                throw new InvalidDataException("The selected project exceeds the supported size limit.");
+            }
+
+            ModFile modFile = null;
+            try
+            {
+                modFile = new ModFile(path);
+                if (modFile.Type == GameFileType.Null)
+                {
+                    throw new InvalidDataException("The selected project format is unsupported.");
+                }
+
+                if (modFile.XmlReader != null)
+                {
+                    modFile.XmlReader.ThrowOnInvalidFormat = true;
+                }
+
+                modFile.Load();
+                List<PreviewTranslationEntry> entries = CreateEntries(modFile);
+                if (entries.Count > MaximumEntryCount)
+                {
+                    throw new InvalidDataException("The selected project contains too many translation records.");
+                }
+
+                return new PreviewTranslationProject(path, modFile, entries);
+            }
+            catch
+            {
+                modFile?.Close();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Translates one entry through the configured provider pipeline.
+        /// </summary>
+        /// <param name="entry">The entry to translate.</param>
+        /// <param name="cancellationToken">Cancels provider work cooperatively.</param>
+        /// <returns>The provider-produced target text.</returns>
+        public string Translate(PreviewTranslationEntry entry, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+            if (entry == null)
+            {
+                throw new ArgumentNullException(nameof(entry));
+            }
+
+            if (!Phoenix.CheckAvailableNodes())
+            {
+                throw new InvalidOperationException("No translation provider is enabled.");
+            }
+
+            _modFile.MakeReady();
+            string emotion = string.Empty;
+            if (_modFile.Type == GameFileType.ESP && _modFile.EspReader.Records.ContainsKey(entry.Key))
+            {
+                emotion = _modFile.EspReader.QueryEmotion(_modFile.EspReader.Records[entry.Key]);
+            }
+
+            var unit = new BaseUnit(
+                _modFile.P_Translator.GetFileUniqueKey(),
+                entry.Key,
+                entry.Type,
+                entry.SourceText,
+                entry.TargetText,
+                emotion,
+                entry.Score);
+            unit.Translated = string.Empty;
+            cancellationToken.ThrowIfCancellationRequested();
+            string result = _modFile.P_Translator.Translate(unit, cancellationToken, false).GetFrist().Translated;
+            cancellationToken.ThrowIfCancellationRequested();
+            return result ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Persists all staged entry targets using the existing format writer and backup boundary.
+        /// </summary>
+        public void Save()
+        {
+            ThrowIfDisposed();
+            foreach (PreviewTranslationEntry entry in Entries)
+            {
+                _modFile.Lex_Dictionary.UPDateTransText(entry.Key, entry.SourceText);
+                if (entry.IsModified)
+                {
+                    _modFile.P_Translator.AutoSetLink(
+                        entry.Key,
+                        entry.SourceText,
+                        new P_String(entry.TargetText, 1));
+                }
+            }
+
+            _modFile.Save();
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _modFile.Close();
+        }
+
+        private static List<PreviewTranslationEntry> CreateEntries(ModFile modFile)
+        {
+            switch (modFile.Type)
+            {
+                case GameFileType.MCM:
+                    return modFile.MCMReader.MCMItems.Select(item => CreateEntry(
+                        modFile, item.Key, item.Type, item.EditorID, item.SourceText, item.TransText, 100)).ToList();
+                case GameFileType.XML:
+                    return modFile.XmlReader.XmlItems.Select(item => CreateEntry(
+                        modFile, item.Key, item.Type, item.EditorID, item.SourceText, item.TransText, 100)).ToList();
+                case GameFileType.JSON:
+                    return modFile.RamCacheReader.RamLines.Select(item => CreateEntry(
+                        modFile, item.Key, item.Type, item.Key, item.SourceText, item.TransText, item.Score)).ToList();
+                case GameFileType.PEX:
+                    return modFile.PexReader.Records.Values.Select(item => CreateEntry(
+                        modFile,
+                        item.UniqueKey,
+                        "PEX",
+                        item.StringTableID.ToString(),
+                        item.Original,
+                        string.Empty,
+                        item.Score)).ToList();
+                case GameFileType.ESP:
+                    return modFile.EspReader.Records.Values.Select(item => CreateEntry(
+                        modFile,
+                        item.UniqueKey,
+                        item.ParentSig,
+                        item.FormID,
+                        item.String,
+                        string.Empty,
+                        100)).ToList();
+                default:
+                    throw new InvalidDataException("The selected project format is unsupported.");
+            }
+        }
+
+        private static PreviewTranslationEntry CreateEntry(
+            ModFile modFile,
+            string key,
+            string type,
+            string record,
+            string sourceText,
+            string fallbackTarget,
+            double score)
+        {
+            P_String linkedValue = modFile.P_Translator.GetLink()[key];
+            string targetText = linkedValue == null ? fallbackTarget : linkedValue.String;
+            return new PreviewTranslationEntry(key, type, record, sourceText, targetText, score);
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(PreviewTranslationProject));
+            }
+        }
+    }
+}

--- a/Phoenix_Translator/Application/PreviewTranslationWorkspaceViewModel.cs
+++ b/Phoenix_Translator/Application/PreviewTranslationWorkspaceViewModel.cs
@@ -1,0 +1,750 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Identifies an entry-state filter in the preview translation workspace.
+    /// </summary>
+    internal enum PreviewTranslationStateFilter
+    {
+        All,
+        Draft,
+        Translated,
+        Modified
+    }
+
+    /// <summary>
+    /// Describes one localized entry-state filter option.
+    /// </summary>
+    internal sealed class PreviewTranslationStateFilterOption
+    {
+        /// <summary>
+        /// Creates a localized state-filter option.
+        /// </summary>
+        /// <param name="value">The filter behavior.</param>
+        /// <param name="label">The localized visible label.</param>
+        internal PreviewTranslationStateFilterOption(PreviewTranslationStateFilter value, string label)
+        {
+            Value = value;
+            Label = label;
+        }
+
+        /// <summary>
+        /// Gets the filter behavior.
+        /// </summary>
+        public PreviewTranslationStateFilter Value { get; private set; }
+
+        /// <summary>
+        /// Gets the localized visible label.
+        /// </summary>
+        public string Label { get; private set; }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return Label;
+        }
+    }
+
+    /// <summary>
+    /// Owns preview translation workspace state, filtering, editing, persistence, and cancellable provider work.
+    /// </summary>
+    internal sealed class PreviewTranslationWorkspaceViewModel : INotifyPropertyChanged, IDisposable
+    {
+        private readonly Func<string> _chooseProjectPath;
+        private readonly Action _openLegacyWorkspace;
+        private readonly PreviewShellViewModel _shell;
+        private readonly Func<string, IPreviewTranslationProject> _openProject;
+        private readonly List<PreviewTranslationEntry> _allEntries = new List<PreviewTranslationEntry>();
+        private readonly HashSet<PreviewTranslationEntry> _draftEntries = new HashSet<PreviewTranslationEntry>();
+        private readonly HashSet<PreviewTranslationEntry> _modifiedEntries = new HashSet<PreviewTranslationEntry>();
+        private readonly HashSet<PreviewTranslationEntry> _visibleEntries = new HashSet<PreviewTranslationEntry>();
+        private int _visibleDraftCount;
+        private IPreviewTranslationProject _project;
+        private PreviewTranslationEntry _selectedEntry;
+        private PreviewTranslationStateFilterOption _selectedStateFilter;
+        private string _selectedTypeFilter;
+        private string _searchText;
+        private bool _isBusy;
+        private string _operationText;
+        private double _operationProgress;
+        private CancellationTokenSource _operationCancellation;
+
+        /// <summary>
+        /// Creates a workspace connected to the persistent preview shell state.
+        /// </summary>
+        /// <param name="chooseProjectPath">Selects a supported project path or returns an empty value.</param>
+        /// <param name="openLegacyWorkspace">Opens the workflow-specific legacy fallback.</param>
+        /// <param name="shell">The persistent shell status owner.</param>
+        /// <param name="openProject">Opens the selected path through the parser boundary.</param>
+        internal PreviewTranslationWorkspaceViewModel(
+            Func<string> chooseProjectPath,
+            Action openLegacyWorkspace,
+            PreviewShellViewModel shell,
+            Func<string, IPreviewTranslationProject> openProject)
+        {
+            _chooseProjectPath = chooseProjectPath ?? throw new ArgumentNullException(nameof(chooseProjectPath));
+            _openLegacyWorkspace = openLegacyWorkspace ?? throw new ArgumentNullException(nameof(openLegacyWorkspace));
+            _shell = shell ?? throw new ArgumentNullException(nameof(shell));
+            _openProject = openProject ?? throw new ArgumentNullException(nameof(openProject));
+            _searchText = string.Empty;
+            _operationText = PreviewMessageCatalog.Get("Common_State_Ready");
+
+            StateFilters = new[]
+            {
+                CreateStateFilter(PreviewTranslationStateFilter.All, "Workspace_Filter_AllStates"),
+                CreateStateFilter(PreviewTranslationStateFilter.Draft, "Workspace_State_Draft"),
+                CreateStateFilter(PreviewTranslationStateFilter.Translated, "Workspace_State_Translated"),
+                CreateStateFilter(PreviewTranslationStateFilter.Modified, "Workspace_State_Modified")
+            };
+            _selectedStateFilter = StateFilters[0];
+            TypeFilters = new ObservableCollection<string>
+            {
+                PreviewMessageCatalog.Get("Workspace_Filter_AllTypes")
+            };
+            _selectedTypeFilter = TypeFilters[0];
+            Entries = new List<PreviewTranslationEntry>();
+
+            OpenProjectCommand = new PreviewShellCommand(parameter => OpenSelectedProject());
+            SaveCommand = new PreviewShellCommand(
+                parameter => SaveProject(),
+                parameter => HasProject && IsModified && !IsBusy);
+            TranslateEntryCommand = new PreviewShellCommand(
+                parameter => TranslateSelectedEntry(),
+                parameter => SelectedEntry != null && !IsBusy);
+            TranslateScopeCommand = new PreviewShellCommand(
+                parameter => TranslateScope(),
+                parameter => Entries.Count > 0 && !IsBusy);
+            CancelOperationCommand = new PreviewShellCommand(
+                parameter => CancelOperation(),
+                parameter => CanCancelOperation);
+            PreviousEntryCommand = new PreviewShellCommand(
+                parameter => SelectPreviousEntry(),
+                parameter => SelectedEntry != null && Entries.Count > 1 && !IsBusy);
+            ApplyEntryCommand = new PreviewShellCommand(
+                parameter => ApplyEntry(),
+                parameter => SelectedEntry != null && !IsBusy);
+            OpenLegacyWorkspaceCommand = new PreviewShellCommand(parameter => _openLegacyWorkspace());
+        }
+
+        /// <inheritdoc />
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Gets the filtered entries presented by the virtualized list.
+        /// </summary>
+        public IReadOnlyList<PreviewTranslationEntry> Entries { get; private set; }
+
+        /// <summary>
+        /// Gets the localized stable entry-state filters.
+        /// </summary>
+        public IReadOnlyList<PreviewTranslationStateFilterOption> StateFilters { get; private set; }
+
+        /// <summary>
+        /// Gets the record types available in the current project.
+        /// </summary>
+        public ObservableCollection<string> TypeFilters { get; private set; }
+
+        /// <summary>
+        /// Gets the command that selects and opens a supported project.
+        /// </summary>
+        public ICommand OpenProjectCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that persists all staged targets.
+        /// </summary>
+        public ICommand SaveCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that translates the selected entry.
+        /// </summary>
+        public ICommand TranslateEntryCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that translates the current filtered scope.
+        /// </summary>
+        public ICommand TranslateScopeCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that requests cooperative operation cancellation.
+        /// </summary>
+        public ICommand CancelOperationCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that moves selection to the previous visible entry.
+        /// </summary>
+        public ICommand PreviousEntryCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that stages the current edit and advances selection.
+        /// </summary>
+        public ICommand ApplyEntryCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command that opens the complete legacy translation workflow.
+        /// </summary>
+        public ICommand OpenLegacyWorkspaceCommand { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the entry presented by the editor and context inspector.
+        /// </summary>
+        public PreviewTranslationEntry SelectedEntry
+        {
+            get => _selectedEntry;
+            set
+            {
+                if (ReferenceEquals(_selectedEntry, value))
+                {
+                    return;
+                }
+
+                _selectedEntry = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(HasSelection));
+                RaiseCommandAvailability();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the active entry-state filter.
+        /// </summary>
+        public PreviewTranslationStateFilterOption SelectedStateFilter
+        {
+            get => _selectedStateFilter;
+            set
+            {
+                if (value == null || ReferenceEquals(_selectedStateFilter, value))
+                {
+                    return;
+                }
+
+                _selectedStateFilter = value;
+                OnPropertyChanged();
+                RefreshFilter();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the active record-type filter.
+        /// </summary>
+        public string SelectedTypeFilter
+        {
+            get => _selectedTypeFilter;
+            set
+            {
+                if (string.Equals(_selectedTypeFilter, value, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                _selectedTypeFilter = value;
+                OnPropertyChanged();
+                RefreshFilter();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the case-insensitive entry search query.
+        /// </summary>
+        public string SearchText
+        {
+            get => _searchText;
+            set
+            {
+                string normalizedValue = value ?? string.Empty;
+                if (string.Equals(_searchText, normalizedValue, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                _searchText = normalizedValue;
+                OnPropertyChanged();
+                RefreshFilter();
+            }
+        }
+
+        /// <summary>
+        /// Gets whether a parser project is loaded.
+        /// </summary>
+        public bool HasProject => _project != null;
+
+        /// <summary>
+        /// Gets whether a visible entry is selected.
+        /// </summary>
+        public bool HasSelection => _selectedEntry != null;
+
+        /// <summary>
+        /// Gets whether the active provider operation supports cooperative cancellation.
+        /// </summary>
+        public bool CanCancelOperation => _operationCancellation != null;
+
+        /// <summary>
+        /// Gets whether project, provider, or persistence work is active.
+        /// </summary>
+        public bool IsBusy
+        {
+            get => _isBusy;
+            private set
+            {
+                if (_isBusy == value)
+                {
+                    return;
+                }
+
+                _isBusy = value;
+                OnPropertyChanged();
+                RaiseCommandAvailability();
+            }
+        }
+
+        /// <summary>
+        /// Gets the localized active or idle operation text.
+        /// </summary>
+        public string OperationText
+        {
+            get => _operationText;
+            private set
+            {
+                _operationText = value ?? string.Empty;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// Gets bounded operation progress from zero through one hundred.
+        /// </summary>
+        public double OperationProgress
+        {
+            get => _operationProgress;
+            private set
+            {
+                _operationProgress = value;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// Gets the localized count of currently visible entries.
+        /// </summary>
+        public string EntryCountText => PreviewMessageCatalog.Format("Workspace_Entry_Count", Entries.Count);
+
+        /// <summary>
+        /// Gets the localized count of currently visible draft entries.
+        /// </summary>
+        public string DraftCountText => PreviewMessageCatalog.Format(
+            "Workspace_Entry_DraftCount",
+            _visibleDraftCount);
+
+        /// <summary>
+        /// Gets whether any project entry differs from its persisted target.
+        /// </summary>
+        public bool IsModified => _modifiedEntries.Count > 0;
+
+        /// <summary>
+        /// Opens and normalizes a selected project without blocking the UI thread.
+        /// </summary>
+        /// <param name="path">The selected private project path.</param>
+        internal async Task OpenProjectAsync(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path) || IsBusy)
+            {
+                return;
+            }
+
+            BeginOperation(PreviewMessageCatalog.Get("Workspace_Project_Opening"), 0);
+            try
+            {
+                IPreviewTranslationProject openedProject = await Task.Run(() => _openProject(path));
+                IPreviewTranslationProject previousProject = _project;
+                _project = openedProject;
+                previousProject?.Dispose();
+                ReplaceEntries(openedProject.Entries);
+                _shell.SetProject(openedProject.DisplayName, false);
+                CompleteOperation();
+            }
+            catch
+            {
+                FailOperation("Workspace_Project_OpenFailed");
+            }
+        }
+
+        /// <summary>
+        /// Persists staged targets and reloads the project through its parser boundary.
+        /// </summary>
+        internal async Task SaveProjectAsync()
+        {
+            if (_project == null || IsBusy)
+            {
+                return;
+            }
+
+            BeginOperation(PreviewMessageCatalog.Get("Workspace_Project_Saving"), 0);
+            try
+            {
+                string projectPath = _project.Path;
+                await Task.Run(() => _project.Save());
+                IPreviewTranslationProject reloadedProject = await Task.Run(() => _openProject(projectPath));
+                IPreviewTranslationProject savedProject = _project;
+                _project = reloadedProject;
+                savedProject.Dispose();
+                ReplaceEntries(reloadedProject.Entries);
+
+                _shell.SetProject(_project.DisplayName, false);
+                _shell.ShowNotification(
+                    PreviewShellNotificationSeverity.Success,
+                    "Workspace_Save_Succeeded");
+                CompleteOperation();
+            }
+            catch
+            {
+                FailOperation("Workspace_Save_Failed");
+            }
+        }
+
+        /// <summary>
+        /// Translates a stable entry snapshot sequentially with cooperative cancellation and bounded progress.
+        /// </summary>
+        /// <param name="entries">The selected or filtered entry snapshot.</param>
+        internal async Task TranslateEntriesAsync(IReadOnlyList<PreviewTranslationEntry> entries)
+        {
+            if (_project == null || entries == null || entries.Count == 0 || IsBusy)
+            {
+                return;
+            }
+
+            _operationCancellation = new CancellationTokenSource();
+            OnPropertyChanged(nameof(CanCancelOperation));
+            CancellationToken cancellationToken = _operationCancellation.Token;
+            int failures = 0;
+            BeginOperation(PreviewMessageCatalog.Format(
+                "Workspace_Operation_TranslatingProgress", 0, entries.Count), 0);
+
+            try
+            {
+                for (int index = 0; index < entries.Count; index++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    PreviewTranslationEntry entry = entries[index];
+                    try
+                    {
+                        string translatedText = await Task.Run(
+                            () => _project.Translate(entry, cancellationToken),
+                            cancellationToken);
+                        entry.TargetText = translatedText;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        throw;
+                    }
+                    catch
+                    {
+                        failures++;
+                    }
+
+                    int completed = index + 1;
+                    double progress = completed * 100d / entries.Count;
+                    UpdateOperation(
+                        PreviewMessageCatalog.Format(
+                            "Workspace_Operation_TranslatingProgress", completed, entries.Count),
+                        progress);
+                }
+
+                if (failures > 0)
+                {
+                    _shell.ShowNotification(
+                        PreviewShellNotificationSeverity.Warning,
+                        "Workspace_Operation_CompletedWithFailures",
+                        failures);
+                }
+
+                CompleteOperation();
+            }
+            catch (OperationCanceledException)
+            {
+                CompleteOperation();
+            }
+            finally
+            {
+                _operationCancellation?.Dispose();
+                _operationCancellation = null;
+                OnPropertyChanged(nameof(CanCancelOperation));
+                RaiseCommandAvailability();
+                OnEntryStateChanged();
+            }
+        }
+
+        /// <summary>
+        /// Rebuilds the visible entry collection from the current search, state, and type filters.
+        /// </summary>
+        internal void RefreshFilter()
+        {
+            PreviewTranslationEntry previousSelection = SelectedEntry;
+            var filteredEntries = new List<PreviewTranslationEntry>();
+            foreach (PreviewTranslationEntry entry in _allEntries)
+            {
+                if (MatchesFilter(entry))
+                {
+                    filteredEntries.Add(entry);
+                }
+            }
+
+            Entries = filteredEntries;
+            _visibleEntries.Clear();
+            foreach (PreviewTranslationEntry entry in filteredEntries)
+            {
+                _visibleEntries.Add(entry);
+            }
+            _visibleDraftCount = filteredEntries.Count(entry => _draftEntries.Contains(entry));
+            OnPropertyChanged(nameof(Entries));
+            SelectedEntry = Entries.Contains(previousSelection)
+                ? previousSelection
+                : Entries.FirstOrDefault();
+            OnPropertyChanged(nameof(EntryCountText));
+            OnPropertyChanged(nameof(DraftCountText));
+            RaiseCommandAvailability();
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _operationCancellation?.Cancel();
+            _operationCancellation?.Dispose();
+            _project?.Dispose();
+            _project = null;
+        }
+
+        private static PreviewTranslationStateFilterOption CreateStateFilter(
+            PreviewTranslationStateFilter value,
+            string messageId)
+        {
+            return new PreviewTranslationStateFilterOption(value, PreviewMessageCatalog.Get(messageId));
+        }
+
+        private async void OpenSelectedProject()
+        {
+            await OpenProjectAsync(_chooseProjectPath());
+        }
+
+        private async void SaveProject()
+        {
+            await SaveProjectAsync();
+        }
+
+        private async void TranslateSelectedEntry()
+        {
+            if (SelectedEntry != null)
+            {
+                await TranslateEntriesAsync(new[] { SelectedEntry });
+            }
+        }
+
+        private async void TranslateScope()
+        {
+            await TranslateEntriesAsync(Entries.ToList());
+        }
+
+        private void CancelOperation()
+        {
+            if (_operationCancellation == null)
+            {
+                return;
+            }
+
+            OperationText = PreviewMessageCatalog.Get("Workspace_Operation_Cancelling");
+            _shell.SetOperation("Workspace_Operation_Cancelling", OperationProgress);
+            _operationCancellation.Cancel();
+        }
+
+        private void SelectPreviousEntry()
+        {
+            int index = Entries.ToList().IndexOf(SelectedEntry);
+            if (index > 0)
+            {
+                SelectedEntry = Entries[index - 1];
+            }
+        }
+
+        private void ApplyEntry()
+        {
+            OnEntryStateChanged();
+            int index = Entries.ToList().IndexOf(SelectedEntry);
+            if (index >= 0 && index < Entries.Count - 1)
+            {
+                SelectedEntry = Entries[index + 1];
+            }
+        }
+
+        private void ReplaceEntries(IEnumerable<PreviewTranslationEntry> entries)
+        {
+            foreach (PreviewTranslationEntry entry in _allEntries)
+            {
+                entry.PropertyChanged -= EntryPropertyChanged;
+            }
+
+            _allEntries.Clear();
+            _allEntries.AddRange(entries);
+            _draftEntries.Clear();
+            _modifiedEntries.Clear();
+            _visibleEntries.Clear();
+            _visibleDraftCount = 0;
+            foreach (PreviewTranslationEntry entry in _allEntries)
+            {
+                entry.PropertyChanged += EntryPropertyChanged;
+                UpdateTrackedState(entry);
+            }
+
+            TypeFilters.Clear();
+            TypeFilters.Add(PreviewMessageCatalog.Get("Workspace_Filter_AllTypes"));
+            foreach (string type in _allEntries.Select(entry => entry.Type)
+                .Where(type => !string.IsNullOrWhiteSpace(type))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(type => type, StringComparer.OrdinalIgnoreCase))
+            {
+                TypeFilters.Add(type);
+            }
+
+            SelectedTypeFilter = TypeFilters[0];
+            RefreshFilter();
+            OnPropertyChanged(nameof(HasProject));
+            RaiseCommandAvailability();
+        }
+
+        private bool MatchesFilter(PreviewTranslationEntry entry)
+        {
+            if (_selectedStateFilter.Value == PreviewTranslationStateFilter.Draft && !entry.IsDraft ||
+                _selectedStateFilter.Value == PreviewTranslationStateFilter.Translated && entry.IsDraft ||
+                _selectedStateFilter.Value == PreviewTranslationStateFilter.Modified && !entry.IsModified)
+            {
+                return false;
+            }
+
+            if (!string.Equals(_selectedTypeFilter, TypeFilters[0], StringComparison.Ordinal) &&
+                !string.Equals(entry.Type, _selectedTypeFilter, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(_searchText))
+            {
+                return true;
+            }
+
+            return Contains(entry.SourceText, _searchText) ||
+                Contains(entry.TargetText, _searchText) ||
+                Contains(entry.Record, _searchText) ||
+                Contains(entry.Type, _searchText);
+        }
+
+        private static bool Contains(string value, string searchText)
+        {
+            return value != null && value.IndexOf(searchText, StringComparison.CurrentCultureIgnoreCase) >= 0;
+        }
+
+        private void EntryPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(PreviewTranslationEntry.TargetText))
+            {
+                UpdateTrackedState((PreviewTranslationEntry)sender);
+                OnEntryStateChanged();
+            }
+        }
+
+        private void UpdateTrackedState(PreviewTranslationEntry entry)
+        {
+            bool wasDraft = _draftEntries.Contains(entry);
+            if (entry.IsDraft)
+            {
+                _draftEntries.Add(entry);
+            }
+            else
+            {
+                _draftEntries.Remove(entry);
+            }
+
+            if (_visibleEntries.Contains(entry) && wasDraft != entry.IsDraft)
+            {
+                _visibleDraftCount += entry.IsDraft ? 1 : -1;
+            }
+
+            if (entry.IsModified)
+            {
+                _modifiedEntries.Add(entry);
+            }
+            else
+            {
+                _modifiedEntries.Remove(entry);
+            }
+        }
+
+        private void OnEntryStateChanged()
+        {
+            _shell.SetProject(_project?.DisplayName, IsModified);
+            OnPropertyChanged(nameof(DraftCountText));
+            OnPropertyChanged(nameof(IsModified));
+            RaiseCommandAvailability();
+            if (_selectedStateFilter.Value != PreviewTranslationStateFilter.All ||
+                !string.IsNullOrWhiteSpace(_searchText))
+            {
+                RefreshFilter();
+            }
+        }
+
+        private void BeginOperation(string message, double progress)
+        {
+            IsBusy = true;
+            OperationText = message;
+            OperationProgress = progress;
+            _shell.SetOperationText(message, progress);
+        }
+
+        private void UpdateOperation(string message, double progress)
+        {
+            OperationText = message;
+            OperationProgress = progress;
+            _shell.SetOperationText(message, progress);
+        }
+
+        private void CompleteOperation()
+        {
+            IsBusy = false;
+            OperationText = PreviewMessageCatalog.Get("Common_State_Ready");
+            OperationProgress = 0;
+            _shell.CompleteOperation();
+        }
+
+        private void FailOperation(string messageId)
+        {
+            _shell.ShowNotification(PreviewShellNotificationSeverity.Error, messageId);
+            CompleteOperation();
+        }
+
+        private void RaiseCommandAvailability()
+        {
+            RaiseCanExecuteChanged(SaveCommand);
+            RaiseCanExecuteChanged(TranslateEntryCommand);
+            RaiseCanExecuteChanged(TranslateScopeCommand);
+            RaiseCanExecuteChanged(CancelOperationCommand);
+            RaiseCanExecuteChanged(PreviousEntryCommand);
+            RaiseCanExecuteChanged(ApplyEntryCommand);
+        }
+
+        private static void RaiseCanExecuteChanged(ICommand command)
+        {
+            var previewCommand = command as PreviewShellCommand;
+            previewCommand?.RaiseCanExecuteChanged();
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/Phoenix_Translator/PhoenixTranslator.csproj
+++ b/Phoenix_Translator/PhoenixTranslator.csproj
@@ -107,9 +107,13 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Application\AdvancedDictionaryQueryBuilder.cs" />
+    <Compile Include="Application\IPreviewTranslationProject.cs" />
     <Compile Include="Application\PreviewMessageCatalog.cs" />
     <Compile Include="Application\PreviewShellCommand.cs" />
     <Compile Include="Application\PreviewShellViewModel.cs" />
+    <Compile Include="Application\PreviewTranslationEntry.cs" />
+    <Compile Include="Application\PreviewTranslationProject.cs" />
+    <Compile Include="Application\PreviewTranslationWorkspaceViewModel.cs" />
     <Compile Include="Application\LegacyTranslationPresetStore.cs" />
     <Compile Include="Application\TranslationPresetService.cs" />
     <Compile Include="FileManagement\ZipHelper.cs" />
@@ -198,6 +202,9 @@
     <Compile Include="UIManagement\Localization\PreviewMessageExtension.cs" />
     <Compile Include="UIManagement\Preview\PreviewShellWindow.xaml.cs">
       <DependentUpon>PreviewShellWindow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="UIManagement\Preview\PreviewTranslationWorkspaceView.xaml.cs">
+      <DependentUpon>PreviewTranslationWorkspaceView.xaml</DependentUpon>
     </Compile>
     <Compile Include="UIManagement\YDListView.cs" />
     <Compile Include="UIManagement\Setting\LexTranslatorRadarChart.xaml.cs">
@@ -311,6 +318,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="UIManagement\Preview\PreviewShellWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="UIManagement\Preview\PreviewTranslationWorkspaceView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Phoenix_Translator/Properties/AssemblyInfo.cs
+++ b/Phoenix_Translator/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Windows;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.0.0.7")]
-[assembly: AssemblyFileVersion("2.0.0.7")]
+[assembly: AssemblyVersion("2.0.0.8")]
+[assembly: AssemblyFileVersion("2.0.0.8")]

--- a/Phoenix_Translator/Properties/Resources.resx
+++ b/Phoenix_Translator/Properties/Resources.resx
@@ -173,6 +173,27 @@
   <data name="Shell_Page_AdvancedTools_Description" xml:space="preserve"><value>Access terminology data, provider pipelines, context inspectors, and diagnostics.</value><comment>Preview shell description for the Advanced tools destination.</comment></data>
   <data name="Workspace_Title" xml:space="preserve"><value>Translation workspace</value><comment>Accessible workflow title for the translation workspace.</comment></data>
   <data name="Workspace_Search_Placeholder" xml:space="preserve"><value>Search entries</value><comment>Placeholder in the workspace entry search field.</comment></data>
+  <data name="Workspace_Open_Title" xml:space="preserve"><value>Open translation project</value><comment>Title of the supported-project file picker.</comment></data>
+  <data name="Workspace_Project_Filter" xml:space="preserve"><value>Supported projects|*.esp;*.esm;*.esl;*.pex;*.txt;*.xml;*.json|All files|*.*</value><comment>File picker filter. Keep pipe separators and supported extensions unchanged.</comment></data>
+  <data name="Workspace_Open_Action" xml:space="preserve"><value>Open project</value><comment>Opens a supported project in the preview workspace.</comment></data>
+  <data name="Workspace_Save_Action" xml:space="preserve"><value>Save project</value><comment>Persists confirmed translation changes through the format writer.</comment></data>
+  <data name="Workspace_TranslateEntry_Action" xml:space="preserve"><value>Translate entry</value><comment>Translates the selected entry through the configured provider pipeline.</comment></data>
+  <data name="Workspace_Cancel_Action" xml:space="preserve"><value>Cancel</value><comment>Requests cooperative cancellation of the active workspace operation.</comment></data>
+  <data name="Workspace_Empty_Title" xml:space="preserve"><value>Open a project to start translating</value><comment>Preview workspace empty-state heading.</comment></data>
+  <data name="Workspace_Empty_Hint" xml:space="preserve"><value>ESP, ESM, ESL, PEX, MCM TXT, XML, and Phoenix RamCache JSON projects are supported.</value><comment>Preview workspace empty-state format summary.</comment></data>
+  <data name="Workspace_Filter_State_Name" xml:space="preserve"><value>Entry state filter</value><comment>Accessible name for the workspace state filter.</comment></data>
+  <data name="Workspace_Filter_Type_Name" xml:space="preserve"><value>Record type filter</value><comment>Accessible name for the workspace record-type filter.</comment></data>
+  <data name="Workspace_State_Draft" xml:space="preserve"><value>Draft</value><comment>Entry state for an empty target translation.</comment></data>
+  <data name="Workspace_State_Translated" xml:space="preserve"><value>Translated</value><comment>Entry state for a populated persisted target translation.</comment></data>
+  <data name="Workspace_State_Modified" xml:space="preserve"><value>Modified</value><comment>Entry state for a staged target that differs from the persisted value.</comment></data>
+  <data name="Workspace_Context_Type_Label" xml:space="preserve"><value>Type</value><comment>Metadata label for the selected parser or record type.</comment></data>
+  <data name="Workspace_Context_Key_Label" xml:space="preserve"><value>Technical key</value><comment>Metadata label for the project-local technical record key.</comment></data>
+  <data name="Workspace_Context_Score_Label" xml:space="preserve"><value>Confidence score</value><comment>Metadata label for the parser or heuristic confidence score.</comment></data>
+  <data name="Workspace_Project_Opening" xml:space="preserve"><value>Opening project…</value><comment>Status while a selected project is parsed and normalized.</comment></data>
+  <data name="Workspace_Project_Saving" xml:space="preserve"><value>Saving project…</value><comment>Status while staged translations are persisted.</comment></data>
+  <data name="Workspace_Project_OpenFailed" xml:space="preserve"><value>The project could not be opened. The selected format may be invalid or unsupported.</value><comment>User-safe project-open failure without paths or parser details.</comment></data>
+  <data name="Workspace_Save_Succeeded" xml:space="preserve"><value>The project was saved and reloaded successfully.</value><comment>Non-blocking confirmation after a successful preview save.</comment></data>
+  <data name="Workspace_Shortcuts_Hint" xml:space="preserve"><value>Ctrl+O Open · Ctrl+S Save · F6 Translate entry · Ctrl+Shift+T Translate scope · Esc Cancel</value><comment>Compact keyboard command map for the preview translation workspace.</comment></data>
   <data name="Workspace_Filter_AllStates" xml:space="preserve"><value>All states</value><comment>Default state-filter option in the workspace.</comment></data>
   <data name="Workspace_Filter_AllTypes" xml:space="preserve"><value>All types</value><comment>Default record-type filter option in the workspace.</comment></data>
   <data name="Workspace_TranslateScope_Action" xml:space="preserve"><value>Translate scope</value><comment>Starts translation for the currently selected or filtered scope.</comment></data>

--- a/Phoenix_Translator/SkyrimManagement/ModFile.cs
+++ b/Phoenix_Translator/SkyrimManagement/ModFile.cs
@@ -106,23 +106,29 @@ namespace PhoenixTranslator.SkyrimManagement
                     int ID = 0;
                     if (Previous == null)
                     {
-                        bool IsCloud = false;
-
-                        FakeGrid GetRow = this.ListView.KeyToFakeGrid(Key);
-                        GetRow.SyncData(this,ref IsCloud);
-
-                        ID = HistoryDBCache.AddHistory(
-                        new HistoryItem(this.P_Translator.GetFileUniqueKey(),Key, (int)this.P_Translator.To,
-                        GetRow.TransText,
-                        0,
-                        DateTime.Now,
-                        ""
-                        ));
-
-                        HistoryDBCache.CheckPreviousHistoryItem(ID, this.P_Translator.GetFileUniqueKey(), (int)this.P_Translator.To, Key, GetRow.TransText, out int TargetID);
-                        if (TargetID > 0)
+                        if (this.ListView != null)
                         {
-                            HistoryDBCache.DeleteHistory(this.P_Translator.GetFileUniqueKey(), TargetID);
+                            bool IsCloud = false;
+                            FakeGrid GetRow = this.ListView.KeyToFakeGrid(Key);
+                            if (GetRow != null)
+                            {
+                                GetRow.SyncData(this, ref IsCloud);
+
+                                ID = HistoryDBCache.AddHistory(
+                                new HistoryItem(this.P_Translator.GetFileUniqueKey(), Key, (int)this.P_Translator.To,
+                                GetRow.TransText,
+                                0,
+                                DateTime.Now,
+                                ""
+                                ));
+
+                                HistoryDBCache.CheckPreviousHistoryItem(ID, this.P_Translator.GetFileUniqueKey(),
+                                    (int)this.P_Translator.To, Key, GetRow.TransText, out int TargetID);
+                                if (TargetID > 0)
+                                {
+                                    HistoryDBCache.DeleteHistory(this.P_Translator.GetFileUniqueKey(), TargetID);
+                                }
+                            }
                         }
                     }
                     else
@@ -396,21 +402,27 @@ namespace PhoenixTranslator.SkyrimManagement
                     }
                 }
 
-                Lex_Dictionary.WriteDictionary(this.ListView);
+                if (this.ListView != null)
+                {
+                    Lex_Dictionary.WriteDictionary(this.ListView);
+                }
                 Lex_Dictionary.CreateDictionary();
 
-                this.Win.Dispatcher.Invoke(new Action(() =>
+                if (this.Win != null)
                 {
-                    this.Win._Parent?.RemoveTab(this.Path);
-                    MessageBoxExtend.Show(
-                    this.Win._Parent,
-                    "File saved successfully:\r\n" +
-                    this.Path +
-                    "\r\n\r\nRollback backup file created:\r\n" +
-                    BackupManagePath
-                    );
-                    this.Win._Parent?.LoadFile(this.Path);
-                }));
+                    this.Win.Dispatcher.Invoke(new Action(() =>
+                    {
+                        this.Win._Parent?.RemoveTab(this.Path);
+                        MessageBoxExtend.Show(
+                        this.Win._Parent,
+                        "File saved successfully:\r\n" +
+                        this.Path +
+                        "\r\n\r\nRollback backup file created:\r\n" +
+                        BackupManagePath
+                        );
+                        this.Win._Parent?.LoadFile(this.Path);
+                    }));
+                }
             }
         }
 

--- a/Phoenix_Translator/SkyrimManagement/XmlReader.cs
+++ b/Phoenix_Translator/SkyrimManagement/XmlReader.cs
@@ -83,6 +83,11 @@ namespace PhoenixTranslator.SkyrimManagement
 
     public class R_XmlReader
     {
+        /// <summary>
+        /// Gets or sets whether invalid XML is reported to the caller instead of the legacy modal boundary.
+        /// </summary>
+        public bool ThrowOnInvalidFormat { get; set; }
+
         public Translator TranslatorRef = null;
         public R_XmlReader(Translator TranslatorRef)
         {
@@ -123,8 +128,15 @@ namespace PhoenixTranslator.SkyrimManagement
                     }
                 }
             }
-            catch 
+            catch (System.Exception exception)
             {
+                if (ThrowOnInvalidFormat)
+                {
+                    throw new System.IO.InvalidDataException(
+                        "The XML translation format is unsupported.",
+                        exception);
+                }
+
                 MessageBoxExtend.Show(DeFine.WorkWin, "This XML file format is not supported.");
             }
         }

--- a/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:localization="clr-namespace:PhoenixTranslator.UIManagement.Localization"
+        xmlns:preview="clr-namespace:PhoenixTranslator.UIManagement.Preview"
         Title="{localization:PreviewMessage Shell_Product_Name}"
         Width="1280" Height="800" MinWidth="1100" MinHeight="700"
         WindowStartupLocation="CenterScreen" Background="#FF1A1A1A"
@@ -169,7 +170,8 @@
                 </Border>
                 <Border Grid.Row="2" Background="{StaticResource PreviewBrushSurfacePrimary}"
                         BorderBrush="{StaticResource PreviewBrushBorder}" BorderThickness="1"
-                        CornerRadius="{StaticResource PreviewRadiusLarge}">
+                        CornerRadius="{StaticResource PreviewRadiusLarge}"
+                        Visibility="{Binding IsPreviewFallbackVisible, Converter={StaticResource BooleanToVisibility}}">
                     <Grid Margin="32">
                         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" MaxWidth="560">
                             <TextBlock HorizontalAlignment="Center" FontSize="18" FontWeight="SemiBold"
@@ -187,6 +189,10 @@
                         </StackPanel>
                     </Grid>
                 </Border>
+                <preview:PreviewTranslationWorkspaceView x:Name="TranslationWorkspace" Grid.Row="2"
+                        Visibility="{Binding DataContext.IsTranslationWorkspaceVisible,
+                            RelativeSource={RelativeSource AncestorType={x:Type Window}},
+                            Converter={StaticResource BooleanToVisibility}}" />
             </Grid>
         </Grid>
 

--- a/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml.cs
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Windows;
+using Microsoft.Win32;
 using PhoenixTranslator.ApplicationLayer;
 
 namespace PhoenixTranslator.UIManagement.Preview
@@ -11,6 +12,7 @@ namespace PhoenixTranslator.UIManagement.Preview
     public partial class PreviewShellWindow : Window
     {
         private PhoenixGui _legacyWorkspace;
+        private readonly PreviewTranslationWorkspaceViewModel _translationWorkspaceViewModel;
 
         /// <summary>
         /// Creates the preview application shell in its no-project state.
@@ -18,7 +20,26 @@ namespace PhoenixTranslator.UIManagement.Preview
         public PreviewShellWindow()
         {
             InitializeComponent();
-            DataContext = new PreviewShellViewModel(OpenLegacyWorkspace);
+            var shellViewModel = new PreviewShellViewModel(OpenLegacyWorkspace);
+            _translationWorkspaceViewModel = new PreviewTranslationWorkspaceViewModel(
+                SelectPreviewProject,
+                OpenLegacyWorkspace,
+                shellViewModel,
+                PreviewTranslationProject.Open);
+            DataContext = shellViewModel;
+            TranslationWorkspace.DataContext = _translationWorkspaceViewModel;
+        }
+
+        private static string SelectPreviewProject()
+        {
+            var dialog = new OpenFileDialog
+            {
+                Title = PreviewMessageCatalog.Get("Workspace_Open_Title"),
+                Filter = PreviewMessageCatalog.Get("Workspace_Project_Filter"),
+                CheckFileExists = true,
+                Multiselect = false
+            };
+            return dialog.ShowDialog() == true ? dialog.FileName : string.Empty;
         }
 
         private void OpenLegacyWorkspace()
@@ -46,6 +67,7 @@ namespace PhoenixTranslator.UIManagement.Preview
 
         private void Window_Closing(object sender, CancelEventArgs e)
         {
+            _translationWorkspaceViewModel.Dispose();
             DeFine.CloseAny();
         }
     }

--- a/Phoenix_Translator/UIManagement/Preview/PreviewTranslationWorkspaceView.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewTranslationWorkspaceView.xaml
@@ -1,0 +1,282 @@
+<UserControl x:Class="PhoenixTranslator.UIManagement.Preview.PreviewTranslationWorkspaceView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:localization="clr-namespace:PhoenixTranslator.UIManagement.Localization"
+             AutomationProperties.Name="{localization:PreviewMessage Workspace_Title}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Themes/PreviewControlStyles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <BooleanToVisibilityConverter x:Key="BooleanToVisibility" />
+            <Style x:Key="WorkspaceComboBox" TargetType="ComboBox">
+            <Setter Property="MinHeight" Value="32" />
+            <Setter Property="Padding" Value="8,3" />
+            <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
+            <Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceCanvas}" />
+            <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushBorder}" />
+            <Setter Property="FocusVisualStyle" Value="{StaticResource PreviewFocusVisual}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ComboBox">
+                        <Grid>
+                            <ToggleButton Focusable="False" Background="Transparent" BorderThickness="0"
+                                          IsChecked="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}">
+                                <ToggleButton.Template>
+                                    <ControlTemplate TargetType="ToggleButton">
+                                        <Border Background="{StaticResource PreviewBrushSurfaceCanvas}"
+                                                BorderBrush="{StaticResource PreviewBrushBorder}" BorderThickness="1"
+                                                CornerRadius="{StaticResource PreviewRadiusMedium}">
+                                            <Path Width="8" Height="5" Margin="0,0,10,0" HorizontalAlignment="Right"
+                                                  VerticalAlignment="Center" Fill="{StaticResource PreviewBrushTextSecondary}"
+                                                  Data="M 0 0 L 8 0 L 4 5 Z" />
+                                        </Border>
+                                    </ControlTemplate>
+                                </ToggleButton.Template>
+                            </ToggleButton>
+                            <ContentPresenter Margin="10,0,28,0" VerticalAlignment="Center"
+                                              IsHitTestVisible="False" Content="{TemplateBinding SelectionBoxItem}"
+                                              ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" />
+                            <Popup x:Name="PART_Popup" Placement="Bottom" AllowsTransparency="True"
+                                   IsOpen="{TemplateBinding IsDropDownOpen}">
+                                <Border MinWidth="{TemplateBinding ActualWidth}" MaxHeight="320"
+                                        Background="{StaticResource PreviewBrushSurfaceRaised}"
+                                        BorderBrush="{StaticResource PreviewBrushBorderStrong}" BorderThickness="1">
+                                    <ScrollViewer><ItemsPresenter /></ScrollViewer>
+                                </Border>
+                            </Popup>
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            </Style>
+            <Style TargetType="ComboBoxItem">
+                <Setter Property="Padding" Value="10,6" />
+                <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
+                <Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceRaised}" />
+                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                <Style.Triggers>
+                    <Trigger Property="IsHighlighted" Value="True">
+                        <Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceInteractive}" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+            <Style x:Key="WorkspaceEntryItem" TargetType="ListBoxItem">
+            <Setter Property="Padding" Value="12,8" />
+            <Setter Property="Margin" Value="4,2" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextSecondary}" />
+            <Setter Property="FocusVisualStyle" Value="{StaticResource PreviewFocusVisual}" />
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceInteractive}" />
+                </Trigger>
+                <Trigger Property="IsSelected" Value="True">
+                    <Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceInteractive}" />
+                    <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
+                    <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushAccentGold}" />
+                    <Setter Property="BorderThickness" Value="3,0,0,0" />
+                </Trigger>
+            </Style.Triggers>
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <UserControl.InputBindings>
+        <KeyBinding Modifiers="Control" Key="O" Command="{Binding OpenProjectCommand}" />
+        <KeyBinding Modifiers="Control" Key="S" Command="{Binding SaveCommand}" />
+        <KeyBinding Key="F6" Command="{Binding TranslateEntryCommand}" />
+        <KeyBinding Modifiers="Control+Shift" Key="T" Command="{Binding TranslateScopeCommand}" />
+        <KeyBinding Key="Escape" Command="{Binding CancelOperationCommand}" />
+    </UserControl.InputBindings>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="12" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0" Padding="10" Background="{StaticResource PreviewBrushSurfacePrimary}"
+                BorderBrush="{StaticResource PreviewBrushBorder}" BorderThickness="1" CornerRadius="5">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="2*" />
+                    <ColumnDefinition Width="12" />
+                    <ColumnDefinition Width="150" />
+                    <ColumnDefinition Width="8" />
+                    <ColumnDefinition Width="140" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="8" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="8" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <TextBox x:Name="SearchBox" Grid.Column="0" Style="{StaticResource PreviewTextBox}"
+                         Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                         ToolTip="{localization:PreviewMessage Workspace_Search_Placeholder}"
+                         AutomationProperties.Name="{localization:PreviewMessage Workspace_Search_Placeholder}" />
+                <ComboBox Grid.Column="2" Style="{StaticResource WorkspaceComboBox}"
+                          ItemsSource="{Binding StateFilters}" DisplayMemberPath="Label"
+                          SelectedItem="{Binding SelectedStateFilter}"
+                          AutomationProperties.Name="{localization:PreviewMessage Workspace_Filter_State_Name}" />
+                <ComboBox Grid.Column="4" Style="{StaticResource WorkspaceComboBox}"
+                          ItemsSource="{Binding TypeFilters}" SelectedItem="{Binding SelectedTypeFilter}"
+                          AutomationProperties.Name="{localization:PreviewMessage Workspace_Filter_Type_Name}" />
+                <Button Grid.Column="6" Style="{StaticResource PreviewButtonSecondary}"
+                        Command="{Binding OpenProjectCommand}"
+                        Content="{localization:PreviewMessage Workspace_Open_Action}" />
+                <Button Grid.Column="8" Style="{StaticResource PreviewButtonSecondary}"
+                        Command="{Binding SaveCommand}"
+                        Content="{localization:PreviewMessage Workspace_Save_Action}" />
+                <Button Grid.Column="10" Style="{StaticResource PreviewButtonPrimary}"
+                        Command="{Binding TranslateScopeCommand}"
+                        Content="{localization:PreviewMessage Workspace_TranslateScope_Action}" />
+            </Grid>
+        </Border>
+
+        <Border Grid.Row="2" Background="{StaticResource PreviewBrushSurfacePrimary}"
+                BorderBrush="{StaticResource PreviewBrushBorder}" BorderThickness="1" CornerRadius="5">
+            <Grid>
+                <Grid>
+                    <Grid.Style>
+                        <Style TargetType="Grid">
+                            <Setter Property="Visibility" Value="Visible" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding HasProject}" Value="True">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Grid.Style>
+                    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" MaxWidth="560">
+                        <TextBlock HorizontalAlignment="Center" FontSize="18" FontWeight="SemiBold"
+                                   Foreground="{StaticResource PreviewBrushTextPrimary}"
+                                   Text="{localization:PreviewMessage Workspace_Empty_Title}" />
+                        <TextBlock Margin="0,10,0,20" TextAlignment="Center" TextWrapping="Wrap"
+                                   Foreground="{StaticResource PreviewBrushTextSecondary}"
+                                   Text="{localization:PreviewMessage Workspace_Empty_Hint}" />
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <Button Style="{StaticResource PreviewButtonPrimary}" Command="{Binding OpenProjectCommand}"
+                                    Content="{localization:PreviewMessage Workspace_Open_Action}" />
+                            <Button Margin="8,0,0,0" Style="{StaticResource PreviewButtonSecondary}"
+                                    Command="{Binding OpenLegacyWorkspaceCommand}"
+                                    Content="{localization:PreviewMessage Shell_Legacy_Open_Action}" />
+                        </StackPanel>
+                    </StackPanel>
+                </Grid>
+
+                <Grid Visibility="{Binding HasProject, Converter={StaticResource BooleanToVisibility}}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="280" MinWidth="220" />
+                        <ColumnDefinition Width="5" />
+                        <ColumnDefinition Width="*" MinWidth="300" />
+                        <ColumnDefinition Width="5" />
+                        <ColumnDefinition Width="220" MinWidth="190" />
+                    </Grid.ColumnDefinitions>
+                    <Grid Grid.Column="0">
+                        <Grid.RowDefinitions><RowDefinition Height="42" /><RowDefinition Height="*" /></Grid.RowDefinitions>
+                        <StackPanel Margin="12,0" Orientation="Horizontal" VerticalAlignment="Center">
+                            <TextBlock Foreground="{StaticResource PreviewBrushTextMuted}" Text="{Binding EntryCountText}" />
+                            <TextBlock Margin="12,0,0,0" Foreground="{StaticResource PreviewBrushWarning}"
+                                       Text="{Binding DraftCountText}" />
+                        </StackPanel>
+                        <ListBox Grid.Row="1" ItemsSource="{Binding Entries}" SelectedItem="{Binding SelectedEntry}"
+                                 ItemContainerStyle="{StaticResource WorkspaceEntryItem}" Background="Transparent"
+                                 BorderThickness="0" ScrollViewer.CanContentScroll="True"
+                                 VirtualizingStackPanel.IsVirtualizing="True"
+                                 VirtualizingStackPanel.VirtualizationMode="Recycling"
+                                 AutomationProperties.Name="{localization:PreviewMessage Accessibility_Workspace_EntryList_Name}">
+                            <ListBox.ItemsPanel><ItemsPanelTemplate><VirtualizingStackPanel /></ItemsPanelTemplate></ListBox.ItemsPanel>
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid>
+                                        <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
+                                        <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                        <TextBlock FontSize="12" FontWeight="SemiBold" TextTrimming="CharacterEllipsis" Text="{Binding Record}" />
+                                        <TextBlock Grid.Column="1" Margin="8,0,0,0" FontSize="11"
+                                                   Foreground="{StaticResource PreviewBrushWarning}" Text="{Binding StateText}" />
+                                        <TextBlock Grid.Row="1" Grid.ColumnSpan="2" Margin="0,5,0,0" FontSize="12"
+                                                   Foreground="{StaticResource PreviewBrushTextMuted}" Text="{Binding SourceText}"
+                                                   TextTrimming="CharacterEllipsis" />
+                                    </Grid>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </Grid>
+                    <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch"
+                                  Background="{StaticResource PreviewBrushBorder}" />
+                    <Grid Grid.Column="2" Margin="18">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" /><RowDefinition Height="*" /><RowDefinition Height="18" />
+                            <RowDefinition Height="Auto" /><RowDefinition Height="*" /><RowDefinition Height="16" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <TextBlock Foreground="{StaticResource PreviewBrushTextMuted}"
+                                   Text="{localization:PreviewMessage Workspace_Entry_SourceText_Label}" />
+                        <TextBox Grid.Row="1" Margin="0,8,0,0" Padding="12" IsReadOnly="True" AcceptsReturn="True"
+                                 TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" Style="{StaticResource PreviewTextBox}"
+                                 Text="{Binding SelectedEntry.SourceText, Mode=OneWay}" />
+                        <TextBlock Grid.Row="3" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                   Text="{localization:PreviewMessage Workspace_Entry_TargetText_Label}" />
+                        <TextBox Grid.Row="4" Margin="0,8,0,0" Padding="12" AcceptsReturn="True" TextWrapping="Wrap"
+                                 VerticalScrollBarVisibility="Auto" Style="{StaticResource PreviewTextBox}"
+                                 Text="{Binding SelectedEntry.TargetText, UpdateSourceTrigger=PropertyChanged}" />
+                        <WrapPanel Grid.Row="6">
+                            <Button Style="{StaticResource PreviewButtonSecondary}" Command="{Binding PreviousEntryCommand}"
+                                    Content="{localization:PreviewMessage Workspace_Entry_Previous_Action}" />
+                            <Button Margin="8,0,0,0" Style="{StaticResource PreviewButtonPrimary}" Command="{Binding ApplyEntryCommand}"
+                                    Content="{localization:PreviewMessage Workspace_Entry_Apply_Action}" />
+                            <Button Margin="8,0,0,0" Style="{StaticResource PreviewButtonSecondary}"
+                                    Command="{Binding TranslateEntryCommand}"
+                                    Content="{localization:PreviewMessage Workspace_TranslateEntry_Action}" />
+                        </WrapPanel>
+                    </Grid>
+                    <GridSplitter Grid.Column="3" Width="5" HorizontalAlignment="Stretch"
+                                  Background="{StaticResource PreviewBrushBorder}" />
+                    <StackPanel Grid.Column="4" Margin="18"
+                                AutomationProperties.Name="{localization:PreviewMessage Accessibility_Workspace_ContextInspector_Name}">
+                        <TextBlock FontSize="16" FontWeight="SemiBold" Foreground="{StaticResource PreviewBrushTextPrimary}"
+                                   Text="{localization:PreviewMessage Workspace_Context_Title}" />
+                        <TextBlock Margin="0,24,0,4" FontSize="11" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                   Text="{localization:PreviewMessage Workspace_Context_Record_Label}" />
+                        <TextBlock Foreground="{StaticResource PreviewBrushTextSecondary}" TextWrapping="Wrap"
+                                   Text="{Binding SelectedEntry.Record}" />
+                        <TextBlock Margin="0,18,0,4" FontSize="11" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                   Text="{localization:PreviewMessage Workspace_Context_Type_Label}" />
+                        <TextBlock Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{Binding SelectedEntry.Type}" />
+                        <TextBlock Margin="0,18,0,4" FontSize="11" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                   Text="{localization:PreviewMessage Workspace_Context_Key_Label}" />
+                        <TextBox Padding="8" IsReadOnly="True" TextWrapping="Wrap" Style="{StaticResource PreviewTextBox}"
+                                 Text="{Binding SelectedEntry.Key, Mode=OneWay}" />
+                        <TextBlock Margin="0,18,0,4" FontSize="11" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                   Text="{localization:PreviewMessage Workspace_Context_Score_Label}" />
+                        <TextBlock Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{Binding SelectedEntry.Score}" />
+                    </StackPanel>
+                </Grid>
+            </Grid>
+        </Border>
+
+        <Grid Grid.Row="3" Margin="0,10,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" /><ColumnDefinition Width="12" /><ColumnDefinition Width="180" />
+                <ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock VerticalAlignment="Center" Foreground="{StaticResource PreviewBrushTextSecondary}"
+                       Text="{Binding OperationText}" />
+            <ProgressBar Grid.Column="2" Height="5" VerticalAlignment="Center" Minimum="0" Maximum="100"
+                         Value="{Binding OperationProgress, Mode=OneWay}"
+                         Visibility="{Binding IsBusy, Converter={StaticResource BooleanToVisibility}}" />
+            <Button Grid.Column="3" HorizontalAlignment="Left" Margin="12,0,0,0"
+                    Style="{StaticResource PreviewButtonDanger}" Command="{Binding CancelOperationCommand}"
+                    Visibility="{Binding CanCancelOperation, Converter={StaticResource BooleanToVisibility}}"
+                    Content="{localization:PreviewMessage Workspace_Cancel_Action}" />
+            <TextBlock Grid.Column="4" VerticalAlignment="Center" Foreground="{StaticResource PreviewBrushTextMuted}"
+                       Text="{localization:PreviewMessage Workspace_Shortcuts_Hint}" TextTrimming="CharacterEllipsis"
+                       ToolTip="{localization:PreviewMessage Workspace_Shortcuts_Hint}" />
+        </Grid>
+    </Grid>
+</UserControl>

--- a/Phoenix_Translator/UIManagement/Preview/PreviewTranslationWorkspaceView.xaml.cs
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewTranslationWorkspaceView.xaml.cs
@@ -1,0 +1,18 @@
+using System.Windows.Controls;
+
+namespace PhoenixTranslator.UIManagement.Preview
+{
+    /// <summary>
+    /// Presents the keyboard-first preview translation workspace.
+    /// </summary>
+    public partial class PreviewTranslationWorkspaceView : UserControl
+    {
+        /// <summary>
+        /// Creates the preview translation workspace view.
+        /// </summary>
+        public PreviewTranslationWorkspaceView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/docs/preview-translation-workspace.md
+++ b/docs/preview-translation-workspace.md
@@ -1,0 +1,35 @@
+# Preview translation workspace
+
+The Translate destination now owns a project-centered preview workflow. The complete legacy workspace remains
+available through the shell action and `Ctrl+L` while reference projects are compared during preview acceptance.
+
+## Project boundary
+
+`PreviewTranslationProject` normalizes ESP, ESM, ESL, PEX, MCM TXT, XML, and Phoenix RamCache JSON records into
+UI-independent entries. Paths remain inside the parser and persistence boundary; the shell receives only the safe
+file name. Inputs are rejected when the file is missing, the format is unsupported, the file exceeds 512 MiB, or
+the normalized project exceeds 500,000 entries.
+
+The adapter reuses the existing format readers, writers, translation provider pipeline, backup behavior, and
+translation memory. A successful save reloads the file through its parser before editing continues. Failures retain
+staged edits and expose only registered user-safe messages.
+
+## Workspace state
+
+`PreviewTranslationWorkspaceViewModel` owns search, state and type filters, selection, staged target text, bounded
+progress, and cooperative cancellation. Provider calls and parser or writer work run away from the WPF UI thread.
+Filtered results are replaced as one collection snapshot so large projects do not generate one UI notification per
+entry. The WPF list uses recycling virtualization and keeps technical keys and confidence metadata in the context
+inspector rather than the primary editing surface.
+
+## Keyboard map
+
+- `Ctrl+O`: open a supported project.
+- `Ctrl+S`: save and reload the current project.
+- `F6`: translate the selected entry.
+- `Ctrl+Shift+T`: translate the current filtered scope.
+- `Esc`: request cancellation of active provider work.
+- `Ctrl+L`: open the complete legacy workspace.
+
+Provider results are staged as modified targets. Partial batch failures keep successful results, preserve failed
+entries, and report a bounded warning summary.


### PR DESCRIPTION
## Problem
The preview shell did not yet provide a usable translation workspace, so users still had to leave the new navigation experience for every translation task.

## User outcome
Users can open supported Skyrim translation content, filter and select records, translate or edit targets, and save through a keyboard-friendly preview workspace while retaining access to the legacy workflow.

## Scope
- Add the preview translation workspace for ESP/ESM/ESL, PEX, MCM TXT, XML, and RamCache JSON projects.
- Add search, type and state filters with a recycling virtualized record list.
- Add source/target editing, metadata inspection, previous/apply-next navigation, scoped translation, progress, and cancellation.
- Preserve successful results when individual provider calls fail and expose a safe recovery message.
- Save through the existing format writers and backup behavior.
- Keep the legacy translation workflow available as a fallback.
- Add stable English preview message identifiers and architecture documentation.
- Increase the application version to 2.0.0.8.

## Validation
- Release x64 solution build completed successfully.
- 17 preset and preview tests passed, including cancellation, partial failure recovery, and filtering 25,000 synthetic records.
- Preview message verification passed.
- A real XML fixture was opened, edited, saved, and reloaded successfully in the WPF application.
- Malformed XML produced the safe in-app error state without terminating the application.
- The workspace was checked at the 1100 x 700 minimum size and retained all primary actions.
- The legacy fallback remains reachable from the translation workspace.

Closes #30