### PR TITLE
Implement the layout for the ModList.

### DIFF
--- a/Phoenix_Translator/PhoenixTranslator.csproj
+++ b/Phoenix_Translator/PhoenixTranslator.csproj
@@ -125,6 +125,7 @@
     <Compile Include="SkyrimManagement\Base26Helper.cs" />
     <Compile Include="SkyrimManagement\ModStringSearcher.cs" />
     <Compile Include="SkyrimManagement\PexReader.cs" />
+    <Compile Include="UIManagement\BlockListView.cs" />
     <Compile Include="UIManagement\Main\CGView.xaml.cs">
       <DependentUpon>CGView.xaml</DependentUpon>
     </Compile>

--- a/Phoenix_Translator/SkyrimManagement/ModStringSearcher.cs
+++ b/Phoenix_Translator/SkyrimManagement/ModStringSearcher.cs
@@ -12,7 +12,10 @@ namespace PhoenixTranslator.SkyrimManagement
         public string ModName = "";
        
         public List<string> AvailableFiles = new List<string>();
-
+        public SkyrimMod()
+        { 
+        
+        }
         public SkyrimMod(string ModPath, string ModName,  List<string> AvailableFiles)
         {
             this.ModPath = ModPath;

--- a/Phoenix_Translator/UIManagement/BlockListView.cs
+++ b/Phoenix_Translator/UIManagement/BlockListView.cs
@@ -1,0 +1,298 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Controls;
+using System.Windows;
+
+namespace PhoenixTranslator.UIManagement
+{
+    public class BlockListView
+    {
+        public List<ExColStyle> ExColStyles = new List<ExColStyle>();
+
+        private Grid Parent = null;
+        private ScrollViewer Scroll = null;
+        private Grid MainGrid;
+
+        public List<ExRow> Rows = new List<ExRow>();
+        public double LineHeight = 0;
+
+        public BlockListView(Grid Parent, double LineHeight = 50)
+        {
+            this.LineHeight = LineHeight;
+
+            this.MainGrid = new Grid();
+            this.MainGrid.Background = null;
+
+            ScrollViewer OneScroll = new ScrollViewer();
+            OneScroll.VerticalScrollBarVisibility = ScrollBarVisibility.Auto;
+            OneScroll.HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled;
+            OneScroll.Content = MainGrid;
+
+            this.Scroll = OneScroll;
+
+            Parent.Children.Add(OneScroll);
+            this.Parent = Parent;
+        }
+
+        public void Clear()
+        {
+            this.Rows.Clear();
+            this.MainGrid.Children.Clear();
+
+            this.MainGrid.RowDefinitions.Clear();
+            this.MainGrid.ColumnDefinitions.Clear();
+
+            this.Scroll.Content = this.MainGrid;
+
+            this.Scroll.ScrollToTop();
+        }
+
+        public Grid GetMainGrid()
+        {
+            if (this.Scroll.Content != null)
+            {
+                return this.Scroll.Content as Grid;
+            }
+
+            return null;
+        }
+
+        private void Refresh()
+        {
+            if (this.Rows.Count == 0) return;
+
+            var GetGrid = GetMainGrid();
+
+            if (GetGrid != null)
+            {
+                this.MainGrid.Children.Clear();
+                this.MainGrid.ColumnDefinitions.Clear();
+                this.MainGrid.RowDefinitions.Clear();
+
+                foreach (var GetStyles in this.ExColStyles)
+                {
+                    ColumnDefinition OneColumn = new ColumnDefinition();
+                    OneColumn.Width = new GridLength(GetStyles.Width, GetStyles.UnitType);
+                    this.MainGrid.ColumnDefinitions.Add(OneColumn);
+                }
+
+                int RowOffset = 0;
+                int ColOffset = 0;
+
+                foreach (var GetControlRow in this.Rows)
+                {
+                    ColOffset = 0;
+
+                    foreach (var GetCol in GetControlRow.Columns)
+                    {
+                        this.MainGrid.Children.Add(GetCol.Control);
+                        Grid.SetColumn(GetCol.Control, ColOffset);
+                        Grid.SetRow(GetCol.Control, RowOffset);
+
+                        ColOffset++;
+                    }
+
+                    RowDefinition OneRow = new RowDefinition();
+                    OneRow.Height = new GridLength(this.LineHeight, GridUnitType.Pixel);
+                    this.MainGrid.RowDefinitions.Add(OneRow);
+                    RowOffset++;
+                }
+            }
+
+        }
+
+        public List<string> AddBlock(params UIElement[] Controls)
+        {
+            List<string> Names = new List<string>();
+
+            ExRow OneRow = null;
+
+            int WaitAutoReturnCount = 0;
+
+            if (this.Rows.Count == 0)
+            {
+                OneRow = new ExRow(this.Rows.Count + 1);
+                this.Rows.Add(OneRow);
+                WaitAutoReturnCount = this.ExColStyles.Count;
+            }
+            else
+            {
+                if (this.Rows[this.Rows.Count - 1].Columns.Count < this.ExColStyles.Count)
+                {
+                    WaitAutoReturnCount = this.ExColStyles.Count - this.Rows[this.Rows.Count - 1].Columns.Count;
+                    OneRow = this.Rows[this.Rows.Count - 1];
+                }
+                else
+                {
+                    OneRow = new ExRow(this.Rows.Count + 1);
+                    this.Rows.Add(OneRow);
+                    WaitAutoReturnCount = this.ExColStyles.Count;
+                }
+            }
+
+            int ColOffset = 0;
+
+            foreach (var Get in ExColStyles)
+            {
+                string CreatControlName = "R{0}C{1}";
+
+                if (Controls.Length < ColOffset + 1) break;
+
+                if (WaitAutoReturnCount > 0)
+                {
+                    CreatControlName = string.Format(CreatControlName, this.Rows.Count, ColOffset);
+
+                    Names.Add(CreatControlName);
+                    OneRow.Columns.Add(new ExCol(Controls[ColOffset], CreatControlName));
+
+                    WaitAutoReturnCount--;
+                }
+                else
+                {
+                    OneRow = new ExRow(this.Rows.Count + 1);
+                    ColOffset = -1;
+                    this.Rows.Add(OneRow);
+                    CreatControlName = string.Format(CreatControlName, this.Rows.Count, ColOffset);
+                    Names.Add(CreatControlName);
+                    OneRow.Columns.Add(new ExCol(Controls[ColOffset], CreatControlName));
+                    WaitAutoReturnCount = this.ExColStyles.Count - 1;
+                }
+
+                ColOffset++;
+            }
+
+            Refresh();
+
+            return Names;
+        }
+
+        /// <summary>
+        /// return Offset
+        /// </summary>
+        /// <param name="Controls"></param>
+        /// <returns></returns>
+        public int AddRow(params UIElement[] Controls)
+        {
+            if (Controls.Length != this.ExColStyles.Count) return -1;
+
+            ExRow OneRow = null;
+            OneRow = new ExRow(this.Rows.Count + 1);
+            this.Rows.Add(OneRow);
+
+            int ColOffset = 0;
+
+            foreach (var Get in ExColStyles)
+            {
+                string CreatControlNameA = string.Format("R{0}C{1}", this.Rows.Count, ColOffset);
+
+                OneRow.Columns.Add(new ExCol(Controls[ColOffset], CreatControlNameA));
+
+                ColOffset++;
+            }
+
+            int RowSign = this.Rows.Count - 1;
+
+            if (this.MainGrid.ColumnDefinitions.Count == 0)
+            {
+                foreach (var GetStyles in this.ExColStyles)
+                {
+                    ColumnDefinition OneColumn = new ColumnDefinition();
+                    OneColumn.Width = new GridLength(GetStyles.Width, GetStyles.UnitType);
+                    this.MainGrid.ColumnDefinitions.Add(OneColumn);
+                }
+            }
+
+            RowDefinition OneGridRow = new RowDefinition();
+            OneGridRow.Height = new GridLength(this.LineHeight, GridUnitType.Pixel);
+            this.MainGrid.RowDefinitions.Add(OneGridRow);
+
+            int GridColOffset = 0;
+
+            foreach (var GetCol in OneRow.Columns)
+            {
+                this.MainGrid.Children.Add(GetCol.Control);
+                Grid.SetColumn(GetCol.Control, GridColOffset);
+                Grid.SetRow(GetCol.Control, RowSign);
+
+                GridColOffset++;
+            }
+
+            return this.Rows.Count - 1;
+        }
+
+        public void DeleteRow(int Offset)
+        {
+            if (this.Rows.Count > (Offset + 1))
+            {
+                this.Rows.RemoveAt(Offset);
+                Refresh();
+            }
+        }
+
+        public void DeleteByName(string Name)
+        {
+            for (int i = 0; i < this.Rows.Count; i++)
+            {
+                for (int ir = 0; ir < this.Rows[i].Columns.Count; ir++)
+                {
+                    if (this.Rows[i].Columns[ir].ControlName.Equals(Name))
+                    {
+                        this.Rows[i].Columns.RemoveAt(ir);
+                    }
+                }
+            }
+
+            Refresh();
+        }
+
+        public void MoveToEnd()
+        {
+            this.Scroll.ScrollToEnd();
+        }
+    }
+
+    public class ExColStyle
+    {
+        public double Width = 0;
+        public GridUnitType UnitType;
+
+        public ExColStyle(double Width = 1, GridUnitType UnitType = GridUnitType.Star)
+        {
+            this.Width = Width;
+            this.UnitType = UnitType;
+        }
+    }
+    public class ExCol
+    {
+        public UIElement Control = null;
+        public string ControlName;
+
+        public ExCol(UIElement Control, string ControlName)
+        {
+            this.Control = Control;
+            this.ControlName = ControlName;
+        }
+    }
+    public class ExRow : IComparable<ExRow>
+    {
+        public int ID = 0;
+
+        public int TopIndex = 0;
+
+        public List<ExCol> Columns = new List<ExCol>();
+
+        public int CompareTo(ExRow p)
+        {
+            if (this.TopIndex > p.TopIndex)
+                return 1;
+            else
+                return -1;
+        }
+
+        public ExRow(int ID)
+        {
+            this.ID = ID;
+            this.TopIndex = ID;
+        }
+    }
+}

--- a/Phoenix_Translator/UIManagement/Main/ModFileDialog.xaml
+++ b/Phoenix_Translator/UIManagement/Main/ModFileDialog.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:PhoenixTranslator.UIManagement.Main"
         Style="{DynamicResource DefWin}"
         mc:Ignorable="d"
-        Title="ModFileDialog" Height="450" Width="800" WindowStartupLocation="CenterOwner">
+        Title="ModFileDialog" Height="450" Width="800" WindowStartupLocation="CenterOwner" Loaded="Window_Loaded">
     <Border Background="#FF282828" CornerRadius="9">
         <Grid>
             <Grid>
@@ -49,7 +49,8 @@
                 </Grid>
 
                 <ScrollViewer Grid.Row="3" Margin="5" Style="{DynamicResource for_scrollviewer}">
-                        
+                    <Grid Name="CModView">
+                    </Grid>
                 </ScrollViewer>
             </Grid>
         </Grid>

--- a/Phoenix_Translator/UIManagement/Main/ModFileDialog.xaml.cs
+++ b/Phoenix_Translator/UIManagement/Main/ModFileDialog.xaml.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using PhoenixTranslator.SkyrimManagement;
+using PhoenixTranslator.UIManage;
 
 namespace PhoenixTranslator.UIManagement.Main
 {
@@ -10,9 +13,69 @@ namespace PhoenixTranslator.UIManagement.Main
     /// </summary>
     public partial class ModFileDialog : Window
     {
+        public BlockListView ModView = null;
+
         public ModFileDialog()
         {
             InitializeComponent();
+        }
+
+        private void Window_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (ModView == null)
+            {
+                ModView = new BlockListView(CModView, 500);
+
+
+                ModView.ExColStyles.Add(new ExColStyle(1, GridUnitType.Star));
+                ModView.ExColStyles.Add(new ExColStyle(1, GridUnitType.Star));
+                ModView.ExColStyles.Add(new ExColStyle(1, GridUnitType.Star));
+                ModView.ExColStyles.Add(new ExColStyle(1, GridUnitType.Star));
+                ModView.ExColStyles.Add(new ExColStyle(1, GridUnitType.Star));
+            }
+        }
+
+        public void UPDateMods(List<SkyrimMod> Mods)
+        {
+            int ColumnLength = 5;
+
+            int CurrentLength = 5;
+
+            List<SkyrimMod> ModBlocks = new List<SkyrimMod>();
+
+            foreach (var GetMod in Mods)
+            {
+                if (CurrentLength > 0)
+                {
+                    CurrentLength--;
+                    ModBlocks.Add(GetMod);
+                }
+
+                if (CurrentLength == 0)
+                {
+                    this.Dispatcher.Invoke(new Action(() =>
+                    {
+                        ModView.AddRow(UIHelper.CreateModLine(ModBlocks).ToArray());
+                    }));
+
+                    ModBlocks.Clear();
+                    CurrentLength = ColumnLength;
+                }
+            }
+
+            if (ModBlocks.Count > 0)
+            {
+                for (int i = 0; i < CurrentLength; i++)
+                {
+                    ModBlocks.Add(new SkyrimMod());
+                }
+
+                this.Dispatcher.Invoke(new Action(() =>
+                {
+                    ModView.AddRow(UIHelper.CreateModLine(ModBlocks).ToArray());
+                }));
+            }
+
         }
 
         private void Path_TextChanged(object sender, TextChangedEventArgs e)
@@ -58,5 +121,7 @@ namespace PhoenixTranslator.UIManagement.Main
                 catch { }
             }
         }
+
+       
     }
 }

--- a/Phoenix_Translator/UIManagement/UIHelper.cs
+++ b/Phoenix_Translator/UIManagement/UIHelper.cs
@@ -91,6 +91,13 @@ namespace PhoenixTranslator.UIManage
 
     public class UIHelper
     {
+        #region ModFileDialog
+        public static List<Grid> CreateModLine(List<SkyrimMod>Items)
+        {
+            return new List<Grid>();
+        }
+
+        #endregion
         public static void ShowButton(Border NormalButton, bool Enable)
         {
             if (Enable)


### PR DESCRIPTION
I’m using a fixed 5-column grid layout for the Mod view. Each row contains up to five Mod items, and when the row is full, a new row is automatically created. If the last row contains fewer than five items, empty placeholders are added to keep the layout aligned.