### PR TITLE
Integrate history and project update workflows

### DIFF
--- a/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
+++ b/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
@@ -59,11 +59,20 @@
     <Compile Include="..\Phoenix_Translator\Application\PreviewQualityFinding.cs">
       <Link>PreviewQualityFinding.cs</Link>
     </Compile>
+    <Compile Include="..\Phoenix_Translator\Application\PreviewProjectComparison.cs">
+      <Link>PreviewProjectComparison.cs</Link>
+    </Compile>
+    <Compile Include="..\Phoenix_Translator\Application\PreviewHistoryUpdateViewModel.cs">
+      <Link>PreviewHistoryUpdateViewModel.cs</Link>
+    </Compile>
     <Compile Include="..\Phoenix_Translator\Application\PreviewReviewQualityViewModel.cs">
       <Link>PreviewReviewQualityViewModel.cs</Link>
     </Compile>
     <Compile Include="..\Phoenix_Translator\Application\PreviewReviewStateStore.cs">
       <Link>PreviewReviewStateStore.cs</Link>
+    </Compile>
+    <Compile Include="..\Phoenix_Translator\Application\PreviewRevisionHistoryStore.cs">
+      <Link>PreviewRevisionHistoryStore.cs</Link>
     </Compile>
     <Compile Include="..\Phoenix_Translator\Application\PreviewShellCommand.cs">
       <Link>PreviewShellCommand.cs</Link>

--- a/PhoenixTranslator.PresetTests/Program.cs
+++ b/PhoenixTranslator.PresetTests/Program.cs
@@ -40,7 +40,11 @@ namespace PhoenixTranslator.PresetTests
                 { nameof(AnalyzesMixedQualityFindings), AnalyzesMixedQualityFindings },
                 { nameof(TracksReviewDecisionsAndBulkUndo), TracksReviewDecisionsAndBulkUndo },
                 { nameof(PersistsPrivateReviewMetadata), PersistsPrivateReviewMetadata },
-                { nameof(NavigatesFromFindingToTranslationEntry), NavigatesFromFindingToTranslationEntry }
+                { nameof(NavigatesFromFindingToTranslationEntry), NavigatesFromFindingToTranslationEntry },
+                { nameof(ClassifiesProjectRevisionChanges), ClassifiesProjectRevisionChanges },
+                { nameof(PreservesReviewedTargetsAsConflicts), PreservesReviewedTargetsAsConflicts },
+                { nameof(PersistsPrivateRevisionHistory), PersistsPrivateRevisionHistory },
+                { nameof(AppliesAndUndoesExplicitRevisionReuse), AppliesAndUndoesExplicitRevisionReuse }
             };
             int failures = 0;
             foreach (KeyValuePair<string, Action> test in tests)
@@ -653,6 +657,177 @@ namespace PhoenixTranslator.PresetTests
                 AssertEqual(entries[0], workspace.SelectedEntry,
                     "Finding navigation must reveal the exact affected entry.");
                 review.Dispose();
+                workspace.Dispose();
+            }
+            finally
+            {
+                Directory.Delete(stateDirectory, true);
+            }
+        }
+
+        private static void ClassifiesProjectRevisionChanges()
+        {
+            var current = new[]
+            {
+                new PreviewTranslationEntry("added", "XML", "ADDED", "New", string.Empty, 100),
+                new PreviewTranslationEntry("reusable", "XML", "REUSABLE", "Same", string.Empty, 100),
+                new PreviewTranslationEntry("changed", "XML", "CHANGED", "New source", string.Empty, 100),
+                new PreviewTranslationEntry("unchanged", "XML", "UNCHANGED", "Stable", "Stabil", 100)
+            };
+            var previous = new[]
+            {
+                new PreviewTranslationEntry("unchanged", "XML", "UNCHANGED", "Stable", "Stabil", 100),
+                new PreviewTranslationEntry("removed", "XML", "REMOVED", "Old", "Alt", 100),
+                new PreviewTranslationEntry("changed", "XML", "CHANGED", "Old source", "Alte Quelle", 100),
+                new PreviewTranslationEntry("reusable", "XML", "REUSABLE", "Same", "Gleich", 100)
+            };
+
+            IReadOnlyList<PreviewProjectComparisonItem> result =
+                new PreviewProjectComparisonService().Compare(current, previous);
+
+            AssertEqual(PreviewRevisionComparisonState.Added,
+                result.Single(item => item.Key == "added").State,
+                "A current-only stable identity must be classified as added.");
+            AssertEqual(PreviewRevisionComparisonState.Removed,
+                result.Single(item => item.Key == "removed").State,
+                "A previous-only stable identity must be classified as removed.");
+            AssertEqual(PreviewRevisionComparisonState.Reusable,
+                result.Single(item => item.Key == "reusable").State,
+                "An untranslated equal source must expose the prior target as reusable.");
+            AssertEqual(PreviewRevisionComparisonState.Changed,
+                result.Single(item => item.Key == "changed").State,
+                "A changed source without a current target must require fresh translation.");
+            AssertEqual(PreviewRevisionComparisonState.Unchanged,
+                result.Single(item => item.Key == "unchanged").State,
+                "Equal source and target content must remain unchanged regardless of source order.");
+
+            PreviewProjectComparisonItem ambiguous = new PreviewProjectComparisonService().Compare(
+                new[]
+                {
+                    new PreviewTranslationEntry("duplicate", "XML", "ONE", "First", string.Empty, 100),
+                    new PreviewTranslationEntry("duplicate", "XML", "TWO", "Second", string.Empty, 100)
+                },
+                new[] { new PreviewTranslationEntry("duplicate", "XML", "OLD", "First", "Erste", 100) })
+                .Single();
+            AssertEqual(PreviewRevisionComparisonState.Conflict, ambiguous.State,
+                "Ambiguous stable identities must be exposed as conflicts instead of being silently discarded.");
+        }
+
+        private static void PreservesReviewedTargetsAsConflicts()
+        {
+            var current = new PreviewTranslationEntry("entry", "PEX", "ENTRY", "Source", "Current", 100);
+            current.SetReviewState(PreviewReviewState.Approved);
+            var previous = new PreviewTranslationEntry("entry", "PEX", "ENTRY", "Source", "Previous", 100);
+
+            PreviewProjectComparisonItem result = new PreviewProjectComparisonService()
+                .Compare(new[] { current }, new[] { previous }).Single();
+
+            AssertEqual(PreviewRevisionComparisonState.Conflict, result.State,
+                "Different populated targets must never be silently reusable.");
+            AssertEqual(true, result.CanReuse,
+                "A conflicting prior target may remain available for an explicit confirmed decision.");
+            AssertEqual("Current", current.TargetText,
+                "Classification must not alter a reviewed current target.");
+
+            current.ApplyReusedTarget(previous.TargetText);
+            AssertEqual(PreviewReviewState.Unreviewed, current.ReviewState,
+                "Explicit target reuse must invalidate the previous review decision.");
+            AssertEqual("Previous project revision", current.Provenance,
+                "Explicit target reuse must expose revision provenance.");
+        }
+
+        private static void PersistsPrivateRevisionHistory()
+        {
+            string stateDirectory = Path.Combine(Path.GetTempPath(), "PhoenixHistoryTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(stateDirectory);
+            try
+            {
+                string projectPath = Path.Combine(stateDirectory, "private-project.xml");
+                const string privateSource = "Private source content";
+                const string privateTarget = "Private target content";
+                var entry = new PreviewTranslationEntry("entry", "XML", "RECORD", privateSource, privateTarget, 100);
+                var store = new PreviewRevisionHistoryStore(stateDirectory);
+                store.Append(projectPath, PreviewRevisionHistoryStore.Create("Reused", entry, DateTime.UtcNow));
+
+                string persistedText = File.ReadAllText(Directory.GetFiles(stateDirectory, "*.xml").Single());
+                AssertEqual(false, persistedText.Contains(projectPath),
+                    "Revision history must not contain an absolute project path.");
+                AssertEqual(false, persistedText.Contains(privateSource),
+                    "Revision history must not contain private source content.");
+                AssertEqual(false, persistedText.Contains(privateTarget),
+                    "Revision history must not contain private target content.");
+                AssertEqual(1, store.Load(projectPath).Count,
+                    "A valid privacy-preserving history event must round-trip.");
+            }
+            finally
+            {
+                Directory.Delete(stateDirectory, true);
+            }
+        }
+
+        private static void AppliesAndUndoesExplicitRevisionReuse()
+        {
+            string stateDirectory = Path.Combine(Path.GetTempPath(), "PhoenixUpdateTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(stateDirectory);
+            try
+            {
+                string currentPath = Path.Combine(stateDirectory, "current.xml");
+                string previousPath = Path.Combine(stateDirectory, "previous.xml");
+                var reusable = new PreviewTranslationEntry("reusable", "XML", "REUSABLE", "Same", string.Empty, 100);
+                var conflict = new PreviewTranslationEntry("conflict", "XML", "CONFLICT", "Stable", "Current", 100);
+                conflict.SetReviewState(PreviewReviewState.Approved);
+                var currentProject = new FakePreviewTranslationProject(new[] { reusable, conflict }, currentPath);
+                var previousProject = new FakePreviewTranslationProject(new[]
+                {
+                    new PreviewTranslationEntry("conflict", "XML", "CONFLICT", "Stable", "Previous", 100),
+                    new PreviewTranslationEntry("reusable", "XML", "REUSABLE", "Same", "Reusable target", 100)
+                }, previousPath);
+                var shell = new PreviewShellViewModel(() => { });
+                var workspace = new PreviewTranslationWorkspaceViewModel(
+                    () => currentPath, () => { }, shell, path => currentProject);
+                workspace.OpenProjectAsync(currentPath).GetAwaiter().GetResult();
+                var update = new PreviewHistoryUpdateViewModel(
+                    shell,
+                    workspace,
+                    new PreviewProjectComparisonService(),
+                    new PreviewRevisionHistoryStore(stateDirectory),
+                    () => previousPath,
+                    path => previousProject,
+                    count => false,
+                    count => true,
+                    () => { });
+
+                update.CompareRevisionCommand.Execute(null);
+                DateTime timeout = DateTime.UtcNow.AddSeconds(5);
+                while (!update.HasComparison && DateTime.UtcNow < timeout)
+                {
+                    System.Threading.Thread.Sleep(10);
+                }
+
+                AssertEqual(true, update.HasComparison,
+                    "A compatible selected revision must produce comparison results.");
+                update.SelectedComparisonItem = update.ComparisonItems.Single(item => item.Key == "conflict");
+                update.ReuseSelectedCommand.Execute(null);
+                AssertEqual("Current", conflict.TargetText,
+                    "Cancelling conflict confirmation must preserve the reviewed current target.");
+                AssertEqual(PreviewReviewState.Approved, conflict.ReviewState,
+                    "Cancelling conflict confirmation must preserve its review decision.");
+
+                update.SelectedComparisonItem = update.ComparisonItems.Single(item => item.Key == "reusable");
+                update.ReuseSelectedCommand.Execute(null);
+                AssertEqual("Reusable target", reusable.TargetText,
+                    "Explicit safe reuse must stage the selected prior target.");
+                AssertEqual(PreviewReviewState.Unreviewed, reusable.ReviewState,
+                    "Reused content must enter review as unreviewed.");
+
+                update.UndoCommand.Execute(null);
+                AssertEqual(string.Empty, reusable.TargetText,
+                    "Undo must restore the target captured before explicit reuse.");
+                AssertEqual(true, update.HistoryEntries.Any(entry => entry.ActionId == "Reused"),
+                    "Explicit reuse must create a project history event.");
+                AssertEqual(true, update.HistoryEntries.Any(entry => entry.ActionId == "Undone"),
+                    "Undo must create a project history event.");
+                update.Dispose();
                 workspace.Dispose();
             }
             finally

--- a/Phoenix_Translator/Application/PreviewHistoryUpdateViewModel.cs
+++ b/Phoenix_Translator/Application/PreviewHistoryUpdateViewModel.cs
@@ -1,0 +1,597 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Describes one localized revision-comparison filter.
+    /// </summary>
+    internal sealed class PreviewComparisonFilterOption
+    {
+        /// <summary>
+        /// Creates a localized filter option.
+        /// </summary>
+        /// <param name="value">The optional comparison state, or <see langword="null"/> for all states.</param>
+        /// <param name="label">The localized visible label.</param>
+        internal PreviewComparisonFilterOption(PreviewRevisionComparisonState? value, string label)
+        {
+            Value = value;
+            Label = label;
+        }
+
+        /// <summary>Gets the optional comparison state.</summary>
+        public PreviewRevisionComparisonState? Value { get; private set; }
+
+        /// <summary>Gets the localized visible label.</summary>
+        public string Label { get; private set; }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return Label;
+        }
+    }
+
+    /// <summary>
+    /// Owns the preview history timeline and explicit project-revision update workflow.
+    /// </summary>
+    internal sealed class PreviewHistoryUpdateViewModel : INotifyPropertyChanged, IDisposable
+    {
+        private readonly PreviewShellViewModel _shell;
+        private readonly PreviewTranslationWorkspaceViewModel _workspace;
+        private readonly PreviewProjectComparisonService _comparisonService;
+        private readonly PreviewRevisionHistoryStore _historyStore;
+        private readonly Func<string> _chooseRevisionPath;
+        private readonly Func<string, IPreviewTranslationProject> _openProject;
+        private readonly Func<int, bool> _confirmConflictReuse;
+        private readonly Func<int, bool> _confirmBulkReuse;
+        private readonly Action _openLegacyWorkspace;
+        private IReadOnlyList<PreviewProjectComparisonItem> _allComparisonItems;
+        private IPreviewTranslationProject _previousProject;
+        private PreviewComparisonFilterOption _selectedFilter;
+        private PreviewProjectComparisonItem _selectedComparisonItem;
+        private PreviewRevisionHistoryEntry _selectedHistoryEntry;
+        private string _searchText;
+        private string _previousRevisionName;
+        private bool _isBusy;
+        private List<UpdateSnapshot> _undoSnapshots;
+
+        /// <summary>
+        /// Creates the combined history and project-update workflow.
+        /// </summary>
+        /// <param name="shell">The persistent shell status owner.</param>
+        /// <param name="workspace">The active translation workspace.</param>
+        /// <param name="comparisonService">The stable-identity comparison service.</param>
+        /// <param name="historyStore">The privacy-preserving event store.</param>
+        /// <param name="chooseRevisionPath">Selects a previous revision path.</param>
+        /// <param name="openProject">Opens a selected revision through the parser boundary.</param>
+        /// <param name="confirmConflictReuse">Confirms replacement of conflicting targets.</param>
+        /// <param name="confirmBulkReuse">Confirms reuse of a safe visible scope.</param>
+        /// <param name="openLegacyWorkspace">Opens the complete legacy fallback.</param>
+        internal PreviewHistoryUpdateViewModel(
+            PreviewShellViewModel shell,
+            PreviewTranslationWorkspaceViewModel workspace,
+            PreviewProjectComparisonService comparisonService,
+            PreviewRevisionHistoryStore historyStore,
+            Func<string> chooseRevisionPath,
+            Func<string, IPreviewTranslationProject> openProject,
+            Func<int, bool> confirmConflictReuse,
+            Func<int, bool> confirmBulkReuse,
+            Action openLegacyWorkspace)
+        {
+            _shell = shell ?? throw new ArgumentNullException(nameof(shell));
+            _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
+            _comparisonService = comparisonService ?? throw new ArgumentNullException(nameof(comparisonService));
+            _historyStore = historyStore ?? throw new ArgumentNullException(nameof(historyStore));
+            _chooseRevisionPath = chooseRevisionPath ?? throw new ArgumentNullException(nameof(chooseRevisionPath));
+            _openProject = openProject ?? throw new ArgumentNullException(nameof(openProject));
+            _confirmConflictReuse = confirmConflictReuse ?? throw new ArgumentNullException(nameof(confirmConflictReuse));
+            _confirmBulkReuse = confirmBulkReuse ?? throw new ArgumentNullException(nameof(confirmBulkReuse));
+            _openLegacyWorkspace = openLegacyWorkspace ?? throw new ArgumentNullException(nameof(openLegacyWorkspace));
+            _searchText = string.Empty;
+            _previousRevisionName = string.Empty;
+            _allComparisonItems = new List<PreviewProjectComparisonItem>();
+            ComparisonItems = _allComparisonItems;
+            HistoryEntries = new List<PreviewRevisionHistoryEntry>();
+            Filters = new[]
+            {
+                CreateFilter(null, "Update_Filter_All"),
+                CreateFilter(PreviewRevisionComparisonState.Reusable, "Update_State_Reusable"),
+                CreateFilter(PreviewRevisionComparisonState.Conflict, "Update_State_Conflict"),
+                CreateFilter(PreviewRevisionComparisonState.Changed, "Update_State_Changed"),
+                CreateFilter(PreviewRevisionComparisonState.Added, "Update_State_Added"),
+                CreateFilter(PreviewRevisionComparisonState.Removed, "Update_State_Removed"),
+                CreateFilter(PreviewRevisionComparisonState.Unchanged, "Update_State_Unchanged")
+            };
+            _selectedFilter = Filters[0];
+
+            OpenProjectCommand = workspace.OpenProjectCommand;
+            CompareRevisionCommand = new PreviewShellCommand(parameter => CompareSelectedRevision(), parameter => HasProject && !IsBusy);
+            ReuseSelectedCommand = new PreviewShellCommand(parameter => ReuseSelected(), parameter => CanReuseSelected && !IsBusy);
+            ReuseVisibleCommand = new PreviewShellCommand(parameter => ReuseVisible(), parameter => ReusableVisibleCount > 0 && !IsBusy);
+            KeepCurrentCommand = new PreviewShellCommand(parameter => KeepCurrent(), parameter => IsSelectedConflict && !IsBusy);
+            UndoCommand = new PreviewShellCommand(parameter => UndoLastUpdate(), parameter => CanUndo && !IsBusy);
+            GoToEntryCommand = new PreviewShellCommand(parameter => GoToSelectedEntry(), parameter => SelectedComparisonItem?.CurrentEntry != null);
+            OpenLegacyWorkspaceCommand = new PreviewShellCommand(parameter => _openLegacyWorkspace());
+
+            _workspace.ProjectChanged += WorkspaceProjectChanged;
+            _shell.PropertyChanged += ShellPropertyChanged;
+            ReloadHistory();
+        }
+
+        /// <inheritdoc />
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>Gets the localized comparison filters.</summary>
+        public IReadOnlyList<PreviewComparisonFilterOption> Filters { get; private set; }
+
+        /// <summary>Gets the filtered comparison results.</summary>
+        public IReadOnlyList<PreviewProjectComparisonItem> ComparisonItems { get; private set; }
+
+        /// <summary>Gets the newest-first project history events.</summary>
+        public IReadOnlyList<PreviewRevisionHistoryEntry> HistoryEntries { get; private set; }
+
+        /// <summary>Gets the command that opens an active project.</summary>
+        public ICommand OpenProjectCommand { get; private set; }
+
+        /// <summary>Gets the command that selects and compares a previous revision.</summary>
+        public ICommand CompareRevisionCommand { get; private set; }
+
+        /// <summary>Gets the command that explicitly reuses the selected prior target.</summary>
+        public ICommand ReuseSelectedCommand { get; private set; }
+
+        /// <summary>Gets the command that reuses only visible safe candidates.</summary>
+        public ICommand ReuseVisibleCommand { get; private set; }
+
+        /// <summary>Gets the command that records retention of a conflicting current target.</summary>
+        public ICommand KeepCurrentCommand { get; private set; }
+
+        /// <summary>Gets the command that restores the most recent reuse action.</summary>
+        public ICommand UndoCommand { get; private set; }
+
+        /// <summary>Gets the command that reveals the selected current entry.</summary>
+        public ICommand GoToEntryCommand { get; private set; }
+
+        /// <summary>Gets the command that opens the complete legacy workflow.</summary>
+        public ICommand OpenLegacyWorkspaceCommand { get; private set; }
+
+        /// <summary>Gets whether an active project is available.</summary>
+        public bool HasProject => !string.IsNullOrWhiteSpace(_workspace.ProjectPath);
+
+        /// <summary>Gets whether project history contains events.</summary>
+        public bool HasHistory => HistoryEntries.Count > 0;
+
+        /// <summary>Gets whether a revision comparison is available.</summary>
+        public bool HasComparison => _allComparisonItems.Count > 0;
+
+        /// <summary>Gets whether the shell currently displays project history.</summary>
+        public bool IsHistoryMode => _shell.CurrentDestination == PreviewShellDestination.History;
+
+        /// <summary>Gets whether the shell currently displays project updates.</summary>
+        public bool IsProjectUpdateMode => _shell.CurrentDestination == PreviewShellDestination.ProjectUpdate;
+
+        /// <summary>Gets whether a revision is being opened and compared.</summary>
+        public bool IsBusy => _isBusy;
+
+        /// <summary>Gets whether the most recent reuse action can be restored.</summary>
+        public bool CanUndo => _undoSnapshots != null && _undoSnapshots.Count > 0;
+
+        /// <summary>Gets whether the selected prior target can be explicitly reused.</summary>
+        public bool CanReuseSelected => SelectedComparisonItem != null && SelectedComparisonItem.CanReuse;
+
+        /// <summary>Gets whether the selected result requires an explicit conflict decision.</summary>
+        public bool IsSelectedConflict => SelectedComparisonItem?.State == PreviewRevisionComparisonState.Conflict;
+
+        /// <summary>Gets the visible safe-reuse candidate count.</summary>
+        public int ReusableVisibleCount => ComparisonItems.Count(item => item.State == PreviewRevisionComparisonState.Reusable);
+
+        /// <summary>Gets the safe display name of the compared revision.</summary>
+        public string PreviousRevisionName => _previousRevisionName;
+
+        /// <summary>Gets the localized aggregate comparison counts.</summary>
+        public string ComparisonSummary => PreviewMessageCatalog.Format(
+            "Update_Comparison_Summary",
+            _allComparisonItems.Count(item => item.State == PreviewRevisionComparisonState.Added),
+            _allComparisonItems.Count(item => item.State == PreviewRevisionComparisonState.Removed),
+            _allComparisonItems.Count(item => item.State == PreviewRevisionComparisonState.Changed),
+            _allComparisonItems.Count(item => item.State == PreviewRevisionComparisonState.Reusable),
+            _allComparisonItems.Count(item => item.State == PreviewRevisionComparisonState.Conflict));
+
+        /// <summary>Gets or sets the selected comparison-state filter.</summary>
+        public PreviewComparisonFilterOption SelectedFilter
+        {
+            get => _selectedFilter;
+            set
+            {
+                if (ReferenceEquals(_selectedFilter, value) || value == null)
+                {
+                    return;
+                }
+
+                _selectedFilter = value;
+                OnPropertyChanged();
+                RefreshComparisonFilter();
+            }
+        }
+
+        /// <summary>Gets or sets the comparison search text.</summary>
+        public string SearchText
+        {
+            get => _searchText;
+            set
+            {
+                string normalized = value ?? string.Empty;
+                if (string.Equals(_searchText, normalized, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                _searchText = normalized;
+                OnPropertyChanged();
+                RefreshComparisonFilter();
+            }
+        }
+
+        /// <summary>Gets or sets the comparison result shown in the detail pane.</summary>
+        public PreviewProjectComparisonItem SelectedComparisonItem
+        {
+            get => _selectedComparisonItem;
+            set
+            {
+                if (ReferenceEquals(_selectedComparisonItem, value))
+                {
+                    return;
+                }
+
+                _selectedComparisonItem = value;
+                OnPropertyChanged();
+                RaiseCommandAvailability();
+                OnPropertyChanged(nameof(CanReuseSelected));
+                OnPropertyChanged(nameof(IsSelectedConflict));
+            }
+        }
+
+        /// <summary>Gets or sets the history event shown in the detail pane.</summary>
+        public PreviewRevisionHistoryEntry SelectedHistoryEntry
+        {
+            get => _selectedHistoryEntry;
+            set
+            {
+                if (ReferenceEquals(_selectedHistoryEntry, value))
+                {
+                    return;
+                }
+
+                _selectedHistoryEntry = value;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _workspace.ProjectChanged -= WorkspaceProjectChanged;
+            _shell.PropertyChanged -= ShellPropertyChanged;
+            _previousProject?.Dispose();
+        }
+
+        private async void CompareSelectedRevision()
+        {
+            string path = _chooseRevisionPath();
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return;
+            }
+
+            if (!string.Equals(Path.GetExtension(path), Path.GetExtension(_workspace.ProjectPath), StringComparison.OrdinalIgnoreCase))
+            {
+                _shell.ShowNotification(PreviewShellNotificationSeverity.Warning, "Update_Comparison_Incompatible");
+                return;
+            }
+
+            SetBusy(true);
+            _shell.SetOperation("Update_Comparison_Progress", 20);
+            IPreviewTranslationProject previousProject = null;
+            try
+            {
+                previousProject = await Task.Run(() => _openProject(path));
+                IReadOnlyList<PreviewTranslationEntry> currentEntries = _workspace.ProjectEntries;
+                IReadOnlyList<PreviewProjectComparisonItem> comparison = await Task.Run(
+                    () => _comparisonService.Compare(currentEntries, previousProject.Entries));
+                _previousProject?.Dispose();
+                _previousProject = previousProject;
+                previousProject = null;
+                _previousRevisionName = _previousProject.DisplayName;
+                _allComparisonItems = comparison;
+                SelectedComparisonItem = comparison.FirstOrDefault(item => item.State != PreviewRevisionComparisonState.Unchanged)
+                    ?? comparison.FirstOrDefault();
+                RefreshComparisonFilter();
+                AppendProjectHistory("Compared", _previousRevisionName);
+                _shell.ShowNotification(PreviewShellNotificationSeverity.Success, "Update_Comparison_Completed");
+            }
+            catch (Exception exception) when (exception is IOException || exception is UnauthorizedAccessException ||
+                exception is InvalidDataException || exception is InvalidOperationException)
+            {
+                _shell.ShowNotification(PreviewShellNotificationSeverity.Error, "Update_Comparison_Failed");
+            }
+            finally
+            {
+                previousProject?.Dispose();
+                _shell.CompleteOperation();
+                SetBusy(false);
+            }
+        }
+
+        private void ReuseSelected()
+        {
+            PreviewProjectComparisonItem item = SelectedComparisonItem;
+            if (item == null || !item.CanReuse)
+            {
+                return;
+            }
+
+            if (item.State == PreviewRevisionComparisonState.Conflict && !_confirmConflictReuse(1))
+            {
+                return;
+            }
+
+            ApplyReuse(new[] { item });
+        }
+
+        private void ReuseVisible()
+        {
+            List<PreviewProjectComparisonItem> reusable = ComparisonItems
+                .Where(item => item.State == PreviewRevisionComparisonState.Reusable && item.CanReuse).ToList();
+            if (reusable.Count == 0 || !_confirmBulkReuse(reusable.Count))
+            {
+                return;
+            }
+
+            ApplyReuse(reusable);
+        }
+
+        private void ApplyReuse(IEnumerable<PreviewProjectComparisonItem> items)
+        {
+            List<PreviewProjectComparisonItem> selectedItems = items.ToList();
+            _undoSnapshots = selectedItems.Select(item => new UpdateSnapshot(
+                item.CurrentEntry,
+                item.CurrentEntry.TargetText,
+                item.CurrentEntry.ReviewState,
+                item.PreviousTargetText)).ToList();
+            foreach (UpdateSnapshot snapshot in _undoSnapshots)
+            {
+                PreviewProjectComparisonItem item = selectedItems.First(
+                    candidate => ReferenceEquals(candidate.CurrentEntry, snapshot.Entry));
+                snapshot.Entry.ApplyReusedTarget(snapshot.ReusedTargetText);
+                AppendEntryHistory(
+                    item.State == PreviewRevisionComparisonState.Conflict ? "ConflictResolved" : "Reused",
+                    snapshot.Entry);
+            }
+
+            RefreshComparison();
+            _shell.ShowNotification(PreviewShellNotificationSeverity.Success, "Update_Reuse_Completed", _undoSnapshots.Count);
+        }
+
+        private void KeepCurrent()
+        {
+            if (!IsSelectedConflict)
+            {
+                return;
+            }
+
+            AppendEntryHistory("KeptCurrent", SelectedComparisonItem.CurrentEntry);
+            _shell.ShowNotification(PreviewShellNotificationSeverity.Information, "Update_KeepCurrent_Completed");
+        }
+
+        private void UndoLastUpdate()
+        {
+            if (!CanUndo)
+            {
+                return;
+            }
+
+            foreach (UpdateSnapshot snapshot in _undoSnapshots)
+            {
+                snapshot.Entry.TargetText = snapshot.TargetText;
+                snapshot.Entry.SetReviewState(snapshot.ReviewState);
+                AppendEntryHistory("Undone", snapshot.Entry);
+            }
+
+            int restoredCount = _undoSnapshots.Count;
+            _undoSnapshots = null;
+            RefreshComparison();
+            _shell.ShowNotification(PreviewShellNotificationSeverity.Information, "Update_Undo_Completed", restoredCount);
+        }
+
+        private void GoToSelectedEntry()
+        {
+            PreviewTranslationEntry entry = SelectedComparisonItem?.CurrentEntry;
+            if (entry == null)
+            {
+                return;
+            }
+
+            _workspace.RevealEntry(entry);
+            _shell.CurrentDestination = PreviewShellDestination.Translate;
+        }
+
+        private void WorkspaceProjectChanged(object sender, EventArgs e)
+        {
+            _previousProject?.Dispose();
+            _previousProject = null;
+            _previousRevisionName = string.Empty;
+            _allComparisonItems = new List<PreviewProjectComparisonItem>();
+            ComparisonItems = _allComparisonItems;
+            SelectedComparisonItem = null;
+            _undoSnapshots = null;
+            ReloadHistory();
+            OnPropertyChanged(nameof(HasProject));
+            OnPropertyChanged(nameof(HasComparison));
+            OnPropertyChanged(nameof(PreviousRevisionName));
+            OnPropertyChanged(nameof(ComparisonSummary));
+            RaiseCommandAvailability();
+        }
+
+        private void ShellPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(PreviewShellViewModel.CurrentDestination))
+            {
+                OnPropertyChanged(nameof(IsHistoryMode));
+                OnPropertyChanged(nameof(IsProjectUpdateMode));
+            }
+        }
+
+        private void ReloadHistory()
+        {
+            try
+            {
+                HistoryEntries = HasProject
+                    ? _historyStore.Load(_workspace.ProjectPath)
+                    : new List<PreviewRevisionHistoryEntry>();
+            }
+            catch (Exception exception) when (exception is IOException || exception is UnauthorizedAccessException ||
+                exception is ArgumentException)
+            {
+                HistoryEntries = new List<PreviewRevisionHistoryEntry>();
+                _shell.ShowNotification(PreviewShellNotificationSeverity.Warning, "History_Load_Failed");
+            }
+
+            SelectedHistoryEntry = HistoryEntries.FirstOrDefault();
+            OnPropertyChanged(nameof(HistoryEntries));
+            OnPropertyChanged(nameof(HasHistory));
+        }
+
+        private void AppendEntryHistory(string actionId, PreviewTranslationEntry entry)
+        {
+            if (!HasProject || entry == null)
+            {
+                return;
+            }
+
+            TryAppend(PreviewRevisionHistoryStore.Create(actionId, entry, DateTime.UtcNow));
+        }
+
+        private void AppendProjectHistory(string actionId, string record)
+        {
+            if (!HasProject)
+            {
+                return;
+            }
+
+            TryAppend(new PreviewRevisionHistoryEntry(
+                DateTime.UtcNow, actionId, "project", record, string.Empty, string.Empty, string.Empty));
+        }
+
+        private void TryAppend(PreviewRevisionHistoryEntry entry)
+        {
+            try
+            {
+                _historyStore.Append(_workspace.ProjectPath, entry);
+                ReloadHistory();
+            }
+            catch (Exception exception) when (exception is IOException || exception is UnauthorizedAccessException ||
+                exception is ArgumentException)
+            {
+                _shell.ShowNotification(PreviewShellNotificationSeverity.Warning, "History_Save_Failed");
+            }
+        }
+
+        private void RefreshComparison()
+        {
+            if (_previousProject == null)
+            {
+                return;
+            }
+
+            string selectedKey = SelectedComparisonItem?.Key;
+            _allComparisonItems = _comparisonService.Compare(_workspace.ProjectEntries, _previousProject.Entries);
+            RefreshComparisonFilter();
+            SelectedComparisonItem = _allComparisonItems.FirstOrDefault(item => item.Key == selectedKey)
+                ?? ComparisonItems.FirstOrDefault();
+        }
+
+        private void RefreshComparisonFilter()
+        {
+            IEnumerable<PreviewProjectComparisonItem> query = _allComparisonItems;
+            if (_selectedFilter?.Value != null)
+            {
+                query = query.Where(item => item.State == _selectedFilter.Value.Value);
+            }
+
+            if (!string.IsNullOrWhiteSpace(_searchText))
+            {
+                query = query.Where(item => Contains(item.Key, _searchText) || Contains(item.Record, _searchText) ||
+                    Contains(item.CurrentSourceText, _searchText) || Contains(item.PreviousSourceText, _searchText) ||
+                    Contains(item.CurrentTargetText, _searchText) || Contains(item.PreviousTargetText, _searchText));
+            }
+
+            ComparisonItems = query.ToList();
+            OnPropertyChanged(nameof(ComparisonItems));
+            OnPropertyChanged(nameof(HasComparison));
+            OnPropertyChanged(nameof(ComparisonSummary));
+            OnPropertyChanged(nameof(ReusableVisibleCount));
+            RaiseCommandAvailability();
+        }
+
+        private void SetBusy(bool value)
+        {
+            _isBusy = value;
+            OnPropertyChanged(nameof(IsBusy));
+            RaiseCommandAvailability();
+        }
+
+        private void RaiseCommandAvailability()
+        {
+            ((PreviewShellCommand)CompareRevisionCommand).RaiseCanExecuteChanged();
+            ((PreviewShellCommand)ReuseSelectedCommand).RaiseCanExecuteChanged();
+            ((PreviewShellCommand)ReuseVisibleCommand).RaiseCanExecuteChanged();
+            ((PreviewShellCommand)KeepCurrentCommand).RaiseCanExecuteChanged();
+            ((PreviewShellCommand)UndoCommand).RaiseCanExecuteChanged();
+            ((PreviewShellCommand)GoToEntryCommand).RaiseCanExecuteChanged();
+            OnPropertyChanged(nameof(CanUndo));
+        }
+
+        private static PreviewComparisonFilterOption CreateFilter(
+            PreviewRevisionComparisonState? value,
+            string messageId)
+        {
+            return new PreviewComparisonFilterOption(value, PreviewMessageCatalog.Get(messageId));
+        }
+
+        private static bool Contains(string value, string search)
+        {
+            return (value ?? string.Empty).IndexOf(search, StringComparison.CurrentCultureIgnoreCase) >= 0;
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        private sealed class UpdateSnapshot
+        {
+            internal UpdateSnapshot(
+                PreviewTranslationEntry entry,
+                string targetText,
+                PreviewReviewState reviewState,
+                string reusedTargetText)
+            {
+                Entry = entry;
+                TargetText = targetText;
+                ReviewState = reviewState;
+                ReusedTargetText = reusedTargetText;
+            }
+
+            internal PreviewTranslationEntry Entry { get; private set; }
+            internal string TargetText { get; private set; }
+            internal PreviewReviewState ReviewState { get; private set; }
+            internal string ReusedTargetText { get; private set; }
+        }
+    }
+}

--- a/Phoenix_Translator/Application/PreviewProjectComparison.cs
+++ b/Phoenix_Translator/Application/PreviewProjectComparison.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Identifies how one stable project entry changed between two revisions.
+    /// </summary>
+    internal enum PreviewRevisionComparisonState
+    {
+        Unchanged,
+        Added,
+        Removed,
+        Changed,
+        Reusable,
+        Conflict
+    }
+
+    /// <summary>
+    /// Describes one stable-identity comparison result without assuming source order.
+    /// </summary>
+    internal sealed class PreviewProjectComparisonItem
+    {
+        /// <summary>
+        /// Creates a comparison item for current and previous entry versions.
+        /// </summary>
+        /// <param name="key">The stable project-local identity.</param>
+        /// <param name="state">The classified comparison state.</param>
+        /// <param name="currentEntry">The current entry, or <see langword="null"/> when removed.</param>
+        /// <param name="previousEntry">The previous entry, or <see langword="null"/> when added.</param>
+        internal PreviewProjectComparisonItem(
+            string key,
+            PreviewRevisionComparisonState state,
+            PreviewTranslationEntry currentEntry,
+            PreviewTranslationEntry previousEntry)
+        {
+            Key = key ?? throw new ArgumentNullException(nameof(key));
+            State = state;
+            CurrentEntry = currentEntry;
+            PreviousEntry = previousEntry;
+        }
+
+        /// <summary>
+        /// Gets the stable project-local identity.
+        /// </summary>
+        public string Key { get; private set; }
+
+        /// <summary>
+        /// Gets the classified revision state.
+        /// </summary>
+        public PreviewRevisionComparisonState State { get; private set; }
+
+        /// <summary>
+        /// Gets the current entry, or <see langword="null"/> when it was removed.
+        /// </summary>
+        public PreviewTranslationEntry CurrentEntry { get; private set; }
+
+        /// <summary>
+        /// Gets the previous entry, or <see langword="null"/> when it was added.
+        /// </summary>
+        public PreviewTranslationEntry PreviousEntry { get; private set; }
+
+        /// <summary>
+        /// Gets the localized comparison-state label.
+        /// </summary>
+        public string StateText => PreviewMessageCatalog.Get("Update_State_" + State);
+
+        /// <summary>
+        /// Gets the user-safe record identity available in either revision.
+        /// </summary>
+        public string Record => CurrentEntry?.Record ?? PreviousEntry?.Record ?? Key;
+
+        /// <summary>
+        /// Gets the current source text, or an empty value when removed.
+        /// </summary>
+        public string CurrentSourceText => CurrentEntry?.SourceText ?? string.Empty;
+
+        /// <summary>
+        /// Gets the previous source text, or an empty value when added.
+        /// </summary>
+        public string PreviousSourceText => PreviousEntry?.SourceText ?? string.Empty;
+
+        /// <summary>
+        /// Gets the current target text, or an empty value when removed.
+        /// </summary>
+        public string CurrentTargetText => CurrentEntry?.TargetText ?? string.Empty;
+
+        /// <summary>
+        /// Gets the previous target text, or an empty value when added.
+        /// </summary>
+        public string PreviousTargetText => PreviousEntry?.TargetText ?? string.Empty;
+
+        /// <summary>
+        /// Gets whether a prior target can be explicitly staged in the current project.
+        /// </summary>
+        public bool CanReuse => CurrentEntry != null && PreviousEntry != null &&
+            !string.IsNullOrWhiteSpace(PreviousEntry.TargetText) &&
+            (State == PreviewRevisionComparisonState.Reusable || State == PreviewRevisionComparisonState.Conflict);
+    }
+
+    /// <summary>
+    /// Compares compatible project revisions using stable entry identities.
+    /// </summary>
+    internal sealed class PreviewProjectComparisonService
+    {
+        /// <summary>
+        /// Compares current and previous entries without using their source order.
+        /// </summary>
+        /// <param name="currentEntries">The active project entries.</param>
+        /// <param name="previousEntries">The selected previous revision entries.</param>
+        /// <returns>Stable ordered comparison results.</returns>
+        internal IReadOnlyList<PreviewProjectComparisonItem> Compare(
+            IReadOnlyList<PreviewTranslationEntry> currentEntries,
+            IReadOnlyList<PreviewTranslationEntry> previousEntries)
+        {
+            if (currentEntries == null)
+            {
+                throw new ArgumentNullException(nameof(currentEntries));
+            }
+
+            if (previousEntries == null)
+            {
+                throw new ArgumentNullException(nameof(previousEntries));
+            }
+
+            var ambiguousKeys = new HashSet<string>(StringComparer.Ordinal);
+            Dictionary<string, PreviewTranslationEntry> current = IndexEntries(currentEntries, ambiguousKeys);
+            Dictionary<string, PreviewTranslationEntry> previous = IndexEntries(previousEntries, ambiguousKeys);
+            return current.Keys.Union(previous.Keys, StringComparer.Ordinal)
+                .OrderBy(key => key, StringComparer.Ordinal)
+                .Select(key => ambiguousKeys.Contains(key)
+                    ? new PreviewProjectComparisonItem(
+                        key, PreviewRevisionComparisonState.Conflict, Get(current, key), Get(previous, key))
+                    : CreateItem(key, Get(current, key), Get(previous, key)))
+                .ToList();
+        }
+
+        private static Dictionary<string, PreviewTranslationEntry> IndexEntries(
+            IEnumerable<PreviewTranslationEntry> entries,
+            ISet<string> ambiguousKeys)
+        {
+            var indexed = new Dictionary<string, PreviewTranslationEntry>(StringComparer.Ordinal);
+            foreach (PreviewTranslationEntry entry in entries)
+            {
+                if (entry == null || string.IsNullOrEmpty(entry.Key))
+                {
+                    continue;
+                }
+
+                if (indexed.ContainsKey(entry.Key))
+                {
+                    ambiguousKeys.Add(entry.Key);
+                }
+                else
+                {
+                    indexed.Add(entry.Key, entry);
+                }
+            }
+
+            return indexed;
+        }
+
+        private static PreviewTranslationEntry Get(
+            IDictionary<string, PreviewTranslationEntry> entries,
+            string key)
+        {
+            PreviewTranslationEntry entry;
+            return entries.TryGetValue(key, out entry) ? entry : null;
+        }
+
+        private static PreviewProjectComparisonItem CreateItem(
+            string key,
+            PreviewTranslationEntry current,
+            PreviewTranslationEntry previous)
+        {
+            PreviewRevisionComparisonState state;
+            if (current == null)
+            {
+                state = PreviewRevisionComparisonState.Removed;
+            }
+            else if (previous == null)
+            {
+                state = PreviewRevisionComparisonState.Added;
+            }
+            else if (string.Equals(current.SourceText, previous.SourceText, StringComparison.Ordinal))
+            {
+                if (string.Equals(current.TargetText, previous.TargetText, StringComparison.Ordinal))
+                {
+                    state = PreviewRevisionComparisonState.Unchanged;
+                }
+                else if (string.IsNullOrWhiteSpace(current.TargetText) &&
+                    !string.IsNullOrWhiteSpace(previous.TargetText))
+                {
+                    state = PreviewRevisionComparisonState.Reusable;
+                }
+                else
+                {
+                    state = PreviewRevisionComparisonState.Conflict;
+                }
+            }
+            else
+            {
+                state = string.IsNullOrWhiteSpace(current.TargetText) &&
+                    current.ReviewState == PreviewReviewState.Unreviewed
+                    ? PreviewRevisionComparisonState.Changed
+                    : PreviewRevisionComparisonState.Conflict;
+            }
+
+            return new PreviewProjectComparisonItem(key, state, current, previous);
+        }
+    }
+}

--- a/Phoenix_Translator/Application/PreviewRevisionHistoryStore.cs
+++ b/Phoenix_Translator/Application/PreviewRevisionHistoryStore.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Describes one privacy-preserving project revision event.
+    /// </summary>
+    internal sealed class PreviewRevisionHistoryEntry
+    {
+        /// <summary>
+        /// Creates an auditable entry-change event.
+        /// </summary>
+        /// <param name="timestampUtc">The UTC event time.</param>
+        /// <param name="actionId">The stable localized action identifier suffix.</param>
+        /// <param name="entryKey">The project-local affected entry identity.</param>
+        /// <param name="record">The user-safe record identity.</param>
+        /// <param name="origin">The user-safe content origin.</param>
+        /// <param name="sourceFingerprint">The source content fingerprint.</param>
+        /// <param name="targetFingerprint">The target content fingerprint.</param>
+        internal PreviewRevisionHistoryEntry(
+            DateTime timestampUtc,
+            string actionId,
+            string entryKey,
+            string record,
+            string origin,
+            string sourceFingerprint,
+            string targetFingerprint)
+        {
+            TimestampUtc = timestampUtc.Kind == DateTimeKind.Utc ? timestampUtc : timestampUtc.ToUniversalTime();
+            ActionId = actionId ?? throw new ArgumentNullException(nameof(actionId));
+            EntryKey = entryKey ?? throw new ArgumentNullException(nameof(entryKey));
+            Record = record ?? string.Empty;
+            Origin = origin ?? string.Empty;
+            SourceFingerprint = sourceFingerprint ?? string.Empty;
+            TargetFingerprint = targetFingerprint ?? string.Empty;
+        }
+
+        /// <summary>Gets the UTC time at which the event occurred.</summary>
+        public DateTime TimestampUtc { get; private set; }
+
+        /// <summary>Gets the stable localized action identifier suffix.</summary>
+        public string ActionId { get; private set; }
+
+        /// <summary>Gets the project-local entry identity.</summary>
+        public string EntryKey { get; private set; }
+
+        /// <summary>Gets the user-safe record identity.</summary>
+        public string Record { get; private set; }
+
+        /// <summary>Gets the user-safe target origin.</summary>
+        public string Origin { get; private set; }
+
+        /// <summary>Gets the source-content fingerprint.</summary>
+        public string SourceFingerprint { get; private set; }
+
+        /// <summary>Gets the target-content fingerprint.</summary>
+        public string TargetFingerprint { get; private set; }
+
+        /// <summary>Gets the localized action label.</summary>
+        public string ActionText => PreviewMessageCatalog.Get("History_Action_" + ActionId);
+
+        /// <summary>Gets the event time formatted in the current local culture.</summary>
+        public string TimestampText => TimestampUtc.ToLocalTime().ToString("g", CultureInfo.CurrentCulture);
+    }
+
+    /// <summary>
+    /// Persists bounded project history without project paths or translated content.
+    /// </summary>
+    internal sealed class PreviewRevisionHistoryStore
+    {
+        private const int MaximumEntries = 2500;
+        private const long MaximumFileBytes = 5 * 1024 * 1024;
+        private readonly string _storageDirectory;
+
+        internal PreviewRevisionHistoryStore()
+            : this(Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "PhoenixTranslator",
+                "RevisionHistory"))
+        {
+        }
+
+        internal PreviewRevisionHistoryStore(string storageDirectory)
+        {
+            _storageDirectory = storageDirectory ?? throw new ArgumentNullException(nameof(storageDirectory));
+        }
+
+        internal IReadOnlyList<PreviewRevisionHistoryEntry> Load(string projectPath)
+        {
+            string path = GetPath(projectPath);
+            if (!File.Exists(path) || new FileInfo(path).Length > MaximumFileBytes)
+            {
+                return new List<PreviewRevisionHistoryEntry>();
+            }
+
+            try
+            {
+                var settings = new XmlReaderSettings
+                {
+                    DtdProcessing = DtdProcessing.Prohibit,
+                    XmlResolver = null,
+                    MaxCharactersInDocument = MaximumFileBytes
+                };
+                using (XmlReader reader = XmlReader.Create(path, settings))
+                {
+                    XElement root = XDocument.Load(reader, LoadOptions.None).Root;
+                    if (root == null || root.Name != "history")
+                    {
+                        return new List<PreviewRevisionHistoryEntry>();
+                    }
+
+                    List<XElement> elements = root.Elements("event").ToList();
+                    return elements.Skip(Math.Max(0, elements.Count - MaximumEntries))
+                        .Select(Parse).Where(entry => entry != null)
+                        .OrderByDescending(entry => entry.TimestampUtc).ToList();
+                }
+            }
+            catch (IOException)
+            {
+                return new List<PreviewRevisionHistoryEntry>();
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return new List<PreviewRevisionHistoryEntry>();
+            }
+            catch (XmlException)
+            {
+                return new List<PreviewRevisionHistoryEntry>();
+            }
+        }
+
+        internal void Append(string projectPath, PreviewRevisionHistoryEntry entry)
+        {
+            if (entry == null)
+            {
+                throw new ArgumentNullException(nameof(entry));
+            }
+
+            var entries = Load(projectPath).Reverse().ToList();
+            entries.Add(entry);
+            if (entries.Count > MaximumEntries)
+            {
+                entries.RemoveRange(0, entries.Count - MaximumEntries);
+            }
+
+            Save(projectPath, entries);
+        }
+
+        internal static PreviewRevisionHistoryEntry Create(
+            string actionId,
+            PreviewTranslationEntry entry,
+            DateTime timestampUtc)
+        {
+            if (entry == null)
+            {
+                throw new ArgumentNullException(nameof(entry));
+            }
+
+            return new PreviewRevisionHistoryEntry(
+                timestampUtc,
+                actionId,
+                entry.Key,
+                entry.Record,
+                entry.Provenance,
+                PreviewReviewStateStore.Fingerprint(entry.SourceText),
+                PreviewReviewStateStore.Fingerprint(entry.TargetText));
+        }
+
+        private void Save(string projectPath, IEnumerable<PreviewRevisionHistoryEntry> entries)
+        {
+            Directory.CreateDirectory(_storageDirectory);
+            string path = GetPath(projectPath);
+            string temporaryPath = path + ".tmp";
+            var root = new XElement("history", new XAttribute("version", "1"),
+                entries.Select(entry => new XElement("event",
+                    new XAttribute("time", entry.TimestampUtc.ToString("o", CultureInfo.InvariantCulture)),
+                    new XAttribute("action", Limit(entry.ActionId, 64)),
+                    new XAttribute("key", Limit(entry.EntryKey, 128)),
+                    new XAttribute("record", Limit(entry.Record, 128)),
+                    new XAttribute("origin", Limit(entry.Origin, 64)),
+                    new XAttribute("source", Limit(entry.SourceFingerprint, 64)),
+                    new XAttribute("target", Limit(entry.TargetFingerprint, 64)))));
+            using (var stream = new FileStream(temporaryPath, FileMode.Create, FileAccess.Write, FileShare.None))
+            using (XmlWriter writer = XmlWriter.Create(stream, new XmlWriterSettings
+            {
+                Encoding = new UTF8Encoding(false),
+                Indent = true,
+                CloseOutput = false
+            }))
+            {
+                new XDocument(root).Save(writer);
+            }
+
+            if (File.Exists(path))
+            {
+                File.Replace(temporaryPath, path, null);
+            }
+            else
+            {
+                File.Move(temporaryPath, path);
+            }
+        }
+
+        private string GetPath(string projectPath)
+        {
+            if (string.IsNullOrWhiteSpace(projectPath))
+            {
+                throw new ArgumentException("A project path is required.", nameof(projectPath));
+            }
+
+            return Path.Combine(
+                _storageDirectory,
+                PreviewReviewStateStore.Fingerprint(Path.GetFullPath(projectPath).ToUpperInvariant()) + ".xml");
+        }
+
+        private static PreviewRevisionHistoryEntry Parse(XElement element)
+        {
+            DateTime timestamp;
+            string action = (string)element.Attribute("action");
+            string key = (string)element.Attribute("key");
+            if (!DateTime.TryParse((string)element.Attribute("time"), CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind, out timestamp) || string.IsNullOrEmpty(action) ||
+                string.IsNullOrEmpty(key) || action.Length > 128 || key.Length > 1024)
+            {
+                return null;
+            }
+
+            return new PreviewRevisionHistoryEntry(
+                timestamp,
+                action,
+                key,
+                (string)element.Attribute("record"),
+                (string)element.Attribute("origin"),
+                (string)element.Attribute("source"),
+                (string)element.Attribute("target"));
+        }
+
+        private static string Limit(string value, int maximumLength)
+        {
+            string normalized = value ?? string.Empty;
+            return normalized.Length <= maximumLength ? normalized : normalized.Substring(0, maximumLength);
+        }
+    }
+}

--- a/Phoenix_Translator/Application/PreviewShellViewModel.cs
+++ b/Phoenix_Translator/Application/PreviewShellViewModel.cs
@@ -131,6 +131,7 @@ namespace PhoenixTranslator.ApplicationLayer
                 OnPropertyChanged(nameof(CurrentDescription));
                 OnPropertyChanged(nameof(IsTranslationWorkspaceVisible));
                 OnPropertyChanged(nameof(IsReviewQualityWorkspaceVisible));
+                OnPropertyChanged(nameof(IsHistoryUpdateWorkspaceVisible));
                 OnPropertyChanged(nameof(IsPreviewFallbackVisible));
             }
         }
@@ -158,9 +159,19 @@ namespace PhoenixTranslator.ApplicationLayer
             _currentDestination == PreviewShellDestination.Quality;
 
         /// <summary>
+        /// Gets whether the history and project-update workspace owns the current page.
+        /// </summary>
+        public bool IsHistoryUpdateWorkspaceVisible =>
+            _currentDestination == PreviewShellDestination.History ||
+            _currentDestination == PreviewShellDestination.ProjectUpdate;
+
+        /// <summary>
         /// Gets whether the selected destination still uses the shared preview fallback page.
         /// </summary>
-        public bool IsPreviewFallbackVisible => !IsTranslationWorkspaceVisible && !IsReviewQualityWorkspaceVisible;
+        public bool IsPreviewFallbackVisible =>
+            !IsTranslationWorkspaceVisible &&
+            !IsReviewQualityWorkspaceVisible &&
+            !IsHistoryUpdateWorkspaceVisible;
 
         /// <summary>
         /// Gets the product version shown independently from dependency versions.

--- a/Phoenix_Translator/Application/PreviewTranslationEntry.cs
+++ b/Phoenix_Translator/Application/PreviewTranslationEntry.cs
@@ -153,6 +153,17 @@ namespace PhoenixTranslator.ApplicationLayer
         }
 
         /// <summary>
+        /// Applies a target explicitly reused from a compatible project revision.
+        /// </summary>
+        /// <param name="targetText">The prior revision target selected by the user.</param>
+        internal void ApplyReusedTarget(string targetText)
+        {
+            TargetText = targetText;
+            _provenance = "Revision";
+            OnPropertyChanged(nameof(Provenance));
+        }
+
+        /// <summary>
         /// Records a human review decision for the current target text.
         /// </summary>
         /// <param name="state">The decision to record.</param>

--- a/Phoenix_Translator/PhoenixTranslator.csproj
+++ b/Phoenix_Translator/PhoenixTranslator.csproj
@@ -111,8 +111,11 @@
     <Compile Include="Application\PreviewMessageCatalog.cs" />
     <Compile Include="Application\PreviewQualityAnalyzer.cs" />
     <Compile Include="Application\PreviewQualityFinding.cs" />
+    <Compile Include="Application\PreviewProjectComparison.cs" />
+    <Compile Include="Application\PreviewHistoryUpdateViewModel.cs" />
     <Compile Include="Application\PreviewReviewQualityViewModel.cs" />
     <Compile Include="Application\PreviewReviewStateStore.cs" />
+    <Compile Include="Application\PreviewRevisionHistoryStore.cs" />
     <Compile Include="Application\PreviewShellCommand.cs" />
     <Compile Include="Application\PreviewShellViewModel.cs" />
     <Compile Include="Application\PreviewTranslationEntry.cs" />
@@ -213,6 +216,9 @@
     </Compile>
     <Compile Include="UIManagement\Preview\PreviewReviewQualityView.xaml.cs">
       <DependentUpon>PreviewReviewQualityView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="UIManagement\Preview\PreviewHistoryUpdateView.xaml.cs">
+      <DependentUpon>PreviewHistoryUpdateView.xaml</DependentUpon>
     </Compile>
     <Compile Include="UIManagement\Preview\PreviewTranslationWorkspaceView.xaml.cs">
       <DependentUpon>PreviewTranslationWorkspaceView.xaml</DependentUpon>
@@ -337,6 +343,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="UIManagement\Preview\PreviewReviewQualityView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="UIManagement\Preview\PreviewHistoryUpdateView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Phoenix_Translator/Properties/AssemblyInfo.cs
+++ b/Phoenix_Translator/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Windows;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.0.0.9")]
-[assembly: AssemblyFileVersion("2.0.0.9")]
+[assembly: AssemblyVersion("2.0.0.10")]
+[assembly: AssemblyFileVersion("2.0.0.10")]

--- a/Phoenix_Translator/Properties/Resources.resx
+++ b/Phoenix_Translator/Properties/Resources.resx
@@ -303,4 +303,58 @@
   <data name="ReviewQuality_Shortcuts_Hint" xml:space="preserve"><value>Ctrl+Enter Approve · Ctrl+Shift+Enter Approve scope · Ctrl+Z Undo · F8 Go to entry</value><comment>Keyboard command map for review and quality assurance.</comment></data>
   <data name="Accessibility_Review_Queue_Name" xml:space="preserve"><value>Review queue</value><comment>Accessible name for the filtered review entry list.</comment></data>
   <data name="Accessibility_Quality_Findings_Name" xml:space="preserve"><value>Quality findings</value><comment>Accessible name for the normalized finding list.</comment></data>
+  <data name="Review_Provenance_Revision" xml:space="preserve"><value>Previous project revision</value><comment>Provenance label for a target explicitly reused from a compatible revision.</comment></data>
+  <data name="HistoryUpdate_Title" xml:space="preserve"><value>History and project updates</value><comment>Accessible title for the combined revision workflow.</comment></data>
+  <data name="HistoryUpdate_Empty_Title" xml:space="preserve"><value>Open a project to inspect revisions</value><comment>Empty-state heading for revision workflows.</comment></data>
+  <data name="HistoryUpdate_Empty_Hint" xml:space="preserve"><value>Project history and explicit update decisions are scoped to the active translation project.</value><comment>Empty-state guidance for revision workflows.</comment></data>
+  <data name="History_Title" xml:space="preserve"><value>Project history</value><comment>History workflow heading.</comment></data>
+  <data name="History_Description" xml:space="preserve"><value>Review privacy-preserving actions recorded for this project. Translation text and absolute paths are never stored here.</value><comment>History workflow description.</comment></data>
+  <data name="History_Timeline_Title" xml:space="preserve"><value>Revision timeline</value><comment>Heading above recorded project events.</comment></data>
+  <data name="History_Details_Title" xml:space="preserve"><value>Event details</value><comment>Heading for selected history event details.</comment></data>
+  <data name="History_Details_Action_Label" xml:space="preserve"><value>Action</value><comment>History event action label.</comment></data>
+  <data name="History_Details_Record_Label" xml:space="preserve"><value>Record</value><comment>History event record label.</comment></data>
+  <data name="History_Details_Origin_Label" xml:space="preserve"><value>Target origin</value><comment>History event provenance label.</comment></data>
+  <data name="History_Privacy_Hint" xml:space="preserve"><value>History stores stable identities and content fingerprints only. It does not store source text, target text, or project paths.</value><comment>Privacy explanation in history details.</comment></data>
+  <data name="History_OpenLegacy_Action" xml:space="preserve"><value>Open legacy history</value><comment>Opens the complete legacy history workflow.</comment></data>
+  <data name="History_Load_Failed" xml:space="preserve"><value>Project history could not be loaded. Translation content was not changed.</value><comment>Safe history load failure.</comment></data>
+  <data name="History_Save_Failed" xml:space="preserve"><value>The history event could not be recorded. Translation content remains available.</value><comment>Safe history persistence failure.</comment></data>
+  <data name="History_Action_Compared" xml:space="preserve"><value>Compared revision</value><comment>History action label for a completed comparison.</comment></data>
+  <data name="History_Action_Reused" xml:space="preserve"><value>Reused prior target</value><comment>History action label for a safe target reuse.</comment></data>
+  <data name="History_Action_ConflictResolved" xml:space="preserve"><value>Resolved conflict with prior target</value><comment>History action label for an explicit conflicting-target reuse.</comment></data>
+  <data name="History_Action_KeptCurrent" xml:space="preserve"><value>Kept current target</value><comment>History action label for retaining a current conflicting target.</comment></data>
+  <data name="History_Action_Undone" xml:space="preserve"><value>Undid revision update</value><comment>History action label for restoring the pre-update target.</comment></data>
+  <data name="Update_Filter_All" xml:space="preserve"><value>All changes</value><comment>Default project comparison filter.</comment></data>
+  <data name="Update_Filter_Name" xml:space="preserve"><value>Revision change filter</value><comment>Accessible name for the comparison state filter.</comment></data>
+  <data name="Update_State_Unchanged" xml:space="preserve"><value>Unchanged</value><comment>Revision state for identical source and target content.</comment></data>
+  <data name="Update_State_Added" xml:space="preserve"><value>Added</value><comment>Revision state for a new current entry.</comment></data>
+  <data name="Update_State_Removed" xml:space="preserve"><value>Removed</value><comment>Revision state for an entry absent from the current project.</comment></data>
+  <data name="Update_State_Changed" xml:space="preserve"><value>Source changed</value><comment>Revision state for changed source content without a reviewed current target.</comment></data>
+  <data name="Update_State_Reusable" xml:space="preserve"><value>Reusable</value><comment>Revision state for a safe prior target candidate.</comment></data>
+  <data name="Update_State_Conflict" xml:space="preserve"><value>Conflict</value><comment>Revision state requiring an explicit target decision.</comment></data>
+  <data name="Update_Search_Placeholder" xml:space="preserve"><value>Search revisions, records, source, or target</value><comment>Project comparison search hint.</comment></data>
+  <data name="Update_Compare_Action" xml:space="preserve"><value>Compare revision</value><comment>Selects and compares a previous compatible project revision.</comment></data>
+  <data name="Update_Compare_Title" xml:space="preserve"><value>Select previous project revision</value><comment>Title of the previous-revision file picker.</comment></data>
+  <data name="Update_Comparison_Progress" xml:space="preserve"><value>Comparing project revisions…</value><comment>Progress message while opening and comparing a previous revision.</comment></data>
+  <data name="Update_Comparison_Completed" xml:space="preserve"><value>Revision comparison completed. Review reuse candidates and conflicts before applying changes.</value><comment>Successful comparison notification.</comment></data>
+  <data name="Update_Comparison_Failed" xml:space="preserve"><value>The selected revision could not be compared. The current project was not changed.</value><comment>Safe comparison failure notification.</comment></data>
+  <data name="Update_Comparison_Incompatible" xml:space="preserve"><value>Select a previous revision with the same project format.</value><comment>Incompatible revision warning.</comment></data>
+  <data name="Update_Comparison_Summary" xml:space="preserve"><value>{0} added · {1} removed · {2} changed · {3} reusable · {4} conflicts</value><comment>Comparison summary. Placeholders are state counts in displayed order.</comment></data>
+  <data name="Update_PreviousSource_Label" xml:space="preserve"><value>Previous source</value><comment>Label above previous revision source text.</comment></data>
+  <data name="Update_CurrentSource_Label" xml:space="preserve"><value>Current source</value><comment>Label above current revision source text.</comment></data>
+  <data name="Update_PreviousTarget_Label" xml:space="preserve"><value>Previous target</value><comment>Label above previous revision target text.</comment></data>
+  <data name="Update_CurrentTarget_Label" xml:space="preserve"><value>Current target</value><comment>Label above current revision target text.</comment></data>
+  <data name="Update_ReuseSelected_Action" xml:space="preserve"><value>Reuse previous target</value><comment>Stages the selected prior target in the current project.</comment></data>
+  <data name="Update_ReuseVisible_Action" xml:space="preserve"><value>Reuse visible safe targets</value><comment>Stages only visible targets classified as safely reusable.</comment></data>
+  <data name="Update_KeepCurrent_Action" xml:space="preserve"><value>Keep current target</value><comment>Explicitly records retention of a conflicting current target.</comment></data>
+  <data name="Update_Undo_Action" xml:space="preserve"><value>Undo last update</value><comment>Restores entries changed by the most recent reuse action.</comment></data>
+  <data name="Update_OpenLegacy_Action" xml:space="preserve"><value>Open legacy mod update</value><comment>Opens the complete legacy project-update workflow.</comment></data>
+  <data name="Update_Conflict_ConfirmationTitle" xml:space="preserve"><value>Replace current target?</value><comment>Conflict-reuse confirmation title.</comment></data>
+  <data name="Update_Conflict_Confirmation" xml:space="preserve"><value>Reuse the previous target for {0} conflicting entry? The current target and its review decision will be replaced.</value><comment>Conflict-reuse confirmation. Placeholder: exact affected entry count.</comment></data>
+  <data name="Update_ReuseVisible_ConfirmationTitle" xml:space="preserve"><value>Reuse safe targets?</value><comment>Safe bulk-reuse confirmation title.</comment></data>
+  <data name="Update_ReuseVisible_Confirmation" xml:space="preserve"><value>Reuse previous targets for {0} visible entries? Conflicts are excluded and review decisions will be reset.</value><comment>Safe bulk-reuse confirmation. Placeholder: exact affected entry count.</comment></data>
+  <data name="Update_Reuse_Completed" xml:space="preserve"><value>Reused targets for {0} entries. Review and quality results were refreshed.</value><comment>Reuse completion notification. Placeholder: exact affected entry count.</comment></data>
+  <data name="Update_KeepCurrent_Completed" xml:space="preserve"><value>The current target was kept and recorded in project history.</value><comment>Keep-current completion notification.</comment></data>
+  <data name="Update_Undo_Completed" xml:space="preserve"><value>Restored {0} entries from before the last revision update.</value><comment>Update undo notification. Placeholder: exact restored entry count.</comment></data>
+  <data name="Accessibility_History_Timeline_Name" xml:space="preserve"><value>Project revision timeline</value><comment>Accessible name for the history event list.</comment></data>
+  <data name="Accessibility_Update_Comparison_Name" xml:space="preserve"><value>Project revision comparison</value><comment>Accessible name for the comparison result list.</comment></data>
 </root>

--- a/Phoenix_Translator/UIManagement/Preview/PreviewHistoryUpdateView.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewHistoryUpdateView.xaml
@@ -1,0 +1,282 @@
+<UserControl x:Class="PhoenixTranslator.UIManagement.Preview.PreviewHistoryUpdateView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:localization="clr-namespace:PhoenixTranslator.UIManagement.Localization"
+             AutomationProperties.Name="{localization:PreviewMessage HistoryUpdate_Title}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Themes/PreviewControlStyles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <BooleanToVisibilityConverter x:Key="BooleanToVisibility" />
+            <Style x:Key="HistoryPanel" TargetType="Border">
+                <Setter Property="Background" Value="{StaticResource PreviewBrushSurfacePrimary}" />
+                <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushBorder}" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="CornerRadius" Value="5" />
+            </Style>
+            <Style x:Key="HistoryListItem" TargetType="ListBoxItem">
+                <Setter Property="Padding" Value="10,8" />
+                <Setter Property="Margin" Value="3,2" />
+                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextSecondary}" />
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="FocusVisualStyle" Value="{StaticResource PreviewFocusVisual}" />
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True">
+                        <Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceInteractive}" />
+                    </Trigger>
+                    <Trigger Property="IsSelected" Value="True">
+                        <Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceInteractive}" />
+                        <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
+                        <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushAccentGold}" />
+                        <Setter Property="BorderThickness" Value="3,0,0,0" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+            <Style x:Key="HistoryComboBox" TargetType="ComboBox">
+                <Setter Property="MinHeight" Value="32" />
+                <Setter Property="Padding" Value="8,3" />
+                <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
+                <Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceCanvas}" />
+                <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushBorder}" />
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <UserControl.InputBindings>
+        <KeyBinding Modifiers="Control" Key="O" Command="{Binding OpenProjectCommand}" />
+        <KeyBinding Modifiers="Control+Shift" Key="O" Command="{Binding CompareRevisionCommand}" />
+        <KeyBinding Modifiers="Control" Key="Enter" Command="{Binding ReuseSelectedCommand}" />
+        <KeyBinding Modifiers="Control+Shift" Key="Enter" Command="{Binding ReuseVisibleCommand}" />
+        <KeyBinding Modifiers="Control" Key="Z" Command="{Binding UndoCommand}" />
+        <KeyBinding Key="F8" Command="{Binding GoToEntryCommand}" />
+    </UserControl.InputBindings>
+
+    <Grid>
+        <Grid Visibility="{Binding IsHistoryMode, Converter={StaticResource BooleanToVisibility}}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="12" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Border Padding="14,11" Style="{StaticResource HistoryPanel}">
+                <DockPanel>
+                    <Button DockPanel.Dock="Right" Style="{StaticResource PreviewButtonSecondary}"
+                            Command="{Binding OpenLegacyWorkspaceCommand}"
+                            Content="{localization:PreviewMessage History_OpenLegacy_Action}" />
+                    <StackPanel>
+                        <TextBlock FontSize="16" FontWeight="SemiBold" Foreground="{StaticResource PreviewBrushTextPrimary}"
+                                   Text="{localization:PreviewMessage History_Title}" />
+                        <TextBlock Margin="0,4,12,0" Foreground="{StaticResource PreviewBrushTextSecondary}"
+                                   Text="{localization:PreviewMessage History_Description}" TextWrapping="Wrap" />
+                    </StackPanel>
+                </DockPanel>
+            </Border>
+            <Grid Grid.Row="2" Visibility="{Binding HasProject, Converter={StaticResource BooleanToVisibility}}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="360" />
+                    <ColumnDefinition Width="12" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Border Style="{StaticResource HistoryPanel}">
+                    <DockPanel>
+                        <TextBlock DockPanel.Dock="Top" Margin="14,11" FontWeight="SemiBold"
+                                   Foreground="{StaticResource PreviewBrushTextPrimary}"
+                                   Text="{localization:PreviewMessage History_Timeline_Title}" />
+                        <ListBox ItemsSource="{Binding HistoryEntries}" SelectedItem="{Binding SelectedHistoryEntry}"
+                                 ItemContainerStyle="{StaticResource HistoryListItem}" Background="Transparent"
+                                 BorderThickness="0" VirtualizingPanel.IsVirtualizing="True"
+                                 VirtualizingPanel.VirtualizationMode="Recycling"
+                                 AutomationProperties.Name="{localization:PreviewMessage Accessibility_History_Timeline_Name}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel>
+                                        <DockPanel>
+                                            <TextBlock DockPanel.Dock="Right" Margin="10,0,0,0" FontSize="11"
+                                                       Foreground="{StaticResource PreviewBrushTextMuted}" Text="{Binding TimestampText}" />
+                                            <TextBlock FontWeight="SemiBold" Foreground="{StaticResource PreviewBrushTextPrimary}"
+                                                       Text="{Binding ActionText}" />
+                                        </DockPanel>
+                                        <TextBlock Margin="0,4,0,0" Text="{Binding Record}" TextTrimming="CharacterEllipsis" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </DockPanel>
+                </Border>
+                <Border Grid.Column="2" Padding="20" Style="{StaticResource HistoryPanel}">
+                    <StackPanel>
+                        <TextBlock FontSize="16" FontWeight="SemiBold" Foreground="{StaticResource PreviewBrushTextPrimary}"
+                                   Text="{localization:PreviewMessage History_Details_Title}" />
+                        <TextBlock Margin="0,20,0,4" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                   Text="{localization:PreviewMessage History_Details_Action_Label}" />
+                        <TextBlock Foreground="{StaticResource PreviewBrushTextPrimary}" Text="{Binding SelectedHistoryEntry.ActionText}" />
+                        <TextBlock Margin="0,14,0,4" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                   Text="{localization:PreviewMessage History_Details_Record_Label}" />
+                        <TextBlock Foreground="{StaticResource PreviewBrushTextPrimary}" Text="{Binding SelectedHistoryEntry.Record}" />
+                        <TextBlock Margin="0,14,0,4" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                   Text="{localization:PreviewMessage History_Details_Origin_Label}" />
+                        <TextBlock Foreground="{StaticResource PreviewBrushTextPrimary}" Text="{Binding SelectedHistoryEntry.Origin}" />
+                        <TextBlock Margin="0,24,0,0" Foreground="{StaticResource PreviewBrushTextSecondary}"
+                                   Text="{localization:PreviewMessage History_Privacy_Hint}" TextWrapping="Wrap" />
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Grid>
+
+        <Grid Visibility="{Binding IsProjectUpdateMode, Converter={StaticResource BooleanToVisibility}}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="12" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Border Padding="10" Style="{StaticResource HistoryPanel}">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="2*" />
+                        <ColumnDefinition Width="10" />
+                        <ColumnDefinition Width="180" />
+                        <ColumnDefinition Width="10" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBox Style="{StaticResource PreviewTextBox}" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                             ToolTip="{localization:PreviewMessage Update_Search_Placeholder}"
+                             AutomationProperties.Name="{localization:PreviewMessage Update_Search_Placeholder}" />
+                    <ComboBox Grid.Column="2" Style="{StaticResource HistoryComboBox}" ItemsSource="{Binding Filters}"
+                              SelectedItem="{Binding SelectedFilter}"
+                              AutomationProperties.Name="{localization:PreviewMessage Update_Filter_Name}" />
+                    <StackPanel Grid.Column="4" Orientation="Horizontal">
+                        <Button Margin="0,0,8,0" Style="{StaticResource PreviewButtonSecondary}"
+                                Command="{Binding OpenProjectCommand}" Content="{localization:PreviewMessage Workspace_Open_Action}" />
+                        <Button Style="{StaticResource PreviewButtonPrimary}" Command="{Binding CompareRevisionCommand}"
+                                Content="{localization:PreviewMessage Update_Compare_Action}" />
+                    </StackPanel>
+                </Grid>
+            </Border>
+            <Grid Grid.Row="2" Visibility="{Binding HasComparison, Converter={StaticResource BooleanToVisibility}}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="310" />
+                    <ColumnDefinition Width="12" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Border Style="{StaticResource HistoryPanel}">
+                    <DockPanel>
+                        <StackPanel DockPanel.Dock="Top" Margin="12,10">
+                            <TextBlock FontWeight="SemiBold" Foreground="{StaticResource PreviewBrushTextPrimary}"
+                                       Text="{Binding PreviousRevisionName}" />
+                            <TextBlock Margin="0,4,0,0" FontSize="11" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                       Text="{Binding ComparisonSummary}" TextWrapping="Wrap" />
+                        </StackPanel>
+                        <ListBox ItemsSource="{Binding ComparisonItems}" SelectedItem="{Binding SelectedComparisonItem}"
+                                 ItemContainerStyle="{StaticResource HistoryListItem}" Background="Transparent" BorderThickness="0"
+                                 VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling"
+                                 AutomationProperties.Name="{localization:PreviewMessage Accessibility_Update_Comparison_Name}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel>
+                                        <DockPanel>
+                                            <TextBlock DockPanel.Dock="Right" Margin="8,0,0,0" FontSize="11"
+                                                       Foreground="{StaticResource PreviewBrushAccentGold}" Text="{Binding StateText}" />
+                                            <TextBlock FontWeight="SemiBold" Text="{Binding Record}" TextTrimming="CharacterEllipsis" />
+                                        </DockPanel>
+                                        <TextBlock Margin="0,4,0,0" FontSize="11" Text="{Binding CurrentSourceText}"
+                                                   TextTrimming="CharacterEllipsis" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </DockPanel>
+                </Border>
+                <Border Grid.Column="2" Padding="16" Style="{StaticResource HistoryPanel}">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="12" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="12" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <DockPanel>
+                            <TextBlock DockPanel.Dock="Right" Foreground="{StaticResource PreviewBrushAccentGold}"
+                                       Text="{Binding SelectedComparisonItem.StateText}" />
+                            <TextBlock FontSize="16" FontWeight="SemiBold" Foreground="{StaticResource PreviewBrushTextPrimary}"
+                                       Text="{Binding SelectedComparisonItem.Record}" />
+                        </DockPanel>
+                        <Grid Grid.Row="2">
+                            <Grid.ColumnDefinitions><ColumnDefinition /><ColumnDefinition Width="12" /><ColumnDefinition /></Grid.ColumnDefinitions>
+                            <StackPanel>
+                                <TextBlock Margin="0,0,0,5" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                           Text="{localization:PreviewMessage Update_PreviousSource_Label}" />
+                                <TextBox Style="{StaticResource PreviewTextBox}" IsReadOnly="True" AcceptsReturn="True"
+                                         VerticalScrollBarVisibility="Auto" TextWrapping="Wrap"
+                                         Text="{Binding SelectedComparisonItem.PreviousSourceText}" />
+                            </StackPanel>
+                            <StackPanel Grid.Column="2">
+                                <TextBlock Margin="0,0,0,5" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                           Text="{localization:PreviewMessage Update_CurrentSource_Label}" />
+                                <TextBox Style="{StaticResource PreviewTextBox}" IsReadOnly="True" AcceptsReturn="True"
+                                         VerticalScrollBarVisibility="Auto" TextWrapping="Wrap"
+                                         Text="{Binding SelectedComparisonItem.CurrentSourceText}" />
+                            </StackPanel>
+                        </Grid>
+                        <Grid Grid.Row="4">
+                            <Grid.ColumnDefinitions><ColumnDefinition /><ColumnDefinition Width="12" /><ColumnDefinition /></Grid.ColumnDefinitions>
+                            <StackPanel>
+                                <TextBlock Margin="0,0,0,5" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                           Text="{localization:PreviewMessage Update_PreviousTarget_Label}" />
+                                <TextBox Style="{StaticResource PreviewTextBox}" IsReadOnly="True" AcceptsReturn="True"
+                                         VerticalScrollBarVisibility="Auto" TextWrapping="Wrap"
+                                         Text="{Binding SelectedComparisonItem.PreviousTargetText}" />
+                            </StackPanel>
+                            <StackPanel Grid.Column="2">
+                                <TextBlock Margin="0,0,0,5" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                           Text="{localization:PreviewMessage Update_CurrentTarget_Label}" />
+                                <TextBox Style="{StaticResource PreviewTextBox}" IsReadOnly="True" AcceptsReturn="True"
+                                         VerticalScrollBarVisibility="Auto" TextWrapping="Wrap"
+                                         Text="{Binding SelectedComparisonItem.CurrentTargetText}" />
+                            </StackPanel>
+                        </Grid>
+                        <StackPanel Grid.Row="5" Margin="0,14,0,0" Orientation="Horizontal">
+                            <Button Margin="0,0,8,0" Style="{StaticResource PreviewButtonPrimary}"
+                                    Command="{Binding ReuseSelectedCommand}" Content="{localization:PreviewMessage Update_ReuseSelected_Action}" />
+                            <Button Margin="0,0,8,0" Style="{StaticResource PreviewButtonSecondary}"
+                                    Command="{Binding KeepCurrentCommand}" Content="{localization:PreviewMessage Update_KeepCurrent_Action}" />
+                            <Button Style="{StaticResource PreviewButtonSecondary}" Command="{Binding GoToEntryCommand}"
+                                    Content="{localization:PreviewMessage Quality_GoToEntry_Action}" />
+                        </StackPanel>
+                    </Grid>
+                </Border>
+            </Grid>
+            <StackPanel Grid.Row="3" Margin="0,12,0,0" Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Margin="0,0,8,0" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding OpenLegacyWorkspaceCommand}"
+                        Content="{localization:PreviewMessage Update_OpenLegacy_Action}" />
+                <Button Margin="0,0,8,0" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding UndoCommand}"
+                        Content="{localization:PreviewMessage Update_Undo_Action}" />
+                <Button Style="{StaticResource PreviewButtonPrimary}" Command="{Binding ReuseVisibleCommand}"
+                        Content="{localization:PreviewMessage Update_ReuseVisible_Action}" />
+            </StackPanel>
+        </Grid>
+
+        <Border Padding="28" HorizontalAlignment="Center" VerticalAlignment="Center">
+            <Border.Style>
+                <Style TargetType="Border" BasedOn="{StaticResource HistoryPanel}">
+                    <Setter Property="Visibility" Value="Collapsed" />
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding HasProject}" Value="False"><Setter Property="Visibility" Value="Visible" /></DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Border.Style>
+            <StackPanel MaxWidth="460">
+                <TextBlock HorizontalAlignment="Center" FontSize="18" FontWeight="SemiBold"
+                           Foreground="{StaticResource PreviewBrushTextPrimary}" Text="{localization:PreviewMessage HistoryUpdate_Empty_Title}" />
+                <TextBlock Margin="0,8,0,18" TextAlignment="Center" TextWrapping="Wrap"
+                           Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{localization:PreviewMessage HistoryUpdate_Empty_Hint}" />
+                <Button HorizontalAlignment="Center" Style="{StaticResource PreviewButtonPrimary}"
+                        Command="{Binding OpenProjectCommand}" Content="{localization:PreviewMessage Workspace_Open_Action}" />
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/Phoenix_Translator/UIManagement/Preview/PreviewHistoryUpdateView.xaml.cs
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewHistoryUpdateView.xaml.cs
@@ -1,0 +1,18 @@
+using System.Windows.Controls;
+
+namespace PhoenixTranslator.UIManagement.Preview
+{
+    /// <summary>
+    /// Presents revision history and explicit project-update decisions.
+    /// </summary>
+    public partial class PreviewHistoryUpdateView : UserControl
+    {
+        /// <summary>
+        /// Creates the combined history and project-update view.
+        /// </summary>
+        public PreviewHistoryUpdateView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml
@@ -197,6 +197,10 @@
                         Visibility="{Binding DataContext.IsReviewQualityWorkspaceVisible,
                             RelativeSource={RelativeSource AncestorType={x:Type Window}},
                             Converter={StaticResource BooleanToVisibility}}" />
+                <preview:PreviewHistoryUpdateView x:Name="HistoryUpdateWorkspace" Grid.Row="2"
+                        Visibility="{Binding DataContext.IsHistoryUpdateWorkspaceVisible,
+                            RelativeSource={RelativeSource AncestorType={x:Type Window}},
+                            Converter={StaticResource BooleanToVisibility}}" />
             </Grid>
         </Grid>
 

--- a/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml.cs
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml.cs
@@ -14,6 +14,7 @@ namespace PhoenixTranslator.UIManagement.Preview
         private PhoenixGui _legacyWorkspace;
         private readonly PreviewTranslationWorkspaceViewModel _translationWorkspaceViewModel;
         private readonly PreviewReviewQualityViewModel _reviewQualityViewModel;
+        private readonly PreviewHistoryUpdateViewModel _historyUpdateViewModel;
 
         /// <summary>
         /// Creates the preview application shell in its no-project state.
@@ -34,9 +35,20 @@ namespace PhoenixTranslator.UIManagement.Preview
                 new PreviewReviewStateStore(),
                 ConfirmBulkApproval,
                 OpenLegacyWorkspace);
+            _historyUpdateViewModel = new PreviewHistoryUpdateViewModel(
+                shellViewModel,
+                _translationWorkspaceViewModel,
+                new PreviewProjectComparisonService(),
+                new PreviewRevisionHistoryStore(),
+                SelectPreviousRevision,
+                PreviewTranslationProject.Open,
+                ConfirmConflictReuse,
+                ConfirmBulkReuse,
+                OpenLegacyWorkspace);
             DataContext = shellViewModel;
             TranslationWorkspace.DataContext = _translationWorkspaceViewModel;
             ReviewQualityWorkspace.DataContext = _reviewQualityViewModel;
+            HistoryUpdateWorkspace.DataContext = _historyUpdateViewModel;
         }
 
         private bool ConfirmBulkApproval(int entryCount)
@@ -60,6 +72,40 @@ namespace PhoenixTranslator.UIManagement.Preview
                 Multiselect = false
             };
             return dialog.ShowDialog() == true ? dialog.FileName : string.Empty;
+        }
+
+        private static string SelectPreviousRevision()
+        {
+            var dialog = new OpenFileDialog
+            {
+                Title = PreviewMessageCatalog.Get("Update_Compare_Title"),
+                Filter = PreviewMessageCatalog.Get("Workspace_Project_Filter"),
+                CheckFileExists = true,
+                Multiselect = false
+            };
+            return dialog.ShowDialog() == true ? dialog.FileName : string.Empty;
+        }
+
+        private bool ConfirmConflictReuse(int entryCount)
+        {
+            return MessageBox.Show(
+                this,
+                PreviewMessageCatalog.Format("Update_Conflict_Confirmation", entryCount),
+                PreviewMessageCatalog.Get("Update_Conflict_ConfirmationTitle"),
+                MessageBoxButton.OKCancel,
+                MessageBoxImage.Warning,
+                MessageBoxResult.Cancel) == MessageBoxResult.OK;
+        }
+
+        private bool ConfirmBulkReuse(int entryCount)
+        {
+            return MessageBox.Show(
+                this,
+                PreviewMessageCatalog.Format("Update_ReuseVisible_Confirmation", entryCount),
+                PreviewMessageCatalog.Get("Update_ReuseVisible_ConfirmationTitle"),
+                MessageBoxButton.OKCancel,
+                MessageBoxImage.Information,
+                MessageBoxResult.Cancel) == MessageBoxResult.OK;
         }
 
         private void OpenLegacyWorkspace()
@@ -87,6 +133,7 @@ namespace PhoenixTranslator.UIManagement.Preview
 
         private void Window_Closing(object sender, CancelEventArgs e)
         {
+            _historyUpdateViewModel.Dispose();
             _reviewQualityViewModel.Dispose();
             _translationWorkspaceViewModel.Dispose();
             DeFine.CloseAny();

--- a/docs/history-project-update/README.md
+++ b/docs/history-project-update/README.md
@@ -1,0 +1,51 @@
+# Preview history and project updates
+
+The preview combines project history and revision comparison around the active normalized translation project.
+`History` presents privacy-preserving events. `Project update` compares a selected prior revision with the current
+project and stages only explicit reuse decisions. The complete legacy history and mod-update tools remain
+available as workflow-specific fallbacks.
+
+## Revision identity and classification
+
+Comparison uses project-local stable keys and never assumes that source order is stable. Duplicate keys in either
+revision are treated as conflicts instead of being silently discarded. Results use six explicit states:
+
+- `Unchanged`: source and target are equal.
+- `Added`: the key exists only in the current revision.
+- `Removed`: the key exists only in the previous revision.
+- `Source changed`: source content changed and the current entry has no reviewed target.
+- `Reusable`: source content is unchanged, the current target is empty, and the previous target is available.
+- `Conflict`: populated targets differ, reviewed work could be affected, or identity is ambiguous.
+
+Only `Reusable` entries participate in visible-scope reuse. A conflicting prior target remains available for an
+individual decision, but replacing the current target requires a warning confirmation. Reuse invalidates the
+entry's previous review decision, marks its provenance as `Previous project revision`, and immediately flows into
+the existing review and quality analysis.
+
+## Reversibility and persistence
+
+The most recent single or visible-scope reuse can be undone before another reuse action or project change. Undo
+restores the staged target and human review state. Project content is persisted only through the existing Save
+command and format writer.
+
+Revision events are stored per user under local application data. The project path is converted to a SHA-256 file
+identity. Stored XML is bounded to 2,500 recent events and 5 MiB and contains only timestamps, stable action IDs,
+bounded project-local identities, safe record metadata, provenance, and SHA-256 content fingerprints. It contains
+no absolute project path, source text, or target text. DTD processing is prohibited when history is loaded.
+
+## Keyboard paths
+
+- `Ctrl+5`: open History.
+- `Ctrl+6`: open Project update.
+- `Ctrl+O`: open the current project.
+- `Ctrl+Shift+O`: select and compare a previous revision.
+- `Ctrl+Enter`: reuse the selected prior target after any required conflict confirmation.
+- `Ctrl+Shift+Enter`: reuse visible safe candidates after confirming the exact count.
+- `Ctrl+Z`: undo the most recent reuse action.
+- `F8`: reveal the selected current entry in Translate.
+
+## Validation
+
+Deterministic tests cover identical, additive, subtractive, changed, reusable, conflicting, reordered, and
+duplicate-identity comparisons. They also verify that classification never changes a reviewed target, explicit
+reuse resets review state, and persisted history contains neither project paths nor translation content.


### PR DESCRIPTION
Closes #32

## Summary

- add dedicated History and Project update preview destinations with legacy fallbacks
- compare compatible revisions by stable entry identity and classify added, removed, changed, reusable, unchanged, ambiguous, and conflicting entries
- require explicit confirmation before replacing a conflicting current target and exclude conflicts from bulk reuse
- make the latest reuse action reversible and feed reused targets back into review and quality state
- persist a bounded privacy-preserving event timeline without project paths or translation content
- document the workflow, keyboard paths, identity model, and persistence boundary
- update the application version to 2.0.0.10

## Validation

- Release x64 solution rebuild with Visual Studio 2022 MSBuild
- 25 deterministic preset tests passed
- no new compiler warnings; six existing legacy warnings remain
- verified the application starts and responds as version 2.0.0.10