### PR TITLE
Redesign settings around user intent

### DIFF
--- a/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
+++ b/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
@@ -74,6 +74,12 @@
     <Compile Include="..\Phoenix_Translator\Application\PreviewRevisionHistoryStore.cs">
       <Link>PreviewRevisionHistoryStore.cs</Link>
     </Compile>
+    <Compile Include="..\Phoenix_Translator\Application\PreviewSettingsModel.cs">
+      <Link>PreviewSettingsModel.cs</Link>
+    </Compile>
+    <Compile Include="..\Phoenix_Translator\Application\PreviewSettingsViewModel.cs">
+      <Link>PreviewSettingsViewModel.cs</Link>
+    </Compile>
     <Compile Include="..\Phoenix_Translator\Application\PreviewShellCommand.cs">
       <Link>PreviewShellCommand.cs</Link>
     </Compile>

--- a/PhoenixTranslator.PresetTests/Program.cs
+++ b/PhoenixTranslator.PresetTests/Program.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Resources;
 using System.Security.Cryptography;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
 using PhoenixTranslator.ApplicationLayer;
@@ -44,7 +46,13 @@ namespace PhoenixTranslator.PresetTests
                 { nameof(ClassifiesProjectRevisionChanges), ClassifiesProjectRevisionChanges },
                 { nameof(PreservesReviewedTargetsAsConflicts), PreservesReviewedTargetsAsConflicts },
                 { nameof(PersistsPrivateRevisionHistory), PersistsPrivateRevisionHistory },
-                { nameof(AppliesAndUndoesExplicitRevisionReuse), AppliesAndUndoesExplicitRevisionReuse }
+                { nameof(AppliesAndUndoesExplicitRevisionReuse), AppliesAndUndoesExplicitRevisionReuse },
+                { nameof(StagesAndCancelsUnifiedSettings), StagesAndCancelsUnifiedSettings },
+                { nameof(ValidatesAndAppliesUnifiedSettings), ValidatesAndAppliesUnifiedSettings },
+                { nameof(SearchesSettingsByLegacyTerminology), SearchesSettingsByLegacyTerminology },
+                { nameof(ProtectsSettingsSecrets), ProtectsSettingsSecrets },
+                { nameof(TestsProviderWithoutSavingSettings), TestsProviderWithoutSavingSettings },
+                { nameof(ClearsStagedCredentialWhenProviderChanges), ClearsStagedCredentialWhenProviderChanges }
             };
             int failures = 0;
             foreach (KeyValuePair<string, Action> test in tests)
@@ -836,6 +844,134 @@ namespace PhoenixTranslator.PresetTests
             }
         }
 
+        private static void StagesAndCancelsUnifiedSettings()
+        {
+            var store = new RecordingPreviewSettingsStore();
+            var shell = new PreviewShellViewModel(() => { });
+            var settings = new PreviewSettingsViewModel(shell, store, () => true, () => true, () => { });
+
+            settings.Settings.ContextLimitText = "500";
+            AssertEqual(true, settings.IsModified,
+                "Editing one centralized setting must stage a modified state.");
+            AssertEqual(0, store.SaveCalls,
+                "Editing staged settings must not persist through legacy immediate-save handlers.");
+
+            settings.CancelCommand.Execute(null);
+            AssertEqual("200", settings.Settings.ContextLimitText,
+                "Cancel must restore the complete loaded snapshot.");
+            AssertEqual(false, settings.IsModified,
+                "Cancel must restore the clean state.");
+            AssertEqual(0, store.SaveCalls,
+                "Cancel must not persist any staged value.");
+            settings.Dispose();
+        }
+
+        private static void ValidatesAndAppliesUnifiedSettings()
+        {
+            var store = new RecordingPreviewSettingsStore();
+            var shell = new PreviewShellViewModel(() => { });
+            var settings = new PreviewSettingsViewModel(shell, store, () => true, () => true, () => { });
+
+            settings.Settings.MaxThreadCountText = "0";
+            AssertEqual(true, settings.HasValidationErrors,
+                "An invalid worker limit must be explained before persistence.");
+            settings.ApplyCommand.Execute(null);
+            AssertEqual(0, store.SaveCalls,
+                "Invalid settings must never reach persistence.");
+
+            settings.Settings.MaxThreadCountText = "4";
+            settings.Settings.EnableGlobalSearch = true;
+            settings.ApplyCommand.Execute(null);
+            AssertEqual(1, store.SaveCalls,
+                "One explicit Apply action must persist the complete valid snapshot exactly once.");
+            AssertEqual(true, store.Current.EnableGlobalSearch,
+                "Apply must persist staged values through the central store boundary.");
+            AssertEqual(false, settings.IsModified,
+                "Successful Apply must establish a new clean baseline.");
+            settings.Dispose();
+        }
+
+        private static void SearchesSettingsByLegacyTerminology()
+        {
+            var store = new RecordingPreviewSettingsStore();
+            var shell = new PreviewShellViewModel(() => { });
+            var settings = new PreviewSettingsViewModel(shell, store, () => true, () => true, () => { });
+
+            settings.SearchText = "node";
+            AssertEqual(1, settings.VisibleCategories.Count,
+                "Legacy provider-node terminology must resolve to one central category.");
+            AssertEqual(PreviewSettingsCategory.Providers, settings.VisibleCategories[0].Value,
+                "Provider nodes must resolve to Providers instead of another settings window.");
+
+            settings.SearchText = "dictionary";
+            AssertEqual(PreviewSettingsCategory.HistoryAndData, settings.VisibleCategories.Single().Value,
+                "Legacy dictionary terminology must route to History and data.");
+            settings.Dispose();
+        }
+
+        private static void ProtectsSettingsSecrets()
+        {
+            var store = new RecordingPreviewSettingsStore();
+            var shell = new PreviewShellViewModel(() => { });
+            var settings = new PreviewSettingsViewModel(shell, store, () => true, () => true, () => { });
+            const string secret = "private-provider-secret";
+
+            settings.StageProviderCredential(secret);
+            AssertEqual(false, settings.Settings.GetType().GetProperties()
+                    .Any(property => string.Equals(property.GetValue(settings.Settings) as string, secret, StringComparison.Ordinal)),
+                "A staged credential must not be exposed through bindable settings properties.");
+            AssertEqual(false, settings.ValidationMessages.Any(message => message.Contains(secret)),
+                "Validation output must never contain a staged credential.");
+
+            settings.Settings.EnableGlobalSearch = true;
+            settings.ApplyCommand.Execute(null);
+            AssertEqual(secret, store.LastProviderCredential,
+                "The write-only store boundary must receive the explicitly staged credential.");
+            AssertEqual(false, settings.Settings.GetType().GetProperties()
+                    .Any(property => string.Equals(property.GetValue(settings.Settings) as string, secret, StringComparison.Ordinal)),
+                "Reloaded settings must expose only credential presence, never its value.");
+            settings.Dispose();
+        }
+
+        private static void TestsProviderWithoutSavingSettings()
+        {
+            var store = new RecordingPreviewSettingsStore();
+            var shell = new PreviewShellViewModel(() => { });
+            var settings = new PreviewSettingsViewModel(shell, store, () => true, () => true, () => { });
+            const string secret = "staged-test-secret";
+
+            settings.StageProviderCredential(secret);
+            settings.TestProviderCommand.Execute(null);
+
+            AssertEqual(1, store.TestCalls,
+                "An explicit provider test must cross the connectivity boundary once.");
+            AssertEqual(0, store.SaveCalls,
+                "Testing staged provider settings must not persist them.");
+            AssertEqual(secret, store.LastTestCredential,
+                "The connectivity boundary must receive a staged credential without exposing it to binding.");
+            AssertEqual(PreviewMessageCatalog.Get("Settings_Providers_Test_Succeeded"), settings.ProviderTestStatusText,
+                "A successful provider test must produce a sanitized status.");
+            settings.Dispose();
+        }
+
+        private static void ClearsStagedCredentialWhenProviderChanges()
+        {
+            var store = new RecordingPreviewSettingsStore();
+            var shell = new PreviewShellViewModel(() => { });
+            var settings = new PreviewSettingsViewModel(shell, store, () => true, () => true, () => { });
+
+            settings.StageProviderCredential("credential-for-first-provider");
+            settings.SelectedProvider = settings.ProviderOptions[1];
+            settings.TestProviderCommand.Execute(null);
+
+            AssertEqual(0, store.TestCalls,
+                "A staged credential must not follow the user to another provider configuration.");
+            AssertEqual(true, settings.ProviderTestStatusText.Contains(
+                    PreviewMessageCatalog.Get("Settings_Validation_CredentialRequired")),
+                "The newly selected provider must require its own credential.");
+            settings.Dispose();
+        }
+
         private static TranslationPresetCoordinator CreateCoordinator(RecordingStore store)
         {
             return new TranslationPresetCoordinator(new TranslationPresetService(), store);
@@ -930,6 +1066,86 @@ namespace PhoenixTranslator.PresetTests
 
             public void Dispose()
             {
+            }
+        }
+
+        private sealed class RecordingPreviewSettingsStore : IPreviewSettingsStore
+        {
+            internal RecordingPreviewSettingsStore()
+            {
+                Current = new PreviewSettingsSnapshot
+                {
+                    ProviderKey = 1,
+                    ProviderModel = "test-model",
+                    ProviderEnabled = false,
+                    HasStoredCredential = true,
+                    LocalPortText = "1234",
+                    SourceLanguage = "English",
+                    TargetLanguage = "English",
+                    EnableLanguageDetection = true,
+                    EnableContext = true,
+                    ContextLimitText = "200",
+                    PlaceholderPattern = "<(.*?)>,",
+                    GenerateCSharp = true,
+                    UiLanguage = "English",
+                    Density = "Compact",
+                    MaxThreadCountText = "2",
+                    ThrottleRatioText = "0.7",
+                    ThrottleDelayText = "200"
+                };
+            }
+
+            internal PreviewSettingsSnapshot Current { get; private set; }
+            internal int SaveCalls { get; private set; }
+            internal int TestCalls { get; private set; }
+            internal string LastProviderCredential { get; private set; }
+            internal string LastTestCredential { get; private set; }
+
+            public IReadOnlyList<PreviewProviderOption> GetProviders()
+            {
+                return new[]
+                {
+                    new PreviewProviderOption(1, "Test provider", false, true, true, new[] { "test-model" }),
+                    new PreviewProviderOption(2, "Second provider", false, false, true, new[] { "other-model" })
+                };
+            }
+
+            public IReadOnlyList<string> GetLanguages()
+            {
+                return new[] { "English", "German" };
+            }
+
+            public PreviewSettingsSnapshot Load()
+            {
+                return Current.Clone();
+            }
+
+            public void Save(PreviewSettingsSnapshot settings, string providerCredential, string proxyPassword)
+            {
+                SaveCalls++;
+                Current = settings.Clone();
+                if (!string.IsNullOrWhiteSpace(providerCredential))
+                {
+                    LastProviderCredential = providerCredential;
+                    Current.HasStoredCredential = true;
+                }
+
+                if (!string.IsNullOrWhiteSpace(proxyPassword))
+                {
+                    Current.HasStoredProxyPassword = true;
+                }
+            }
+
+            public Task<PreviewProviderTestResult> TestProviderAsync(
+                PreviewSettingsSnapshot settings,
+                string providerCredential,
+                string proxyPassword,
+                CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                TestCalls++;
+                LastTestCredential = providerCredential;
+                return Task.FromResult(new PreviewProviderTestResult(PreviewProviderTestStatus.Succeeded));
             }
         }
     }

--- a/Phoenix_Translator/Application/LegacyPreviewSettingsStore.cs
+++ b/Phoenix_Translator/Application/LegacyPreviewSettingsStore.cs
@@ -1,0 +1,426 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using PhoenixEngine;
+using PhoenixEngine.Language;
+using PhoenixEngine.Platform;
+using PhoenixEngine.Translate;
+using PhoenixTranslator.UIManage;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Adapts the existing engine and local configuration to staged Settings Center persistence.
+    /// </summary>
+    internal sealed class LegacyPreviewSettingsStore : IPreviewSettingsStore
+    {
+        /// <inheritdoc />
+        public IReadOnlyList<PreviewProviderOption> GetProviders()
+        {
+            if (Phoenix.Config?.PlatformConfigs == null)
+            {
+                return new List<PreviewProviderOption>();
+            }
+
+            return Phoenix.Config.PlatformConfigs
+                .OrderBy(pair => GetProviderName(pair.Key, pair.Value), StringComparer.CurrentCultureIgnoreCase)
+                .Select(pair => new PreviewProviderOption(
+                    pair.Key,
+                    GetProviderName(pair.Key, pair.Value),
+                    pair.Value.Platform == PlatformType.LMLocalAI ||
+                    pair.Value.CustomInFo?.Type == CustomPlatformType.LocalAI,
+                    pair.Value.ApiKeys?.Any(key => !string.IsNullOrWhiteSpace(key)) == true,
+                    pair.Value.CustomInFo == null && pair.Value.Platform != PlatformType.HumanTranslation,
+                    GetModels(pair.Value)))
+                .ToList();
+        }
+
+        /// <inheritdoc />
+        public IReadOnlyList<string> GetLanguages()
+        {
+            return Enum.GetNames(typeof(Languages))
+                .Where(name => !string.Equals(name, Languages.Null.ToString(), StringComparison.Ordinal))
+                .ToList();
+        }
+
+        /// <inheritdoc />
+        public PreviewSettingsSnapshot Load()
+        {
+            if (Phoenix.Config == null)
+            {
+                throw new InvalidOperationException("Engine configuration is not initialized.");
+            }
+
+            List<PreviewProviderOption> providers = GetProviders().ToList();
+            int providerKey = SelectProviderKey(providers);
+            PlatformConfig provider = GetProvider(providerKey);
+            return new PreviewSettingsSnapshot
+            {
+                ProviderKey = providerKey,
+                ProviderModel = provider?.Model ?? string.Empty,
+                ProviderEnabled = provider?.Enable == true,
+                HasStoredCredential = provider?.ApiKeys?.Any(key => !string.IsNullOrWhiteSpace(key)) == true,
+                LocalPortText = (provider?.LocalPort > 0 ? provider.LocalPort : 1234)
+                    .ToString(CultureInfo.InvariantCulture),
+                SourceLanguage = DeFine.GlobalLocalSetting.SourceLanguage.ToString(),
+                TargetLanguage = DeFine.GlobalLocalSetting.TargetLanguage.ToString(),
+                EnableLanguageDetection = DeFine.GlobalLocalSetting.EnableLanguageDetect,
+                EnableContext = Phoenix.Config.ContextEnable,
+                ContextLimitText = Phoenix.Config.ContextLimit.ToString(CultureInfo.InvariantCulture),
+                AdditionalPrompt = Phoenix.Config.UserCustomAIPrompt ?? string.Empty,
+                PlaceholderPattern = DeFine.GlobalLocalSetting.P_Placeholders ?? string.Empty,
+                GamePath = DeFine.GlobalLocalSetting.SkyrimPath ?? string.Empty,
+                ShowAssembly = DeFine.GlobalLocalSetting.ShowAssembly,
+                GenerateCSharp = DeFine.GlobalLocalSetting.GenCSharp,
+                AutoUpdateDatabase = DeFine.GlobalLocalSetting.AutoUpdateStringsFileToDatabase,
+                EnableGlobalSearch = Phoenix.Config.EnableGlobalSearch,
+                UiLanguage = DeFine.GlobalLocalSetting.CurrentUILanguage.ToString(),
+                Density = string.IsNullOrWhiteSpace(DeFine.GlobalLocalSetting.UiDensity)
+                    ? "Compact"
+                    : DeFine.GlobalLocalSetting.UiDensity,
+                RightToLeft = DeFine.GlobalLocalSetting.TextDisplay == TextLayout.RTL,
+                ProxyUrl = Phoenix.Config.ProxyUrl ?? string.Empty,
+                ProxyUserName = Phoenix.Config.ProxyUserName ?? string.Empty,
+                HasStoredProxyPassword = !string.IsNullOrEmpty(Phoenix.Config.ProxyPassword),
+                MaxThreadCountText = Phoenix.Config.MaxThreadCount.ToString(CultureInfo.InvariantCulture),
+                ThrottleRatioText = Phoenix.Config.ThrottleRatio.ToString(CultureInfo.InvariantCulture),
+                ThrottleDelayText = Phoenix.Config.ThrottleDelayMs.ToString(CultureInfo.InvariantCulture)
+            };
+        }
+
+        /// <inheritdoc />
+        public void Save(PreviewSettingsSnapshot settings, string providerCredential, string proxyPassword)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            PlatformConfig provider = GetProvider(settings.ProviderKey);
+            if (provider != null)
+            {
+                provider.Model = settings.ProviderModel;
+                provider.Enable = settings.ProviderEnabled;
+                int localPort;
+                if (int.TryParse(settings.LocalPortText, NumberStyles.None, CultureInfo.InvariantCulture, out localPort))
+                {
+                    provider.LocalPort = localPort;
+                }
+
+                if (!string.IsNullOrWhiteSpace(providerCredential) &&
+                    !provider.ApiKeys.Contains(providerCredential))
+                {
+                    provider.ApiKeys.Add(providerCredential);
+                    Phoenix.ReSetKeyData();
+                }
+            }
+
+            Languages language;
+            if (Enum.TryParse(settings.SourceLanguage, out language))
+            {
+                DeFine.GlobalLocalSetting.SourceLanguage = language;
+            }
+
+            if (Enum.TryParse(settings.TargetLanguage, out language))
+            {
+                DeFine.GlobalLocalSetting.TargetLanguage = language;
+            }
+
+            if (Enum.TryParse(settings.UiLanguage, out language))
+            {
+                DeFine.GlobalLocalSetting.CurrentUILanguage = language;
+            }
+
+            DeFine.GlobalLocalSetting.EnableLanguageDetect = settings.EnableLanguageDetection;
+            DeFine.GlobalLocalSetting.P_Placeholders = settings.PlaceholderPattern;
+            DeFine.GlobalLocalSetting.SkyrimPath = settings.GamePath;
+            DeFine.GlobalLocalSetting.ShowAssembly = settings.ShowAssembly;
+            DeFine.GlobalLocalSetting.GenCSharp = settings.GenerateCSharp;
+            DeFine.GlobalLocalSetting.AutoUpdateStringsFileToDatabase = settings.AutoUpdateDatabase;
+            DeFine.GlobalLocalSetting.UiDensity = settings.Density;
+            DeFine.GlobalLocalSetting.TextDisplay = settings.RightToLeft ? TextLayout.RTL : TextLayout.LTR;
+
+            Phoenix.Config.ContextEnable = settings.EnableContext;
+            Phoenix.Config.ContextLimit = int.Parse(settings.ContextLimitText, CultureInfo.InvariantCulture);
+            Phoenix.Config.UserCustomAIPrompt = settings.AdditionalPrompt.Trim();
+            Phoenix.Config.EnableGlobalSearch = settings.EnableGlobalSearch;
+            Phoenix.Config.ProxyUrl = settings.ProxyUrl.Trim();
+            Phoenix.Config.ProxyUserName = settings.ProxyUserName.Trim();
+            if (!string.IsNullOrEmpty(proxyPassword))
+            {
+                Phoenix.Config.ProxyPassword = proxyPassword;
+            }
+
+            Phoenix.Config.MaxThreadCount = int.Parse(settings.MaxThreadCountText, CultureInfo.InvariantCulture);
+            Phoenix.Config.ThrottleRatio = double.Parse(settings.ThrottleRatioText, CultureInfo.InvariantCulture);
+            Phoenix.Config.ThrottleDelayMs = int.Parse(settings.ThrottleDelayText, CultureInfo.InvariantCulture);
+            DeFine.GlobalLocalSetting.SaveConfig();
+        }
+
+        /// <inheritdoc />
+        public async Task<PreviewProviderTestResult> TestProviderAsync(
+            PreviewSettingsSnapshot settings,
+            string providerCredential,
+            string proxyPassword,
+            CancellationToken cancellationToken)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            PlatformConfig provider = GetProvider(settings.ProviderKey);
+            if (provider == null || provider.CustomInFo != null ||
+                provider.Platform == PlatformType.HumanTranslation)
+            {
+                return new PreviewProviderTestResult(PreviewProviderTestStatus.Unsupported);
+            }
+
+            string credential = string.IsNullOrWhiteSpace(providerCredential)
+                ? provider.ApiKeys?.FirstOrDefault(key => !string.IsNullOrWhiteSpace(key)) ?? string.Empty
+                : providerCredential;
+            if (provider.Platform != PlatformType.LMLocalAI && string.IsNullOrWhiteSpace(credential))
+            {
+                return new PreviewProviderTestResult(PreviewProviderTestStatus.AuthenticationFailed);
+            }
+
+            HttpRequestMessage providerRequest;
+            try
+            {
+                providerRequest = CreateProviderTestRequest(provider, settings, credential);
+            }
+            catch (FormatException)
+            {
+                return new PreviewProviderTestResult(PreviewProviderTestStatus.AuthenticationFailed);
+            }
+
+            using (HttpRequestMessage request = providerRequest)
+            {
+                if (request == null)
+                {
+                    return new PreviewProviderTestResult(PreviewProviderTestStatus.Unsupported);
+                }
+
+                try
+                {
+                    using (HttpClientHandler handler = CreateHttpHandler(
+                        provider.Platform == PlatformType.LMLocalAI,
+                        settings,
+                        proxyPassword))
+                    using (var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(10) })
+                    using (HttpResponseMessage response = await client.SendAsync(
+                        request,
+                        HttpCompletionOption.ResponseHeadersRead,
+                        cancellationToken).ConfigureAwait(false))
+                    {
+                        if (response.IsSuccessStatusCode)
+                        {
+                            return new PreviewProviderTestResult(PreviewProviderTestStatus.Succeeded);
+                        }
+
+                        if (response.StatusCode == HttpStatusCode.Unauthorized ||
+                            response.StatusCode == HttpStatusCode.Forbidden)
+                        {
+                            return new PreviewProviderTestResult(PreviewProviderTestStatus.AuthenticationFailed);
+                        }
+
+                        return new PreviewProviderTestResult(PreviewProviderTestStatus.Rejected);
+                    }
+                }
+                catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
+                {
+                    return new PreviewProviderTestResult(PreviewProviderTestStatus.TimedOut);
+                }
+                catch (HttpRequestException)
+                {
+                    return new PreviewProviderTestResult(PreviewProviderTestStatus.Unreachable);
+                }
+                catch (WebException)
+                {
+                    return new PreviewProviderTestResult(PreviewProviderTestStatus.Unreachable);
+                }
+                catch (FormatException)
+                {
+                    return new PreviewProviderTestResult(PreviewProviderTestStatus.Rejected);
+                }
+            }
+        }
+
+        private static HttpRequestMessage CreateProviderTestRequest(
+            PlatformConfig provider,
+            PreviewSettingsSnapshot settings,
+            string credential)
+        {
+            HttpRequestMessage request;
+            switch (provider.Platform)
+            {
+                case PlatformType.ChatGpt:
+                    request = new HttpRequestMessage(HttpMethod.Get, "https://api.openai.com/v1/models");
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", credential);
+                    break;
+                case PlatformType.DeepSeek:
+                    request = new HttpRequestMessage(HttpMethod.Get, "https://api.deepseek.com/models");
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", credential);
+                    break;
+                case PlatformType.Gemini:
+                    request = new HttpRequestMessage(
+                        HttpMethod.Get,
+                        "https://generativelanguage.googleapis.com/v1beta/models");
+                    request.Headers.Add("x-goog-api-key", credential);
+                    break;
+                case PlatformType.DeepL:
+                    request = new HttpRequestMessage(
+                        HttpMethod.Get,
+                        provider.IsFree
+                            ? "https://api-free.deepl.com/v2/usage"
+                            : "https://api.deepl.com/v2/usage");
+                    request.Headers.Authorization = new AuthenticationHeaderValue("DeepL-Auth-Key", credential);
+                    break;
+                case PlatformType.LMLocalAI:
+                    int port;
+                    if (!int.TryParse(settings.LocalPortText, NumberStyles.None, CultureInfo.InvariantCulture, out port) ||
+                        port < 1 || port > 65535)
+                    {
+                        return null;
+                    }
+
+                    request = new HttpRequestMessage(
+                        HttpMethod.Get,
+                        string.Format(CultureInfo.InvariantCulture, "http://localhost:{0}/v1/models", port));
+                    break;
+                default:
+                    return null;
+            }
+
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            return request;
+        }
+
+        private static HttpClientHandler CreateHttpHandler(
+            bool isLocal,
+            PreviewSettingsSnapshot settings,
+            string stagedProxyPassword)
+        {
+            var handler = new HttpClientHandler();
+            if (isLocal)
+            {
+                handler.UseProxy = false;
+                return handler;
+            }
+
+            if (string.IsNullOrWhiteSpace(settings.ProxyUrl))
+            {
+                return handler;
+            }
+
+            var proxy = new WebProxy(new Uri(settings.ProxyUrl, UriKind.Absolute));
+            string password = string.IsNullOrEmpty(stagedProxyPassword)
+                ? Phoenix.Config?.ProxyPassword ?? string.Empty
+                : stagedProxyPassword;
+            if (!string.IsNullOrWhiteSpace(settings.ProxyUserName) || !string.IsNullOrEmpty(password))
+            {
+                proxy.Credentials = new NetworkCredential(settings.ProxyUserName, password);
+            }
+
+            handler.Proxy = proxy;
+            handler.UseProxy = true;
+            return handler;
+        }
+
+        private static int SelectProviderKey(IReadOnlyList<PreviewProviderOption> providers)
+        {
+            if (providers.Count == 0)
+            {
+                return 0;
+            }
+
+            PreviewProviderOption enabled = providers.FirstOrDefault(option => GetProvider(option.Key)?.Enable == true);
+            PreviewProviderOption chatGpt = providers.FirstOrDefault(option =>
+                GetProvider(option.Key)?.Platform == PlatformType.ChatGpt);
+            return (enabled ?? chatGpt ?? providers[0]).Key;
+        }
+
+        private static PlatformConfig GetProvider(int key)
+        {
+            if (Phoenix.Config?.PlatformConfigs == null)
+            {
+                return null;
+            }
+
+            PlatformConfig provider;
+            return Phoenix.Config.PlatformConfigs.TryGetValue(key, out provider) ? provider : null;
+        }
+
+        private static string GetProviderName(int key, PlatformConfig provider)
+        {
+            if (!string.IsNullOrWhiteSpace(provider?.CustomInFo?.Name))
+            {
+                return provider.CustomInFo.Name;
+            }
+
+            switch (provider?.Platform)
+            {
+                case PlatformType.ChatGpt:
+                    return "ChatGPT";
+                case PlatformType.DeepSeek:
+                    return "DeepSeek";
+                case PlatformType.Gemini:
+                    return "Gemini";
+                case PlatformType.DeepL:
+                    return "DeepL";
+                case PlatformType.LMLocalAI:
+                    return "LM Studio";
+                case PlatformType.HumanTranslation:
+                    return "Interactive translation";
+                default:
+                    return string.Format(CultureInfo.InvariantCulture, "Provider {0}", key);
+            }
+        }
+
+        private static IReadOnlyList<string> GetModels(PlatformConfig provider)
+        {
+            var models = new List<string>();
+            if (!string.IsNullOrWhiteSpace(provider?.Model))
+            {
+                models.Add(provider.Model);
+            }
+
+            if (provider?.CustomInFo != null)
+            {
+                return models;
+            }
+
+            switch (provider?.Platform)
+            {
+                case PlatformType.ChatGpt:
+                    AddDistinct(models, "gpt-5-nano", "gpt-5-mini", "gpt-4.1-nano", "gpt-4.1-mini", "gpt-4o-mini");
+                    break;
+                case PlatformType.Gemini:
+                    AddDistinct(models, "gemini-2.5-flash", "gemini-2.0-flash");
+                    break;
+                case PlatformType.DeepSeek:
+                    AddDistinct(models, "deepseek-v4-pro");
+                    break;
+            }
+
+            return models;
+        }
+
+        private static void AddDistinct(ICollection<string> target, params string[] values)
+        {
+            foreach (string value in values)
+            {
+                if (!target.Contains(value))
+                {
+                    target.Add(value);
+                }
+            }
+        }
+    }
+}

--- a/Phoenix_Translator/Application/PreviewSettingsModel.cs
+++ b/Phoenix_Translator/Application/PreviewSettingsModel.cs
@@ -1,0 +1,377 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Identifies one intent-oriented Settings Center category.
+    /// </summary>
+    internal enum PreviewSettingsCategory
+    {
+        General,
+        Providers,
+        Translation,
+        FilesAndFormats,
+        HistoryAndData,
+        AppearanceAndAccessibility,
+        Advanced
+    }
+
+    /// <summary>
+    /// Describes one searchable Settings Center category.
+    /// </summary>
+    internal sealed class PreviewSettingsCategoryOption
+    {
+        internal PreviewSettingsCategoryOption(
+            PreviewSettingsCategory value,
+            string label,
+            string description,
+            string searchTerms)
+        {
+            Value = value;
+            Label = label ?? throw new ArgumentNullException(nameof(label));
+            Description = description ?? string.Empty;
+            SearchTerms = searchTerms ?? string.Empty;
+        }
+
+        /// <summary>Gets the category identity.</summary>
+        public PreviewSettingsCategory Value { get; private set; }
+
+        /// <summary>Gets the localized category label.</summary>
+        public string Label { get; private set; }
+
+        /// <summary>Gets the localized category description.</summary>
+        public string Description { get; private set; }
+
+        /// <summary>Gets non-visible search terms including legacy terminology.</summary>
+        public string SearchTerms { get; private set; }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return Label;
+        }
+    }
+
+    /// <summary>
+    /// Describes one configurable translation provider without exposing credentials.
+    /// </summary>
+    internal sealed class PreviewProviderOption
+    {
+        internal PreviewProviderOption(
+            int key,
+            string name,
+            bool isLocal,
+            bool hasStoredCredential,
+            bool supportsConnectivityTest,
+            IReadOnlyList<string> models)
+        {
+            Key = key;
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            IsLocal = isLocal;
+            HasStoredCredential = hasStoredCredential;
+            SupportsConnectivityTest = supportsConnectivityTest;
+            Models = models ?? new List<string>();
+        }
+
+        /// <summary>Gets the engine configuration key.</summary>
+        public int Key { get; private set; }
+
+        /// <summary>Gets the safe provider display name.</summary>
+        public string Name { get; private set; }
+
+        /// <summary>Gets whether the provider uses a local endpoint.</summary>
+        public bool IsLocal { get; private set; }
+
+        /// <summary>Gets whether this provider has a stored credential without exposing its value.</summary>
+        public bool HasStoredCredential { get; private set; }
+
+        /// <summary>Gets whether the central Settings Center can safely test this provider.</summary>
+        public bool SupportsConnectivityTest { get; private set; }
+
+        /// <summary>Gets the provider's configured model candidates.</summary>
+        public IReadOnlyList<string> Models { get; private set; }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return Name;
+        }
+    }
+
+    /// <summary>
+    /// Identifies a sanitized provider connectivity outcome without carrying response content.
+    /// </summary>
+    internal enum PreviewProviderTestStatus
+    {
+        Succeeded,
+        AuthenticationFailed,
+        Unreachable,
+        TimedOut,
+        Rejected,
+        Unsupported
+    }
+
+    /// <summary>
+    /// Carries a sanitized provider connectivity outcome across the settings boundary.
+    /// </summary>
+    internal sealed class PreviewProviderTestResult
+    {
+        internal PreviewProviderTestResult(PreviewProviderTestStatus status)
+        {
+            Status = status;
+        }
+
+        /// <summary>Gets the sanitized outcome classification.</summary>
+        public PreviewProviderTestStatus Status { get; private set; }
+    }
+
+    /// <summary>
+    /// Holds one editable settings snapshot independently from WPF controls and persistence.
+    /// </summary>
+    internal sealed class PreviewSettingsSnapshot : INotifyPropertyChanged
+    {
+        private int _providerKey;
+        private string _providerModel = string.Empty;
+        private bool _providerEnabled;
+        private bool _hasStoredCredential;
+        private string _localPortText = "1234";
+        private string _sourceLanguage = "English";
+        private string _targetLanguage = "English";
+        private bool _enableLanguageDetection = true;
+        private bool _enableContext = true;
+        private string _contextLimitText = "200";
+        private string _additionalPrompt = string.Empty;
+        private string _placeholderPattern = "<(.*?)>,";
+        private string _gamePath = string.Empty;
+        private bool _showAssembly;
+        private bool _generateCSharp = true;
+        private bool _autoUpdateDatabase;
+        private bool _enableGlobalSearch;
+        private string _uiLanguage = "English";
+        private string _density = "Compact";
+        private bool _rightToLeft;
+        private string _proxyUrl = string.Empty;
+        private string _proxyUserName = string.Empty;
+        private bool _hasStoredProxyPassword;
+        private string _maxThreadCountText = "2";
+        private string _throttleRatioText = "0.7";
+        private string _throttleDelayText = "200";
+
+        /// <inheritdoc />
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>Gets or sets the selected engine provider key.</summary>
+        public int ProviderKey { get => _providerKey; set => Set(ref _providerKey, value); }
+
+        /// <summary>Gets or sets the selected provider model.</summary>
+        public string ProviderModel { get => _providerModel; set => Set(ref _providerModel, value ?? string.Empty); }
+
+        /// <summary>Gets or sets whether the selected provider is enabled.</summary>
+        public bool ProviderEnabled { get => _providerEnabled; set => Set(ref _providerEnabled, value); }
+
+        /// <summary>Gets or sets whether a credential is already stored without exposing its value.</summary>
+        public bool HasStoredCredential { get => _hasStoredCredential; set => Set(ref _hasStoredCredential, value); }
+
+        /// <summary>Gets or sets the local-provider port as staged text.</summary>
+        public string LocalPortText { get => _localPortText; set => Set(ref _localPortText, value ?? string.Empty); }
+
+        /// <summary>Gets or sets the default source-language name.</summary>
+        public string SourceLanguage { get => _sourceLanguage; set => Set(ref _sourceLanguage, value ?? string.Empty); }
+
+        /// <summary>Gets or sets the default target-language name.</summary>
+        public string TargetLanguage { get => _targetLanguage; set => Set(ref _targetLanguage, value ?? string.Empty); }
+
+        /// <summary>Gets or sets whether automatic source-language detection is enabled.</summary>
+        public bool EnableLanguageDetection { get => _enableLanguageDetection; set => Set(ref _enableLanguageDetection, value); }
+
+        /// <summary>Gets or sets whether contextual translation is enabled.</summary>
+        public bool EnableContext { get => _enableContext; set => Set(ref _enableContext, value); }
+
+        /// <summary>Gets or sets the context character limit as staged text.</summary>
+        public string ContextLimitText { get => _contextLimitText; set => Set(ref _contextLimitText, value ?? string.Empty); }
+
+        /// <summary>Gets or sets the optional additional provider prompt.</summary>
+        public string AdditionalPrompt { get => _additionalPrompt; set => Set(ref _additionalPrompt, value ?? string.Empty); }
+
+        /// <summary>Gets or sets the protected-placeholder regular expression.</summary>
+        public string PlaceholderPattern { get => _placeholderPattern; set => Set(ref _placeholderPattern, value ?? string.Empty); }
+
+        /// <summary>Gets or sets the configured game path.</summary>
+        public string GamePath { get => _gamePath; set => Set(ref _gamePath, value ?? string.Empty); }
+
+        /// <summary>Gets or sets whether PEX assembly is visible.</summary>
+        public bool ShowAssembly { get => _showAssembly; set => Set(ref _showAssembly, value); }
+
+        /// <summary>Gets or sets whether PEX output uses C# instead of Papyrus.</summary>
+        public bool GenerateCSharp { get => _generateCSharp; set => Set(ref _generateCSharp, value); }
+
+        /// <summary>Gets or sets whether imported strings update the database automatically.</summary>
+        public bool AutoUpdateDatabase { get => _autoUpdateDatabase; set => Set(ref _autoUpdateDatabase, value); }
+
+        /// <summary>Gets or sets whether translation memory searches across projects.</summary>
+        public bool EnableGlobalSearch { get => _enableGlobalSearch; set => Set(ref _enableGlobalSearch, value); }
+
+        /// <summary>Gets or sets the application interface language name.</summary>
+        public string UiLanguage { get => _uiLanguage; set => Set(ref _uiLanguage, value ?? string.Empty); }
+
+        /// <summary>Gets or sets the compact or comfortable density name.</summary>
+        public string Density { get => _density; set => Set(ref _density, value ?? string.Empty); }
+
+        /// <summary>Gets or sets whether target editors use right-to-left layout.</summary>
+        public bool RightToLeft { get => _rightToLeft; set => Set(ref _rightToLeft, value); }
+
+        /// <summary>Gets or sets the optional HTTP or HTTPS proxy address.</summary>
+        public string ProxyUrl { get => _proxyUrl; set => Set(ref _proxyUrl, value ?? string.Empty); }
+
+        /// <summary>Gets or sets the proxy user name.</summary>
+        public string ProxyUserName { get => _proxyUserName; set => Set(ref _proxyUserName, value ?? string.Empty); }
+
+        /// <summary>Gets or sets whether a proxy password is stored without exposing its value.</summary>
+        public bool HasStoredProxyPassword
+        {
+            get => _hasStoredProxyPassword;
+            set => Set(ref _hasStoredProxyPassword, value);
+        }
+
+        /// <summary>Gets or sets the worker limit as staged text.</summary>
+        public string MaxThreadCountText
+        {
+            get => _maxThreadCountText;
+            set => Set(ref _maxThreadCountText, value ?? string.Empty);
+        }
+
+        /// <summary>Gets or sets the throttling ratio as staged text.</summary>
+        public string ThrottleRatioText
+        {
+            get => _throttleRatioText;
+            set => Set(ref _throttleRatioText, value ?? string.Empty);
+        }
+
+        /// <summary>Gets or sets the throttling delay in milliseconds as staged text.</summary>
+        public string ThrottleDelayText
+        {
+            get => _throttleDelayText;
+            set => Set(ref _throttleDelayText, value ?? string.Empty);
+        }
+
+        /// <summary>Creates a detached copy for staged editing or comparison.</summary>
+        /// <returns>A snapshot with the same non-secret values.</returns>
+        internal PreviewSettingsSnapshot Clone()
+        {
+            return new PreviewSettingsSnapshot
+            {
+                ProviderKey = ProviderKey,
+                ProviderModel = ProviderModel,
+                ProviderEnabled = ProviderEnabled,
+                HasStoredCredential = HasStoredCredential,
+                LocalPortText = LocalPortText,
+                SourceLanguage = SourceLanguage,
+                TargetLanguage = TargetLanguage,
+                EnableLanguageDetection = EnableLanguageDetection,
+                EnableContext = EnableContext,
+                ContextLimitText = ContextLimitText,
+                AdditionalPrompt = AdditionalPrompt,
+                PlaceholderPattern = PlaceholderPattern,
+                GamePath = GamePath,
+                ShowAssembly = ShowAssembly,
+                GenerateCSharp = GenerateCSharp,
+                AutoUpdateDatabase = AutoUpdateDatabase,
+                EnableGlobalSearch = EnableGlobalSearch,
+                UiLanguage = UiLanguage,
+                Density = Density,
+                RightToLeft = RightToLeft,
+                ProxyUrl = ProxyUrl,
+                ProxyUserName = ProxyUserName,
+                HasStoredProxyPassword = HasStoredProxyPassword,
+                MaxThreadCountText = MaxThreadCountText,
+                ThrottleRatioText = ThrottleRatioText,
+                ThrottleDelayText = ThrottleDelayText
+            };
+        }
+
+        /// <summary>Compares every staged non-secret value with another snapshot.</summary>
+        /// <param name="other">The snapshot to compare.</param>
+        /// <returns><see langword="true"/> when every value is equal.</returns>
+        internal bool HasSameValues(PreviewSettingsSnapshot other)
+        {
+            return other != null &&
+                ProviderKey == other.ProviderKey &&
+                ProviderModel == other.ProviderModel &&
+                ProviderEnabled == other.ProviderEnabled &&
+                HasStoredCredential == other.HasStoredCredential &&
+                LocalPortText == other.LocalPortText &&
+                SourceLanguage == other.SourceLanguage &&
+                TargetLanguage == other.TargetLanguage &&
+                EnableLanguageDetection == other.EnableLanguageDetection &&
+                EnableContext == other.EnableContext &&
+                ContextLimitText == other.ContextLimitText &&
+                AdditionalPrompt == other.AdditionalPrompt &&
+                PlaceholderPattern == other.PlaceholderPattern &&
+                GamePath == other.GamePath &&
+                ShowAssembly == other.ShowAssembly &&
+                GenerateCSharp == other.GenerateCSharp &&
+                AutoUpdateDatabase == other.AutoUpdateDatabase &&
+                EnableGlobalSearch == other.EnableGlobalSearch &&
+                UiLanguage == other.UiLanguage &&
+                Density == other.Density &&
+                RightToLeft == other.RightToLeft &&
+                ProxyUrl == other.ProxyUrl &&
+                ProxyUserName == other.ProxyUserName &&
+                HasStoredProxyPassword == other.HasStoredProxyPassword &&
+                MaxThreadCountText == other.MaxThreadCountText &&
+                ThrottleRatioText == other.ThrottleRatioText &&
+                ThrottleDelayText == other.ThrottleDelayText;
+        }
+
+        private void Set<T>(ref T field, T value, [CallerMemberName] string propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+            {
+                return;
+            }
+
+            field = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+
+    /// <summary>
+    /// Defines the persistence boundary used by the staged Settings Center.
+    /// </summary>
+    internal interface IPreviewSettingsStore
+    {
+        /// <summary>Gets safe provider choices without credential values.</summary>
+        IReadOnlyList<PreviewProviderOption> GetProviders();
+
+        /// <summary>Gets supported language names without UI dependencies.</summary>
+        IReadOnlyList<string> GetLanguages();
+
+        /// <summary>Loads a detached non-secret settings snapshot.</summary>
+        PreviewSettingsSnapshot Load();
+
+        /// <summary>Persists one validated snapshot and optional write-only credential replacements.</summary>
+        /// <param name="settings">The validated staged settings.</param>
+        /// <param name="providerCredential">The optional new provider credential.</param>
+        /// <param name="proxyPassword">The optional new proxy password.</param>
+        void Save(PreviewSettingsSnapshot settings, string providerCredential, string proxyPassword);
+
+        /// <summary>
+        /// Tests staged provider connectivity without persisting settings or sending translation content.
+        /// </summary>
+        /// <param name="settings">The staged non-secret provider and proxy settings.</param>
+        /// <param name="providerCredential">The optional write-only staged provider credential.</param>
+        /// <param name="proxyPassword">The optional write-only staged proxy password.</param>
+        /// <param name="cancellationToken">Cancels the bounded connectivity request.</param>
+        /// <returns>A sanitized result that excludes response content, endpoints, and credentials.</returns>
+        Task<PreviewProviderTestResult> TestProviderAsync(
+            PreviewSettingsSnapshot settings,
+            string providerCredential,
+            string proxyPassword,
+            CancellationToken cancellationToken);
+    }
+}

--- a/Phoenix_Translator/Application/PreviewSettingsViewModel.cs
+++ b/Phoenix_Translator/Application/PreviewSettingsViewModel.cs
@@ -1,0 +1,803 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Owns the searchable staged Settings Center, validation, and explicit persistence actions.
+    /// </summary>
+    internal sealed class PreviewSettingsViewModel : INotifyPropertyChanged, IDisposable
+    {
+        private readonly PreviewShellViewModel _shell;
+        private readonly IPreviewSettingsStore _store;
+        private readonly Func<bool> _confirmReset;
+        private readonly Func<bool> _confirmDiscard;
+        private readonly Action _openLegacyWorkspace;
+        private PreviewSettingsSnapshot _baseline;
+        private PreviewSettingsSnapshot _settings;
+        private PreviewSettingsCategoryOption _selectedCategory;
+        private PreviewProviderOption _selectedProvider;
+        private string _searchText;
+        private string _pendingProviderCredential;
+        private string _pendingProxyPassword;
+        private string _providerTestStatusText;
+        private CancellationTokenSource _providerTestCancellation;
+        private bool _restoringNavigation;
+
+        /// <summary>
+        /// Creates a staged Settings Center coordinator over the legacy persistence boundary.
+        /// </summary>
+        /// <param name="shell">The shell used for safe operation and notification status.</param>
+        /// <param name="store">The settings persistence and provider-test boundary.</param>
+        /// <param name="confirmReset">Confirms replacing staged values with defaults.</param>
+        /// <param name="confirmDiscard">Confirms discarding unsaved values.</param>
+        /// <param name="openLegacyWorkspace">Opens the explicit legacy fallback.</param>
+        internal PreviewSettingsViewModel(
+            PreviewShellViewModel shell,
+            IPreviewSettingsStore store,
+            Func<bool> confirmReset,
+            Func<bool> confirmDiscard,
+            Action openLegacyWorkspace)
+        {
+            _shell = shell ?? throw new ArgumentNullException(nameof(shell));
+            _store = store ?? throw new ArgumentNullException(nameof(store));
+            _confirmReset = confirmReset ?? throw new ArgumentNullException(nameof(confirmReset));
+            _confirmDiscard = confirmDiscard ?? throw new ArgumentNullException(nameof(confirmDiscard));
+            _openLegacyWorkspace = openLegacyWorkspace ?? throw new ArgumentNullException(nameof(openLegacyWorkspace));
+            _searchText = string.Empty;
+            _pendingProviderCredential = string.Empty;
+            _pendingProxyPassword = string.Empty;
+            _providerTestStatusText = string.Empty;
+
+            Categories = CreateCategories();
+            VisibleCategories = Categories;
+            _selectedCategory = Categories[0];
+            ProviderOptions = _store.GetProviders();
+            LanguageOptions = _store.GetLanguages();
+            DensityOptions = new[] { "Compact", "Comfortable" };
+            ValidationMessages = new List<string>();
+
+            SelectCategoryCommand = new PreviewShellCommand(SelectCategory);
+            ApplyCommand = new PreviewShellCommand(parameter => Apply(), parameter => CanApply);
+            CancelCommand = new PreviewShellCommand(parameter => Cancel(), parameter => IsModified);
+            ResetCommand = new PreviewShellCommand(parameter => Reset(), parameter => !IsBusy && !IsTestingProvider);
+            TestProviderCommand = new PreviewShellCommand(
+                async parameter => await TestProviderAsync(),
+                parameter => CanTestProvider);
+            CancelProviderTestCommand = new PreviewShellCommand(
+                parameter => CancelProviderTest(),
+                parameter => IsTestingProvider);
+            OpenLegacyWorkspaceCommand = new PreviewShellCommand(parameter => _openLegacyWorkspace());
+
+            _shell.PropertyChanged += ShellPropertyChanged;
+            Reload();
+        }
+
+        /// <inheritdoc />
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Occurs when write-only credential controls must clear their in-memory values.
+        /// </summary>
+        internal event EventHandler SecretsCleared;
+
+        /// <summary>
+        /// Occurs when the provider credential control must clear after provider selection changes.
+        /// </summary>
+        internal event EventHandler ProviderCredentialCleared;
+
+        /// <summary>Gets the complete stable category list.</summary>
+        public IReadOnlyList<PreviewSettingsCategoryOption> Categories { get; private set; }
+
+        /// <summary>Gets categories matching the current global search.</summary>
+        public IReadOnlyList<PreviewSettingsCategoryOption> VisibleCategories { get; private set; }
+
+        /// <summary>Gets safe provider choices.</summary>
+        public IReadOnlyList<PreviewProviderOption> ProviderOptions { get; private set; }
+
+        /// <summary>Gets model candidates for the selected provider.</summary>
+        public IReadOnlyList<string> ModelOptions => SelectedProvider?.Models ?? new List<string>();
+
+        /// <summary>Gets supported language names.</summary>
+        public IReadOnlyList<string> LanguageOptions { get; private set; }
+
+        /// <summary>Gets supported density preference names.</summary>
+        public IReadOnlyList<string> DensityOptions { get; private set; }
+
+        /// <summary>Gets actionable validation messages for staged values.</summary>
+        public IReadOnlyList<string> ValidationMessages { get; private set; }
+
+        /// <summary>Gets the staged non-secret settings.</summary>
+        public PreviewSettingsSnapshot Settings => _settings;
+
+        /// <summary>Gets the command that selects an intent category.</summary>
+        public ICommand SelectCategoryCommand { get; private set; }
+
+        /// <summary>Gets the command that validates and persists all staged changes.</summary>
+        public ICommand ApplyCommand { get; private set; }
+
+        /// <summary>Gets the command that discards all staged changes.</summary>
+        public ICommand CancelCommand { get; private set; }
+
+        /// <summary>Gets the command that stages safe defaults after confirmation.</summary>
+        public ICommand ResetCommand { get; private set; }
+
+        /// <summary>Gets the command that tests staged provider connectivity without saving.</summary>
+        public ICommand TestProviderCommand { get; private set; }
+
+        /// <summary>Gets the command that cancels the active provider connectivity test.</summary>
+        public ICommand CancelProviderTestCommand { get; private set; }
+
+        /// <summary>Gets the command that opens the complete legacy settings fallback.</summary>
+        public ICommand OpenLegacyWorkspaceCommand { get; private set; }
+
+        /// <summary>Gets or sets the global settings search.</summary>
+        public string SearchText
+        {
+            get => _searchText;
+            set
+            {
+                string normalized = value ?? string.Empty;
+                if (string.Equals(_searchText, normalized, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                _searchText = normalized;
+                OnPropertyChanged();
+                RefreshSearch();
+            }
+        }
+
+        /// <summary>Gets or sets the category displayed in the editor.</summary>
+        public PreviewSettingsCategoryOption SelectedCategory
+        {
+            get => _selectedCategory;
+            set
+            {
+                if (value == null || ReferenceEquals(_selectedCategory, value))
+                {
+                    return;
+                }
+
+                _selectedCategory = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(CurrentTitle));
+                OnPropertyChanged(nameof(CurrentDescription));
+                RaiseCategoryVisibility();
+            }
+        }
+
+        /// <summary>Gets or sets the selected provider without exposing its credential.</summary>
+        public PreviewProviderOption SelectedProvider
+        {
+            get => _selectedProvider;
+            set
+            {
+                if (ReferenceEquals(_selectedProvider, value) || value == null)
+                {
+                    return;
+                }
+
+                CancelProviderTest();
+                ClearPendingProviderCredential();
+                _selectedProvider = value;
+                _settings.ProviderKey = value.Key;
+                _settings.HasStoredCredential = value.HasStoredCredential;
+                if (value.Models.Count > 0 && !value.Models.Contains(_settings.ProviderModel))
+                {
+                    _settings.ProviderModel = value.Models[0];
+                }
+
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(ModelOptions));
+                OnPropertyChanged(nameof(IsLocalProvider));
+                OnPropertyChanged(nameof(IsProviderUnavailable));
+                OnPropertyChanged(nameof(ProviderDependencyText));
+                ClearProviderTestStatus();
+                Validate();
+            }
+        }
+
+        /// <summary>Gets the localized selected category title.</summary>
+        public string CurrentTitle => SelectedCategory?.Label ?? string.Empty;
+
+        /// <summary>Gets the localized selected category description.</summary>
+        public string CurrentDescription => SelectedCategory?.Description ?? string.Empty;
+
+        /// <summary>Gets whether staged values differ from the loaded baseline.</summary>
+        public bool IsModified => _settings != null && (!_settings.HasSameValues(_baseline) ||
+            !string.IsNullOrEmpty(_pendingProviderCredential) || !string.IsNullOrEmpty(_pendingProxyPassword));
+
+        /// <summary>Gets whether one or more staged values are invalid.</summary>
+        public bool HasValidationErrors => ValidationMessages.Count > 0;
+
+        /// <summary>Gets whether Apply is currently allowed.</summary>
+        public bool CanApply => IsModified && !HasValidationErrors && !IsBusy && !IsTestingProvider;
+
+        /// <summary>Gets whether settings persistence is active.</summary>
+        public bool IsBusy { get; private set; }
+
+        /// <summary>Gets whether an explicit provider connectivity test is active.</summary>
+        public bool IsTestingProvider { get; private set; }
+
+        /// <summary>Gets whether staged provider connectivity can currently be tested.</summary>
+        public bool CanTestProvider => HasProviders && !IsBusy && !IsTestingProvider;
+
+        /// <summary>Gets the localized, sanitized result of the latest provider test.</summary>
+        public string ProviderTestStatusText => _providerTestStatusText;
+
+        /// <summary>Gets whether the selected provider uses a local endpoint.</summary>
+        public bool IsLocalProvider => SelectedProvider?.IsLocal == true;
+
+        /// <summary>Gets whether no provider configuration is available.</summary>
+        public bool IsProviderUnavailable => ProviderOptions.Count == 0;
+
+        /// <summary>Gets whether one or more provider configurations are available.</summary>
+        public bool HasProviders => ProviderOptions.Count > 0;
+
+        /// <summary>Gets a localized explanation when provider settings are unavailable.</summary>
+        public string ProviderDependencyText => IsProviderUnavailable
+            ? PreviewMessageCatalog.Get("Settings_Dependency_NoProviders")
+            : string.Empty;
+
+        /// <summary>Gets whether General is selected.</summary>
+        public bool IsGeneralVisible => IsCategory(PreviewSettingsCategory.General);
+
+        /// <summary>Gets whether Providers is selected.</summary>
+        public bool IsProvidersVisible => IsCategory(PreviewSettingsCategory.Providers);
+
+        /// <summary>Gets whether Translation is selected.</summary>
+        public bool IsTranslationVisible => IsCategory(PreviewSettingsCategory.Translation);
+
+        /// <summary>Gets whether Files and formats is selected.</summary>
+        public bool IsFilesVisible => IsCategory(PreviewSettingsCategory.FilesAndFormats);
+
+        /// <summary>Gets whether History and data is selected.</summary>
+        public bool IsHistoryDataVisible => IsCategory(PreviewSettingsCategory.HistoryAndData);
+
+        /// <summary>Gets whether Appearance and accessibility is selected.</summary>
+        public bool IsAppearanceVisible => IsCategory(PreviewSettingsCategory.AppearanceAndAccessibility);
+
+        /// <summary>Gets whether Advanced is selected.</summary>
+        public bool IsAdvancedVisible => IsCategory(PreviewSettingsCategory.Advanced);
+
+        /// <summary>Gets the localized persistent staged-state label.</summary>
+        public string StateText => PreviewMessageCatalog.Get(
+            HasValidationErrors ? "Settings_State_Invalid" : IsModified ? "Settings_State_Modified" : "Settings_State_Clean");
+
+        /// <summary>Stages a write-only provider credential without exposing it to WPF binding.</summary>
+        /// <param name="credential">The PasswordBox value.</param>
+        internal void StageProviderCredential(string credential)
+        {
+            _pendingProviderCredential = credential ?? string.Empty;
+            ClearProviderTestStatus();
+            Validate();
+        }
+
+        /// <summary>Stages a write-only proxy password without exposing it to WPF binding.</summary>
+        /// <param name="password">The PasswordBox value.</param>
+        internal void StageProxyPassword(string password)
+        {
+            _pendingProxyPassword = password ?? string.Empty;
+            ClearProviderTestStatus();
+            Validate();
+        }
+
+        /// <summary>Confirms and discards staged changes before the application closes.</summary>
+        /// <returns><see langword="true"/> when closing may continue.</returns>
+        internal bool TryDiscardForClose()
+        {
+            if (!IsModified)
+            {
+                return true;
+            }
+
+            if (!_confirmDiscard())
+            {
+                return false;
+            }
+
+            Reload();
+            return true;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            CancelProviderTest();
+            _shell.PropertyChanged -= ShellPropertyChanged;
+            DetachSettings();
+            ClearPendingSecrets();
+        }
+
+        private void Reload()
+        {
+            DetachSettings();
+            ProviderOptions = _store.GetProviders();
+            _settings = _store.Load();
+            _baseline = _settings.Clone();
+            _settings.PropertyChanged += SettingsPropertyChanged;
+            _selectedProvider = ProviderOptions.FirstOrDefault(option => option.Key == _settings.ProviderKey)
+                ?? ProviderOptions.FirstOrDefault();
+            ClearPendingSecrets();
+            Validate();
+            OnPropertyChanged(nameof(ProviderOptions));
+            OnPropertyChanged(nameof(Settings));
+            OnPropertyChanged(nameof(SelectedProvider));
+            OnPropertyChanged(nameof(ModelOptions));
+            OnPropertyChanged(nameof(IsLocalProvider));
+            OnPropertyChanged(nameof(IsProviderUnavailable));
+            OnPropertyChanged(nameof(HasProviders));
+            OnPropertyChanged(nameof(CanTestProvider));
+        }
+
+        private void Apply()
+        {
+            Validate();
+            if (!CanApply)
+            {
+                return;
+            }
+
+            IsBusy = true;
+            OnPropertyChanged(nameof(IsBusy));
+            RaiseCommandAvailability();
+            try
+            {
+                _store.Save(_settings.Clone(), _pendingProviderCredential, _pendingProxyPassword);
+                Reload();
+                _shell.ShowNotification(PreviewShellNotificationSeverity.Success, "Settings_Apply_Succeeded");
+            }
+            catch (Exception exception) when (exception is IOException || exception is UnauthorizedAccessException ||
+                exception is InvalidOperationException || exception is ArgumentException)
+            {
+                _shell.ShowNotification(PreviewShellNotificationSeverity.Error, "Settings_Apply_Failed");
+            }
+            finally
+            {
+                IsBusy = false;
+                OnPropertyChanged(nameof(IsBusy));
+                RaiseCommandAvailability();
+            }
+        }
+
+        private void Cancel()
+        {
+            Reload();
+            _shell.ShowNotification(PreviewShellNotificationSeverity.Information, "Settings_Cancel_Completed");
+        }
+
+        private void Reset()
+        {
+            if (!_confirmReset())
+            {
+                return;
+            }
+
+            PreviewSettingsSnapshot defaults = new PreviewSettingsSnapshot
+            {
+                ProviderKey = _settings.ProviderKey,
+                ProviderModel = _settings.ProviderModel,
+                ProviderEnabled = _settings.ProviderEnabled,
+                HasStoredCredential = _settings.HasStoredCredential,
+                LocalPortText = "1234",
+                SourceLanguage = "English",
+                TargetLanguage = "English",
+                EnableLanguageDetection = true,
+                EnableContext = true,
+                ContextLimitText = "200",
+                PlaceholderPattern = "<(.*?)>,",
+                UiLanguage = "English",
+                Density = "Compact",
+                GenerateCSharp = true,
+                HasStoredProxyPassword = _settings.HasStoredProxyPassword,
+                MaxThreadCountText = "2",
+                ThrottleRatioText = "0.7",
+                ThrottleDelayText = "200"
+            };
+            ReplaceSettings(defaults);
+            ClearPendingSecrets();
+            Validate();
+        }
+
+        private void ReplaceSettings(PreviewSettingsSnapshot replacement)
+        {
+            DetachSettings();
+            _settings = replacement;
+            _settings.PropertyChanged += SettingsPropertyChanged;
+            OnPropertyChanged(nameof(Settings));
+        }
+
+        private void SettingsPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            ClearProviderTestStatus();
+            Validate();
+        }
+
+        private async Task TestProviderAsync()
+        {
+            string validationMessage = GetProviderTestValidationMessage();
+            if (!string.IsNullOrEmpty(validationMessage))
+            {
+                SetProviderTestStatus(PreviewMessageCatalog.Format(
+                    "Settings_Providers_Test_Failed",
+                    validationMessage));
+                _shell.ShowNotification(
+                    PreviewShellNotificationSeverity.Error,
+                    "Settings_Providers_Test_Failed",
+                    validationMessage);
+                return;
+            }
+
+            var cancellation = new CancellationTokenSource();
+            _providerTestCancellation = cancellation;
+            IsTestingProvider = true;
+            SetProviderTestStatus(PreviewMessageCatalog.Get("Settings_Providers_Test_Running"));
+            OnPropertyChanged(nameof(IsTestingProvider));
+            OnPropertyChanged(nameof(CanTestProvider));
+            _shell.SetOperation("Settings_Providers_Test_Running", 0);
+            RaiseCommandAvailability();
+            try
+            {
+                PreviewProviderTestResult result = await _store.TestProviderAsync(
+                    _settings.Clone(),
+                    _pendingProviderCredential,
+                    _pendingProxyPassword,
+                    cancellation.Token);
+                if (result.Status == PreviewProviderTestStatus.Succeeded)
+                {
+                    SetProviderTestStatus(PreviewMessageCatalog.Get("Settings_Providers_Test_Succeeded"));
+                    _shell.ShowNotification(
+                        PreviewShellNotificationSeverity.Success,
+                        "Settings_Providers_Test_Succeeded");
+                }
+                else
+                {
+                    string reason = PreviewMessageCatalog.Get(GetProviderTestReasonId(result.Status));
+                    SetProviderTestStatus(PreviewMessageCatalog.Format("Settings_Providers_Test_Failed", reason));
+                    _shell.ShowNotification(
+                        result.Status == PreviewProviderTestStatus.Unsupported
+                            ? PreviewShellNotificationSeverity.Information
+                            : PreviewShellNotificationSeverity.Error,
+                        "Settings_Providers_Test_Failed",
+                        reason);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                SetProviderTestStatus(PreviewMessageCatalog.Get("Settings_Providers_Test_Cancelled"));
+            }
+            catch (Exception exception) when (exception is InvalidOperationException ||
+                exception is ArgumentException)
+            {
+                string reason = PreviewMessageCatalog.Get("Settings_Providers_Test_Reason_Unreachable");
+                SetProviderTestStatus(PreviewMessageCatalog.Format("Settings_Providers_Test_Failed", reason));
+                _shell.ShowNotification(
+                    PreviewShellNotificationSeverity.Error,
+                    "Settings_Providers_Test_Failed",
+                    reason);
+            }
+            finally
+            {
+                if (ReferenceEquals(_providerTestCancellation, cancellation))
+                {
+                    _providerTestCancellation = null;
+                }
+
+                cancellation.Dispose();
+                IsTestingProvider = false;
+                OnPropertyChanged(nameof(IsTestingProvider));
+                OnPropertyChanged(nameof(CanTestProvider));
+                _shell.CompleteOperation();
+                RaiseCommandAvailability();
+            }
+        }
+
+        private void CancelProviderTest()
+        {
+            _providerTestCancellation?.Cancel();
+        }
+
+        private string GetProviderTestValidationMessage()
+        {
+            int number;
+            if (SelectedProvider == null)
+            {
+                return PreviewMessageCatalog.Get("Settings_Dependency_NoProviders");
+            }
+
+            if (SelectedProvider.IsLocal && !TryInt(_settings.LocalPortText, 1, 65535, out number))
+            {
+                return PreviewMessageCatalog.Format("Settings_Validation_PortRange", 1, 65535);
+            }
+
+            if (SelectedProvider.SupportsConnectivityTest && !SelectedProvider.IsLocal &&
+                !_settings.HasStoredCredential && string.IsNullOrWhiteSpace(_pendingProviderCredential))
+            {
+                return PreviewMessageCatalog.Get("Settings_Validation_CredentialRequired");
+            }
+
+            if (_pendingProviderCredential.Length > 4096 || _pendingProxyPassword.Length > 4096)
+            {
+                return PreviewMessageCatalog.Get("Settings_Validation_CredentialLength");
+            }
+
+            Uri uri;
+            if (!string.IsNullOrWhiteSpace(_settings.ProxyUrl) &&
+                (!Uri.TryCreate(_settings.ProxyUrl, UriKind.Absolute, out uri) ||
+                    (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)))
+            {
+                return PreviewMessageCatalog.Get("Settings_Validation_InvalidEndpoint");
+            }
+
+            return string.Empty;
+        }
+
+        private static string GetProviderTestReasonId(PreviewProviderTestStatus status)
+        {
+            switch (status)
+            {
+                case PreviewProviderTestStatus.AuthenticationFailed:
+                    return "Settings_Providers_Test_Reason_Authentication";
+                case PreviewProviderTestStatus.TimedOut:
+                    return "Settings_Providers_Test_Reason_TimedOut";
+                case PreviewProviderTestStatus.Rejected:
+                    return "Settings_Providers_Test_Reason_Rejected";
+                case PreviewProviderTestStatus.Unsupported:
+                    return "Settings_Providers_Test_Reason_Unsupported";
+                default:
+                    return "Settings_Providers_Test_Reason_Unreachable";
+            }
+        }
+
+        private void SetProviderTestStatus(string message)
+        {
+            _providerTestStatusText = message ?? string.Empty;
+            OnPropertyChanged(nameof(ProviderTestStatusText));
+        }
+
+        private void ClearProviderTestStatus()
+        {
+            if (!IsTestingProvider && !string.IsNullOrEmpty(_providerTestStatusText))
+            {
+                SetProviderTestStatus(string.Empty);
+            }
+        }
+
+        private void Validate()
+        {
+            var messages = new List<string>();
+            int number;
+            double ratio;
+            if (!TryInt(_settings?.ContextLimitText, 1, 100000, out number))
+            {
+                messages.Add(PreviewMessageCatalog.Format("Settings_Validation_IntegerRange", 1, 100000));
+            }
+
+            if (!TryInt(_settings?.MaxThreadCountText, 1, 256, out number))
+            {
+                messages.Add(PreviewMessageCatalog.Format("Settings_Validation_ThreadRange", 1, 256));
+            }
+
+            if (!TryInt(_settings?.ThrottleDelayText, 0, 600000, out number))
+            {
+                messages.Add(PreviewMessageCatalog.Format("Settings_Validation_DelayRange", 0, 600000));
+            }
+
+            if (!double.TryParse(_settings?.ThrottleRatioText, NumberStyles.Float, CultureInfo.InvariantCulture, out ratio) ||
+                ratio < 0 || ratio > 1)
+            {
+                messages.Add(PreviewMessageCatalog.Get("Settings_Validation_ThrottleRatio"));
+            }
+
+            if (IsLocalProvider && !TryInt(_settings?.LocalPortText, 1, 65535, out number))
+            {
+                messages.Add(PreviewMessageCatalog.Format("Settings_Validation_PortRange", 1, 65535));
+            }
+
+            if (_settings?.ProviderEnabled == true && SelectedProvider?.SupportsConnectivityTest == true &&
+                !SelectedProvider.IsLocal &&
+                !_settings.HasStoredCredential && string.IsNullOrWhiteSpace(_pendingProviderCredential))
+            {
+                messages.Add(PreviewMessageCatalog.Get("Settings_Validation_CredentialRequired"));
+            }
+
+            if (SelectedProvider?.Models.Count > 0 && string.IsNullOrWhiteSpace(_settings?.ProviderModel))
+            {
+                messages.Add(PreviewMessageCatalog.Get("Settings_Validation_ModelRequired"));
+            }
+
+            if (_pendingProviderCredential.Length > 4096 || _pendingProxyPassword.Length > 4096)
+            {
+                messages.Add(PreviewMessageCatalog.Get("Settings_Validation_CredentialLength"));
+            }
+
+            Uri uri;
+            if (!string.IsNullOrWhiteSpace(_settings?.ProxyUrl) &&
+                (!Uri.TryCreate(_settings.ProxyUrl, UriKind.Absolute, out uri) ||
+                    (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)))
+            {
+                messages.Add(PreviewMessageCatalog.Get("Settings_Validation_InvalidEndpoint"));
+            }
+
+            if (!string.IsNullOrWhiteSpace(_settings?.GamePath) && !Directory.Exists(_settings.GamePath))
+            {
+                messages.Add(PreviewMessageCatalog.Get("Settings_Validation_GamePath"));
+            }
+
+            try
+            {
+                new Regex(_settings?.PlaceholderPattern ?? string.Empty, RegexOptions.None, TimeSpan.FromMilliseconds(250));
+            }
+            catch (ArgumentException)
+            {
+                messages.Add(PreviewMessageCatalog.Get("Settings_Validation_PlaceholderPattern"));
+            }
+
+            ValidationMessages = messages;
+            OnPropertyChanged(nameof(ValidationMessages));
+            OnPropertyChanged(nameof(HasValidationErrors));
+            OnPropertyChanged(nameof(IsModified));
+            OnPropertyChanged(nameof(CanApply));
+            OnPropertyChanged(nameof(StateText));
+            RaiseCommandAvailability();
+        }
+
+        private void RefreshSearch()
+        {
+            if (string.IsNullOrWhiteSpace(_searchText))
+            {
+                VisibleCategories = Categories;
+            }
+            else
+            {
+                VisibleCategories = Categories.Where(category =>
+                    Contains(category.Label, _searchText) || Contains(category.Description, _searchText) ||
+                    Contains(category.SearchTerms, _searchText)).ToList();
+            }
+
+            OnPropertyChanged(nameof(VisibleCategories));
+            if (VisibleCategories.Count > 0 && !VisibleCategories.Contains(SelectedCategory))
+            {
+                SelectedCategory = VisibleCategories[0];
+            }
+        }
+
+        private void SelectCategory(object parameter)
+        {
+            PreviewSettingsCategoryOption option = parameter as PreviewSettingsCategoryOption;
+            if (option != null)
+            {
+                SelectedCategory = option;
+            }
+        }
+
+        private void ShellPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != nameof(PreviewShellViewModel.CurrentDestination) || _restoringNavigation ||
+                _shell.CurrentDestination == PreviewShellDestination.Settings || !IsModified)
+            {
+                return;
+            }
+
+            if (_confirmDiscard())
+            {
+                Reload();
+                return;
+            }
+
+            _restoringNavigation = true;
+            try
+            {
+                _shell.CurrentDestination = PreviewShellDestination.Settings;
+            }
+            finally
+            {
+                _restoringNavigation = false;
+            }
+        }
+
+        private void RaiseCategoryVisibility()
+        {
+            OnPropertyChanged(nameof(IsGeneralVisible));
+            OnPropertyChanged(nameof(IsProvidersVisible));
+            OnPropertyChanged(nameof(IsTranslationVisible));
+            OnPropertyChanged(nameof(IsFilesVisible));
+            OnPropertyChanged(nameof(IsHistoryDataVisible));
+            OnPropertyChanged(nameof(IsAppearanceVisible));
+            OnPropertyChanged(nameof(IsAdvancedVisible));
+        }
+
+        private void RaiseCommandAvailability()
+        {
+            ((PreviewShellCommand)ApplyCommand).RaiseCanExecuteChanged();
+            ((PreviewShellCommand)CancelCommand).RaiseCanExecuteChanged();
+            ((PreviewShellCommand)ResetCommand).RaiseCanExecuteChanged();
+            ((PreviewShellCommand)TestProviderCommand).RaiseCanExecuteChanged();
+            ((PreviewShellCommand)CancelProviderTestCommand).RaiseCanExecuteChanged();
+        }
+
+        private void DetachSettings()
+        {
+            if (_settings != null)
+            {
+                _settings.PropertyChanged -= SettingsPropertyChanged;
+            }
+        }
+
+        private void ClearPendingSecrets()
+        {
+            _pendingProviderCredential = string.Empty;
+            _pendingProxyPassword = string.Empty;
+            SecretsCleared?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void ClearPendingProviderCredential()
+        {
+            if (string.IsNullOrEmpty(_pendingProviderCredential))
+            {
+                return;
+            }
+
+            _pendingProviderCredential = string.Empty;
+            ProviderCredentialCleared?.Invoke(this, EventArgs.Empty);
+        }
+
+        private bool IsCategory(PreviewSettingsCategory category)
+        {
+            return SelectedCategory?.Value == category;
+        }
+
+        private static bool TryInt(string text, int minimum, int maximum, out int value)
+        {
+            return int.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out value) &&
+                value >= minimum && value <= maximum;
+        }
+
+        private static bool Contains(string value, string search)
+        {
+            return (value ?? string.Empty).IndexOf(search, StringComparison.CurrentCultureIgnoreCase) >= 0;
+        }
+
+        private static IReadOnlyList<PreviewSettingsCategoryOption> CreateCategories()
+        {
+            return new[]
+            {
+                CreateCategory(PreviewSettingsCategory.General, "General", "language defaults startup game"),
+                CreateCategory(PreviewSettingsCategory.Providers, "Providers", "api key credential model node local endpoint lm studio cloud"),
+                CreateCategory(PreviewSettingsCategory.Translation, "Translation", "ai prompt preset context language detect placeholder punctuation preprocessing"),
+                CreateCategory(PreviewSettingsCategory.FilesAndFormats, "FilesAndFormats", "game path esp esm pex assembly papyrus csharp import export"),
+                CreateCategory(PreviewSettingsCategory.HistoryAndData, "HistoryAndData", "history cache database dictionary terminology memory retention global search"),
+                CreateCategory(PreviewSettingsCategory.AppearanceAndAccessibility, "AppearanceAndAccessibility", "ui theme density compact comfortable rtl accessibility"),
+                CreateCategory(PreviewSettingsCategory.Advanced, "Advanced", "proxy pipeline custom provider concurrency threads throttle diagnostics"),
+            };
+        }
+
+        private static PreviewSettingsCategoryOption CreateCategory(
+            PreviewSettingsCategory value,
+            string id,
+            string searchTerms)
+        {
+            return new PreviewSettingsCategoryOption(
+                value,
+                PreviewMessageCatalog.Get("Settings_Category_" + id + "_Title"),
+                PreviewMessageCatalog.Get("Settings_Category_" + id + "_Description"),
+                searchTerms);
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/Phoenix_Translator/Application/PreviewShellViewModel.cs
+++ b/Phoenix_Translator/Application/PreviewShellViewModel.cs
@@ -132,6 +132,7 @@ namespace PhoenixTranslator.ApplicationLayer
                 OnPropertyChanged(nameof(IsTranslationWorkspaceVisible));
                 OnPropertyChanged(nameof(IsReviewQualityWorkspaceVisible));
                 OnPropertyChanged(nameof(IsHistoryUpdateWorkspaceVisible));
+                OnPropertyChanged(nameof(IsSettingsWorkspaceVisible));
                 OnPropertyChanged(nameof(IsPreviewFallbackVisible));
             }
         }
@@ -166,12 +167,18 @@ namespace PhoenixTranslator.ApplicationLayer
             _currentDestination == PreviewShellDestination.ProjectUpdate;
 
         /// <summary>
+        /// Gets whether the unified Settings Center owns the current page.
+        /// </summary>
+        public bool IsSettingsWorkspaceVisible => _currentDestination == PreviewShellDestination.Settings;
+
+        /// <summary>
         /// Gets whether the selected destination still uses the shared preview fallback page.
         /// </summary>
         public bool IsPreviewFallbackVisible =>
             !IsTranslationWorkspaceVisible &&
             !IsReviewQualityWorkspaceVisible &&
-            !IsHistoryUpdateWorkspaceVisible;
+            !IsHistoryUpdateWorkspaceVisible &&
+            !IsSettingsWorkspaceVisible;
 
         /// <summary>
         /// Gets the product version shown independently from dependency versions.

--- a/Phoenix_Translator/DeFine.cs
+++ b/Phoenix_Translator/DeFine.cs
@@ -175,6 +175,9 @@ namespace PhoenixTranslator
         public double WritingAreaHeight { get; set; } = 0;
         public string ViewMode { get; set; } = "Normal";
 
+        /// <summary>Gets or sets the preview control density preference.</summary>
+        public string UiDensity { get; set; } = "Compact";
+
         public Languages SourceLanguage { get; set; } = Languages.English;
         public Languages TargetLanguage { get; set; } = Languages.English;
 
@@ -231,6 +234,9 @@ namespace PhoenixTranslator
                             this.GameType = GetSetting.GameType;
                             this.WritingAreaHeight = GetSetting.WritingAreaHeight;
                             this.ViewMode = GetSetting.ViewMode;
+                            this.UiDensity = string.IsNullOrWhiteSpace(GetSetting.UiDensity)
+                                ? "Compact"
+                                : GetSetting.UiDensity;
                             this.SourceLanguage = GetSetting.SourceLanguage;
                             this.TargetLanguage = GetSetting.TargetLanguage;
                             this.CanClearCloudTranslationCache = GetSetting.CanClearCloudTranslationCache;

--- a/Phoenix_Translator/PhoenixTranslator.csproj
+++ b/Phoenix_Translator/PhoenixTranslator.csproj
@@ -116,6 +116,9 @@
     <Compile Include="Application\PreviewReviewQualityViewModel.cs" />
     <Compile Include="Application\PreviewReviewStateStore.cs" />
     <Compile Include="Application\PreviewRevisionHistoryStore.cs" />
+    <Compile Include="Application\PreviewSettingsModel.cs" />
+    <Compile Include="Application\PreviewSettingsViewModel.cs" />
+    <Compile Include="Application\LegacyPreviewSettingsStore.cs" />
     <Compile Include="Application\PreviewShellCommand.cs" />
     <Compile Include="Application\PreviewShellViewModel.cs" />
     <Compile Include="Application\PreviewTranslationEntry.cs" />
@@ -219,6 +222,9 @@
     </Compile>
     <Compile Include="UIManagement\Preview\PreviewHistoryUpdateView.xaml.cs">
       <DependentUpon>PreviewHistoryUpdateView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="UIManagement\Preview\PreviewSettingsView.xaml.cs">
+      <DependentUpon>PreviewSettingsView.xaml</DependentUpon>
     </Compile>
     <Compile Include="UIManagement\Preview\PreviewTranslationWorkspaceView.xaml.cs">
       <DependentUpon>PreviewTranslationWorkspaceView.xaml</DependentUpon>
@@ -347,6 +353,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="UIManagement\Preview\PreviewHistoryUpdateView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="UIManagement\Preview\PreviewSettingsView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Phoenix_Translator/Properties/AssemblyInfo.cs
+++ b/Phoenix_Translator/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Windows;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.0.0.10")]
-[assembly: AssemblyFileVersion("2.0.0.10")]
+[assembly: AssemblyVersion("2.0.0.11")]
+[assembly: AssemblyFileVersion("2.0.0.11")]

--- a/Phoenix_Translator/Properties/Resources.resx
+++ b/Phoenix_Translator/Properties/Resources.resx
@@ -226,9 +226,17 @@
   <data name="Settings_Providers_ApiKey_Stored" xml:space="preserve"><value>Stored securely</value><comment>Status shown instead of exposing a stored provider credential.</comment></data>
   <data name="Settings_Providers_Endpoint_Label" xml:space="preserve"><value>Endpoint</value><comment>Field label for a local or custom provider endpoint.</comment></data>
   <data name="Settings_Providers_Test_Action" xml:space="preserve"><value>Test provider</value><comment>Explicit action that tests staged provider settings without saving them.</comment></data>
+  <data name="Settings_Providers_Test_Cancel_Action" xml:space="preserve"><value>Cancel test</value><comment>Cancels the active provider connectivity test.</comment></data>
   <data name="Settings_Providers_Test_Running" xml:space="preserve"><value>Testing provider…</value><comment>Status while a provider test is running.</comment></data>
   <data name="Settings_Providers_Test_Succeeded" xml:space="preserve"><value>The provider responded successfully.</value><comment>Provider-test success message; does not imply settings were saved.</comment></data>
   <data name="Settings_Providers_Test_Failed" xml:space="preserve"><value>The provider test failed: {0}</value><comment>Safe provider-test failure. Placeholders: {0}=sanitized failure reason without credentials or private content.</comment></data>
+  <data name="Settings_Providers_Test_Cancelled" xml:space="preserve"><value>The provider test was cancelled.</value><comment>Status after the user cancels a provider test.</comment></data>
+  <data name="Settings_Providers_Test_Privacy" xml:space="preserve"><value>Tests authentication and availability only. No project or translation text is sent, and staged settings are not saved.</value><comment>Privacy boundary for provider connectivity tests.</comment></data>
+  <data name="Settings_Providers_Test_Reason_Authentication" xml:space="preserve"><value>The credential was not accepted.</value><comment>Sanitized provider-test authentication failure.</comment></data>
+  <data name="Settings_Providers_Test_Reason_TimedOut" xml:space="preserve"><value>The provider did not respond before the timeout.</value><comment>Sanitized provider-test timeout failure.</comment></data>
+  <data name="Settings_Providers_Test_Reason_Rejected" xml:space="preserve"><value>The provider rejected the availability request.</value><comment>Sanitized provider-test service failure.</comment></data>
+  <data name="Settings_Providers_Test_Reason_Unsupported" xml:space="preserve"><value>This provider requires the advanced provider manager for testing.</value><comment>Explanation when the central settings test does not support a custom or interactive provider.</comment></data>
+  <data name="Settings_Providers_Test_Reason_Unreachable" xml:space="preserve"><value>The provider could not be reached.</value><comment>Sanitized provider-test network failure.</comment></data>
   <data name="Settings_ProviderPipeline_Title" xml:space="preserve"><value>Provider pipeline</value><comment>Settings card heading for the ordered provider pipeline.</comment></data>
   <data name="Settings_ProviderPipeline_EditAdvanced_Action" xml:space="preserve"><value>Edit advanced pipeline</value><comment>Opens progressively disclosed provider-pipeline configuration.</comment></data>
   <data name="Settings_Modified_Hint" xml:space="preserve"><value>Changes are not applied until you choose Apply.</value><comment>Persistent settings footer hint while staged changes exist.</comment></data>
@@ -357,4 +365,81 @@
   <data name="Update_Undo_Completed" xml:space="preserve"><value>Restored {0} entries from before the last revision update.</value><comment>Update undo notification. Placeholder: exact restored entry count.</comment></data>
   <data name="Accessibility_History_Timeline_Name" xml:space="preserve"><value>Project revision timeline</value><comment>Accessible name for the history event list.</comment></data>
   <data name="Accessibility_Update_Comparison_Name" xml:space="preserve"><value>Project revision comparison</value><comment>Accessible name for the comparison result list.</comment></data>
+  <data name="Settings_Search_Placeholder" xml:space="preserve"><value>Search all settings, including legacy terms</value><comment>Global Settings Center search hint.</comment></data>
+  <data name="Settings_Category_General_Title" xml:space="preserve"><value>General</value><comment>Settings category for application defaults.</comment></data>
+  <data name="Settings_Category_General_Description" xml:space="preserve"><value>Choose language defaults and application-level behavior.</value><comment>General settings category description.</comment></data>
+  <data name="Settings_Category_Providers_Title" xml:space="preserve"><value>Providers</value><comment>Settings category for translation services.</comment></data>
+  <data name="Settings_Category_Providers_Description" xml:space="preserve"><value>Choose providers, models, credentials, and local endpoints.</value><comment>Provider settings category description.</comment></data>
+  <data name="Settings_Category_Translation_Title" xml:space="preserve"><value>Translation</value><comment>Settings category for translation behavior.</comment></data>
+  <data name="Settings_Category_Translation_Description" xml:space="preserve"><value>Control context, language detection, prompts, and protected placeholders.</value><comment>Translation settings category description.</comment></data>
+  <data name="Settings_Category_FilesAndFormats_Title" xml:space="preserve"><value>Files &amp; formats</value><comment>Settings category for project paths and format behavior.</comment></data>
+  <data name="Settings_Category_FilesAndFormats_Description" xml:space="preserve"><value>Configure game paths, ESP and PEX behavior, and format defaults.</value><comment>Files and formats settings category description.</comment></data>
+  <data name="Settings_Category_HistoryAndData_Title" xml:space="preserve"><value>History &amp; data</value><comment>Settings category for caches and translation data.</comment></data>
+  <data name="Settings_Category_HistoryAndData_Description" xml:space="preserve"><value>Control translation memory, database updates, caches, and retention routes.</value><comment>History and data settings category description.</comment></data>
+  <data name="Settings_Category_AppearanceAndAccessibility_Title" xml:space="preserve"><value>Appearance &amp; accessibility</value><comment>Settings category for visual and accessibility preferences.</comment></data>
+  <data name="Settings_Category_AppearanceAndAccessibility_Description" xml:space="preserve"><value>Choose interface language, density, text direction, and presentation defaults.</value><comment>Appearance and accessibility category description.</comment></data>
+  <data name="Settings_Category_Advanced_Title" xml:space="preserve"><value>Advanced</value><comment>Settings category for expert configuration.</comment></data>
+  <data name="Settings_Category_Advanced_Description" xml:space="preserve"><value>Configure proxies, concurrency, throttling, provider pipelines, and custom providers.</value><comment>Advanced settings category description.</comment></data>
+  <data name="Settings_Card_LanguageDefaults_Title" xml:space="preserve"><value>Language defaults</value><comment>General settings card title.</comment></data>
+  <data name="Settings_Field_SourceLanguage_Label" xml:space="preserve"><value>Source language</value><comment>Default source language field label.</comment></data>
+  <data name="Settings_Field_TargetLanguage_Label" xml:space="preserve"><value>Target language</value><comment>Default target language field label.</comment></data>
+  <data name="Settings_Field_Enabled_Label" xml:space="preserve"><value>Enable this provider</value><comment>Provider enabled toggle label.</comment></data>
+  <data name="Settings_Providers_CredentialReplace_Hint" xml:space="preserve"><value>Leave empty to keep the stored credential. New values are write-only.</value><comment>Provider credential privacy hint.</comment></data>
+  <data name="Settings_Dependency_NoProviders" xml:space="preserve"><value>No provider configuration is available. Open the legacy provider manager to create one.</value><comment>Explanation shown when provider settings are unavailable.</comment></data>
+  <data name="Settings_Dependency_ContextDisabled" xml:space="preserve"><value>Context length is available only while contextual translation is enabled.</value><comment>Explanation for the dependent context-length field.</comment></data>
+  <data name="Settings_Card_Context_Title" xml:space="preserve"><value>Context and language analysis</value><comment>Translation settings card title.</comment></data>
+  <data name="Settings_Field_ContextEnabled_Label" xml:space="preserve"><value>Use contextual translation</value><comment>Context enabled toggle label.</comment></data>
+  <data name="Settings_Field_ContextLimit_Label" xml:space="preserve"><value>Maximum context characters</value><comment>Context length field label.</comment></data>
+  <data name="Settings_Field_LanguageDetection_Label" xml:space="preserve"><value>Detect the source language automatically</value><comment>Language detection toggle label.</comment></data>
+  <data name="Settings_Card_Prompt_Title" xml:space="preserve"><value>Prompt and protected text</value><comment>Translation prompt settings card title.</comment></data>
+  <data name="Settings_Field_AdditionalPrompt_Label" xml:space="preserve"><value>Additional provider instructions</value><comment>Additional prompt field label.</comment></data>
+  <data name="Settings_Field_PlaceholderPattern_Label" xml:space="preserve"><value>Protected placeholder pattern</value><comment>Placeholder regular expression field label.</comment></data>
+  <data name="Settings_Card_GamePath_Title" xml:space="preserve"><value>Game and project files</value><comment>Files settings card title.</comment></data>
+  <data name="Settings_Field_GamePath_Label" xml:space="preserve"><value>Skyrim installation path</value><comment>Game path field label.</comment></data>
+  <data name="Settings_Field_ShowAssembly_Label" xml:space="preserve"><value>Show PEX assembly details</value><comment>PEX assembly toggle label.</comment></data>
+  <data name="Settings_Field_GenerateCSharp_Label" xml:space="preserve"><value>Generate C# view instead of Papyrus</value><comment>PEX code view toggle label.</comment></data>
+  <data name="Settings_Card_TranslationData_Title" xml:space="preserve"><value>Translation data</value><comment>History and data settings card title.</comment></data>
+  <data name="Settings_Field_AutoUpdateDatabase_Label" xml:space="preserve"><value>Update translation memory when string files are imported</value><comment>Automatic database update toggle label.</comment></data>
+  <data name="Settings_Field_GlobalSearch_Label" xml:space="preserve"><value>Search translation memory across projects</value><comment>Global translation memory search toggle label.</comment></data>
+  <data name="Settings_Data_OpenManager_Action" xml:space="preserve"><value>Open terminology and data manager</value><comment>Opens the legacy content manager during preview.</comment></data>
+  <data name="Settings_Card_Appearance_Title" xml:space="preserve"><value>Interface presentation</value><comment>Appearance settings card title.</comment></data>
+  <data name="Settings_Field_UiLanguage_Label" xml:space="preserve"><value>Interface language</value><comment>Interface language field label.</comment></data>
+  <data name="Settings_Field_Density_Label" xml:space="preserve"><value>Control density</value><comment>Compact or comfortable density field label.</comment></data>
+  <data name="Settings_Field_RightToLeft_Label" xml:space="preserve"><value>Use right-to-left target editors</value><comment>Right-to-left layout toggle label.</comment></data>
+  <data name="Settings_Restart_Hint" xml:space="preserve"><value>Some appearance changes take effect after restart.</value><comment>Restart guidance for appearance preferences.</comment></data>
+  <data name="Settings_Card_Proxy_Title" xml:space="preserve"><value>Network proxy</value><comment>Advanced proxy settings card title.</comment></data>
+  <data name="Settings_Field_ProxyUrl_Label" xml:space="preserve"><value>Proxy URL</value><comment>Proxy address field label.</comment></data>
+  <data name="Settings_Field_ProxyUser_Label" xml:space="preserve"><value>Proxy user name</value><comment>Proxy user field label.</comment></data>
+  <data name="Settings_Field_ProxyPassword_Label" xml:space="preserve"><value>Proxy password</value><comment>Write-only proxy password field label.</comment></data>
+  <data name="Settings_Card_Performance_Title" xml:space="preserve"><value>Concurrency and throttling</value><comment>Advanced performance settings card title.</comment></data>
+  <data name="Settings_Field_MaxThreads_Label" xml:space="preserve"><value>Maximum workers</value><comment>Maximum translation worker count field label.</comment></data>
+  <data name="Settings_Field_ThrottleRatio_Label" xml:space="preserve"><value>Throttling ratio</value><comment>Engine throttling ratio field label.</comment></data>
+  <data name="Settings_Field_ThrottleDelay_Label" xml:space="preserve"><value>Throttling delay in milliseconds</value><comment>Engine throttling delay field label.</comment></data>
+  <data name="Settings_Advanced_OpenPipeline_Action" xml:space="preserve"><value>Open provider pipeline and custom providers</value><comment>Opens advanced legacy provider tools during preview.</comment></data>
+  <data name="Settings_Action_Apply" xml:space="preserve"><value>Apply settings</value><comment>Persists every valid staged setting.</comment></data>
+  <data name="Settings_Action_Cancel" xml:space="preserve"><value>Cancel changes</value><comment>Discards every staged setting change.</comment></data>
+  <data name="Settings_Action_Reset" xml:space="preserve"><value>Reset to defaults</value><comment>Stages safe default values after confirmation.</comment></data>
+  <data name="Settings_Action_OpenLegacy" xml:space="preserve"><value>Open legacy settings</value><comment>Opens the complete legacy settings fallback.</comment></data>
+  <data name="Settings_State_Clean" xml:space="preserve"><value>All settings are applied</value><comment>Persistent clean settings state.</comment></data>
+  <data name="Settings_State_Modified" xml:space="preserve"><value>Settings have unapplied changes</value><comment>Persistent modified settings state.</comment></data>
+  <data name="Settings_State_Invalid" xml:space="preserve"><value>Correct invalid settings before applying</value><comment>Persistent invalid settings state.</comment></data>
+  <data name="Settings_Apply_Succeeded" xml:space="preserve"><value>Settings were applied successfully.</value><comment>Settings persistence success notification.</comment></data>
+  <data name="Settings_Apply_Failed" xml:space="preserve"><value>Settings could not be applied. Staged values remain available.</value><comment>Safe settings persistence failure notification.</comment></data>
+  <data name="Settings_Cancel_Completed" xml:space="preserve"><value>Unapplied settings were discarded.</value><comment>Settings cancellation notification.</comment></data>
+  <data name="Settings_Reset_ConfirmationTitle" xml:space="preserve"><value>Reset settings?</value><comment>Reset confirmation title.</comment></data>
+  <data name="Settings_Reset_Confirmation" xml:space="preserve"><value>Stage default values for ordinary settings? Stored credentials are preserved until you apply or cancel.</value><comment>Reset confirmation text.</comment></data>
+  <data name="Settings_Discard_ConfirmationTitle" xml:space="preserve"><value>Discard settings changes?</value><comment>Unsaved navigation confirmation title.</comment></data>
+  <data name="Settings_Discard_Confirmation" xml:space="preserve"><value>Leave Settings and discard every unapplied change?</value><comment>Unsaved navigation confirmation text.</comment></data>
+  <data name="Settings_Validation_IntegerRange" xml:space="preserve"><value>Context characters must be a whole number from {0} through {1}.</value><comment>Context validation. Placeholders: minimum and maximum.</comment></data>
+  <data name="Settings_Validation_ThreadRange" xml:space="preserve"><value>Maximum workers must be a whole number from {0} through {1}.</value><comment>Worker-count validation. Placeholders: minimum and maximum.</comment></data>
+  <data name="Settings_Validation_DelayRange" xml:space="preserve"><value>Throttling delay must be a whole number from {0} through {1} milliseconds.</value><comment>Throttle-delay validation. Placeholders: minimum and maximum.</comment></data>
+  <data name="Settings_Validation_ThrottleRatio" xml:space="preserve"><value>Throttling ratio must be a number from 0 through 1 using a decimal point.</value><comment>Throttle-ratio validation.</comment></data>
+  <data name="Settings_Validation_PortRange" xml:space="preserve"><value>Local provider port must be a whole number from {0} through {1}.</value><comment>Local port validation. Placeholders: minimum and maximum.</comment></data>
+  <data name="Settings_Validation_CredentialRequired" xml:space="preserve"><value>The enabled cloud provider requires a stored or newly entered credential.</value><comment>Provider credential validation.</comment></data>
+  <data name="Settings_Validation_CredentialLength" xml:space="preserve"><value>A credential exceeds the supported length limit.</value><comment>Bounded secret input validation.</comment></data>
+  <data name="Settings_Validation_ModelRequired" xml:space="preserve"><value>Select or enter a model for the configured provider.</value><comment>Provider model validation.</comment></data>
+  <data name="Settings_Validation_GamePath" xml:space="preserve"><value>The configured Skyrim path does not exist.</value><comment>Game path validation.</comment></data>
+  <data name="Settings_Validation_PlaceholderPattern" xml:space="preserve"><value>The protected placeholder pattern is not a valid regular expression.</value><comment>Placeholder regular expression validation.</comment></data>
+  <data name="Accessibility_Settings_CategoryList_Name" xml:space="preserve"><value>Settings categories</value><comment>Accessible name for central category navigation.</comment></data>
+  <data name="Accessibility_Settings_Validation_Name" xml:space="preserve"><value>Settings validation messages</value><comment>Accessible name for the validation message list.</comment></data>
 </root>

--- a/Phoenix_Translator/Themes/PreviewControlStyles.xaml
+++ b/Phoenix_Translator/Themes/PreviewControlStyles.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="PreviewDesignTokens.xaml" />
     </ResourceDictionary.MergedDictionaries>
@@ -13,6 +14,171 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+    </Style>
+
+    <Style x:Key="PreviewScrollBarPageButton" TargetType="RepeatButton">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="RepeatButton">
+                    <Border Background="{TemplateBinding Background}" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="PreviewVerticalScrollBarThumb" TargetType="Thumb">
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Thumb">
+                    <Grid Background="Transparent">
+                        <Border x:Name="Indicator" Width="4" Margin="0,2" HorizontalAlignment="Right"
+                                Background="{StaticResource PreviewBrushBorderStrong}" CornerRadius="3" Opacity="0.75" />
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType={x:Type ScrollBar}}}" Value="True">
+                            <Setter TargetName="Indicator" Property="Background" Value="{StaticResource PreviewBrushTextSecondary}" />
+                            <Setter TargetName="Indicator" Property="Opacity" Value="1" />
+                            <DataTrigger.EnterActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="Indicator" Storyboard.TargetProperty="Width"
+                                                         To="8" Duration="0:0:0.12" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </DataTrigger.EnterActions>
+                            <DataTrigger.ExitActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="Indicator" Storyboard.TargetProperty="Width"
+                                                         To="4" Duration="0:0:0.16" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </DataTrigger.ExitActions>
+                        </DataTrigger>
+                        <Trigger Property="IsDragging" Value="True">
+                            <Setter TargetName="Indicator" Property="Background" Value="{StaticResource PreviewBrushTextPrimary}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="PreviewHorizontalScrollBarThumb" TargetType="Thumb">
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Thumb">
+                    <Grid Background="Transparent">
+                        <Border x:Name="Indicator" Height="4" Margin="2,0" VerticalAlignment="Bottom"
+                                Background="{StaticResource PreviewBrushBorderStrong}" CornerRadius="3" Opacity="0.75" />
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType={x:Type ScrollBar}}}" Value="True">
+                            <Setter TargetName="Indicator" Property="Background" Value="{StaticResource PreviewBrushTextSecondary}" />
+                            <Setter TargetName="Indicator" Property="Opacity" Value="1" />
+                            <DataTrigger.EnterActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="Indicator" Storyboard.TargetProperty="Height"
+                                                         To="8" Duration="0:0:0.12" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </DataTrigger.EnterActions>
+                            <DataTrigger.ExitActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="Indicator" Storyboard.TargetProperty="Height"
+                                                         To="4" Duration="0:0:0.16" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </DataTrigger.ExitActions>
+                        </DataTrigger>
+                        <Trigger Property="IsDragging" Value="True">
+                            <Setter TargetName="Indicator" Property="Background" Value="{StaticResource PreviewBrushTextPrimary}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="ScrollBar">
+        <Setter Property="Width" Value="8" />
+        <Setter Property="MinWidth" Value="8" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
+        <Setter Property="Stylus.IsPressAndHoldEnabled" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ScrollBar">
+                    <Track x:Name="PART_Track" IsDirectionReversed="True">
+                        <Track.Resources>
+                            <sys:Double x:Key="{x:Static SystemParameters.VerticalScrollBarButtonHeightKey}">52</sys:Double>
+                        </Track.Resources>
+                        <Track.DecreaseRepeatButton>
+                            <RepeatButton Command="{x:Static ScrollBar.PageUpCommand}"
+                                          Style="{StaticResource PreviewScrollBarPageButton}" />
+                        </Track.DecreaseRepeatButton>
+                        <Track.IncreaseRepeatButton>
+                            <RepeatButton Command="{x:Static ScrollBar.PageDownCommand}"
+                                          Style="{StaticResource PreviewScrollBarPageButton}" />
+                        </Track.IncreaseRepeatButton>
+                        <Track.Thumb>
+                            <Thumb Style="{StaticResource PreviewVerticalScrollBarThumb}" />
+                        </Track.Thumb>
+                    </Track>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="Orientation" Value="Horizontal">
+                <Setter Property="Width" Value="Auto" />
+                <Setter Property="MinWidth" Value="0" />
+                <Setter Property="Height" Value="8" />
+                <Setter Property="MinHeight" Value="8" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ScrollBar">
+                            <Track x:Name="PART_Track">
+                                <Track.Resources>
+                                    <sys:Double x:Key="{x:Static SystemParameters.HorizontalScrollBarButtonWidthKey}">52</sys:Double>
+                                </Track.Resources>
+                                <Track.DecreaseRepeatButton>
+                                    <RepeatButton Command="{x:Static ScrollBar.PageLeftCommand}"
+                                                  Style="{StaticResource PreviewScrollBarPageButton}" />
+                                </Track.DecreaseRepeatButton>
+                                <Track.IncreaseRepeatButton>
+                                    <RepeatButton Command="{x:Static ScrollBar.PageRightCommand}"
+                                                  Style="{StaticResource PreviewScrollBarPageButton}" />
+                                </Track.IncreaseRepeatButton>
+                                <Track.Thumb>
+                                    <Thumb Style="{StaticResource PreviewHorizontalScrollBarThumb}" />
+                                </Track.Thumb>
+                            </Track>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="0.35" />
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style x:Key="PreviewButtonBase" TargetType="Button">
@@ -65,7 +231,7 @@
     </Style>
 
     <Style x:Key="PreviewTextBox" TargetType="TextBox">
-        <Setter Property="MinHeight" Value="{StaticResource PreviewControlHeightCompact}" />
+        <Setter Property="MinHeight" Value="{StaticResource PreviewInputHeight}" />
         <Setter Property="Padding" Value="{StaticResource PreviewControlPaddingCompact}" />
         <Setter Property="FontFamily" Value="{StaticResource PreviewFontFamilyUi}" />
         <Setter Property="FontSize" Value="{StaticResource PreviewFontSizeBody}" />
@@ -75,13 +241,185 @@
         <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushBorder}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="FocusVisualStyle" Value="{StaticResource PreviewFocusVisual}" />
-        <Style.Triggers>
-            <Trigger Property="IsKeyboardFocused" Value="True">
-                <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushFocusBlue}" />
-            </Trigger>
-            <Trigger Property="IsEnabled" Value="False">
-                <Setter Property="Opacity" Value="0.45" />
-            </Trigger>
-        </Style.Triggers>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TextBox">
+                    <Border x:Name="Chrome" Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{StaticResource PreviewRadiusMedium}" SnapsToDevicePixels="True">
+                        <ScrollViewer x:Name="PART_ContentHost" Padding="{TemplateBinding Padding}" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{StaticResource PreviewBrushBorderStrong}" />
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{StaticResource PreviewBrushFocusBlue}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.45" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="PreviewPasswordBox" TargetType="PasswordBox">
+        <Setter Property="MinHeight" Value="{StaticResource PreviewInputHeight}" />
+        <Setter Property="Padding" Value="{StaticResource PreviewControlPaddingCompact}" />
+        <Setter Property="FontFamily" Value="{StaticResource PreviewFontFamilyUi}" />
+        <Setter Property="FontSize" Value="{StaticResource PreviewFontSizeBody}" />
+        <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
+        <Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceCanvas}" />
+        <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushBorder}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource PreviewFocusVisual}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="PasswordBox">
+                    <Border x:Name="Chrome" Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{StaticResource PreviewRadiusMedium}" SnapsToDevicePixels="True">
+                        <ScrollViewer x:Name="PART_ContentHost" Padding="{TemplateBinding Padding}" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{StaticResource PreviewBrushBorderStrong}" />
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{StaticResource PreviewBrushFocusBlue}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.45" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="PreviewComboBoxEditableTextBox" TargetType="TextBox">
+        <Setter Property="Padding" Value="10,0,4,0" />
+        <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
+        <Setter Property="CaretBrush" Value="{StaticResource PreviewBrushTextPrimary}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TextBox">
+                    <ScrollViewer x:Name="PART_ContentHost" Padding="{TemplateBinding Padding}" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="PreviewComboBoxItem" TargetType="ComboBoxItem">
+        <Setter Property="Padding" Value="10,7" />
+        <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource PreviewFocusVisual}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ComboBoxItem">
+                    <Border x:Name="ItemChrome" Padding="{TemplateBinding Padding}"
+                            Background="{TemplateBinding Background}" CornerRadius="{StaticResource PreviewRadiusSmall}">
+                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsHighlighted" Value="True">
+                            <Setter TargetName="ItemChrome" Property="Background" Value="{StaticResource PreviewBrushSurfaceInteractive}" />
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="ItemChrome" Property="Background" Value="{StaticResource PreviewBrushBorder}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.45" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="PreviewComboBox" TargetType="ComboBox">
+        <Setter Property="MinHeight" Value="{StaticResource PreviewInputHeight}" />
+        <Setter Property="FontFamily" Value="{StaticResource PreviewFontFamilyUi}" />
+        <Setter Property="FontSize" Value="{StaticResource PreviewFontSizeBody}" />
+        <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
+        <Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceCanvas}" />
+        <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushBorder}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource PreviewFocusVisual}" />
+        <Setter Property="ItemContainerStyle" Value="{StaticResource PreviewComboBoxItem}" />
+        <Setter Property="MaxDropDownHeight" Value="320" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ComboBox">
+                    <Grid>
+                        <Border x:Name="Chrome" Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{StaticResource PreviewRadiusMedium}" SnapsToDevicePixels="True" />
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="32" />
+                            </Grid.ColumnDefinitions>
+                            <ToggleButton x:Name="DropDownToggle" Grid.ColumnSpan="2" Focusable="False"
+                                          Background="Transparent" BorderThickness="0"
+                                          IsChecked="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}">
+                                <ToggleButton.Template>
+                                    <ControlTemplate TargetType="ToggleButton">
+                                        <Border Background="Transparent" />
+                                    </ControlTemplate>
+                                </ToggleButton.Template>
+                            </ToggleButton>
+                            <ContentPresenter x:Name="ContentSite" Margin="10,0,4,0" VerticalAlignment="Center"
+                                              IsHitTestVisible="False" Content="{TemplateBinding SelectionBoxItem}"
+                                              ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" />
+                            <TextBox x:Name="PART_EditableTextBox" Margin="1" Visibility="Hidden"
+                                     IsReadOnly="{TemplateBinding IsReadOnly}"
+                                     Style="{StaticResource PreviewComboBoxEditableTextBox}" />
+                            <Path Grid.Column="1" Width="8" Height="5" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                  Fill="{StaticResource PreviewBrushTextSecondary}" IsHitTestVisible="False"
+                                  Data="M 0 0 L 8 0 L 4 5 Z" />
+                        </Grid>
+                        <Popup x:Name="PART_Popup" Placement="Bottom" AllowsTransparency="True"
+                               Focusable="False" IsOpen="{TemplateBinding IsDropDownOpen}">
+                            <Border MinWidth="{TemplateBinding ActualWidth}" MaxHeight="{TemplateBinding MaxDropDownHeight}"
+                                    Margin="0,4,0,0" Padding="4"
+                                    Background="{StaticResource PreviewBrushSurfaceRaised}"
+                                    BorderBrush="{StaticResource PreviewBrushBorderStrong}" BorderThickness="1"
+                                    CornerRadius="{StaticResource PreviewRadiusMedium}">
+                                <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                                    <ItemsPresenter />
+                                </ScrollViewer>
+                            </Border>
+                        </Popup>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{StaticResource PreviewBrushBorderStrong}" />
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocusWithin" Value="True">
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{StaticResource PreviewBrushFocusBlue}" />
+                        </Trigger>
+                        <Trigger Property="IsDropDownOpen" Value="True">
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="{StaticResource PreviewBrushFocusBlue}" />
+                        </Trigger>
+                        <Trigger Property="IsEditable" Value="True">
+                            <Setter TargetName="ContentSite" Property="Visibility" Value="Hidden" />
+                            <Setter TargetName="PART_EditableTextBox" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.45" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 </ResourceDictionary>

--- a/Phoenix_Translator/Themes/PreviewDesignTokens.xaml
+++ b/Phoenix_Translator/Themes/PreviewDesignTokens.xaml
@@ -58,6 +58,7 @@
     <Thickness x:Key="PreviewControlPaddingComfortable">12,8</Thickness>
     <sys:Double x:Key="PreviewControlHeightCompact">30</sys:Double>
     <sys:Double x:Key="PreviewControlHeightComfortable">38</sys:Double>
+    <sys:Double x:Key="PreviewInputHeight">34</sys:Double>
     <sys:Double x:Key="PreviewNavigationWidth">216</sys:Double>
     <sys:Double x:Key="PreviewInspectorWidth">320</sys:Double>
     <sys:Double x:Key="PreviewMotionFastMilliseconds">100</sys:Double>

--- a/Phoenix_Translator/UIManagement/Preview/PreviewHistoryUpdateView.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewHistoryUpdateView.xaml
@@ -34,13 +34,6 @@
                     </Trigger>
                 </Style.Triggers>
             </Style>
-            <Style x:Key="HistoryComboBox" TargetType="ComboBox">
-                <Setter Property="MinHeight" Value="32" />
-                <Setter Property="Padding" Value="8,3" />
-                <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
-                <Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceCanvas}" />
-                <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushBorder}" />
-            </Style>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -144,7 +137,7 @@
                     <TextBox Style="{StaticResource PreviewTextBox}" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
                              ToolTip="{localization:PreviewMessage Update_Search_Placeholder}"
                              AutomationProperties.Name="{localization:PreviewMessage Update_Search_Placeholder}" />
-                    <ComboBox Grid.Column="2" Style="{StaticResource HistoryComboBox}" ItemsSource="{Binding Filters}"
+                    <ComboBox Grid.Column="2" Style="{StaticResource PreviewComboBox}" ItemsSource="{Binding Filters}"
                               SelectedItem="{Binding SelectedFilter}"
                               AutomationProperties.Name="{localization:PreviewMessage Update_Filter_Name}" />
                     <StackPanel Grid.Column="4" Orientation="Horizontal">

--- a/Phoenix_Translator/UIManagement/Preview/PreviewReviewQualityView.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewReviewQualityView.xaml
@@ -9,57 +9,6 @@
                 <ResourceDictionary Source="/Themes/PreviewControlStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibility" />
-            <Style x:Key="ReviewComboBox" TargetType="ComboBox">
-                <Setter Property="MinHeight" Value="32" />
-                <Setter Property="Padding" Value="8,3" />
-                <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
-                <Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceCanvas}" />
-                <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushBorder}" />
-                <Setter Property="FocusVisualStyle" Value="{StaticResource PreviewFocusVisual}" />
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="ComboBox">
-                            <Grid>
-                                <ToggleButton Focusable="False" Background="Transparent" BorderThickness="0"
-                                              IsChecked="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}">
-                                    <ToggleButton.Template>
-                                        <ControlTemplate TargetType="ToggleButton">
-                                            <Border Background="{StaticResource PreviewBrushSurfaceCanvas}"
-                                                    BorderBrush="{StaticResource PreviewBrushBorder}" BorderThickness="1"
-                                                    CornerRadius="{StaticResource PreviewRadiusMedium}">
-                                                <Path Width="8" Height="5" Margin="0,0,10,0" HorizontalAlignment="Right"
-                                                      VerticalAlignment="Center" Fill="{StaticResource PreviewBrushTextSecondary}"
-                                                      Data="M 0 0 L 8 0 L 4 5 Z" />
-                                            </Border>
-                                        </ControlTemplate>
-                                    </ToggleButton.Template>
-                                </ToggleButton>
-                                <ContentPresenter Margin="10,0,28,0" VerticalAlignment="Center" IsHitTestVisible="False"
-                                                  Content="{TemplateBinding SelectionBoxItem}" />
-                                <Popup x:Name="PART_Popup" Placement="Bottom" AllowsTransparency="True"
-                                       IsOpen="{TemplateBinding IsDropDownOpen}">
-                                    <Border MinWidth="{TemplateBinding ActualWidth}" MaxHeight="320"
-                                            Background="{StaticResource PreviewBrushSurfaceRaised}"
-                                            BorderBrush="{StaticResource PreviewBrushBorderStrong}" BorderThickness="1">
-                                        <ScrollViewer><ItemsPresenter /></ScrollViewer>
-                                    </Border>
-                                </Popup>
-                            </Grid>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-            <Style TargetType="ComboBoxItem">
-                <Setter Property="Padding" Value="10,6" />
-                <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
-                <Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceRaised}" />
-                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                <Style.Triggers>
-                    <Trigger Property="IsHighlighted" Value="True">
-                        <Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceInteractive}" />
-                    </Trigger>
-                </Style.Triggers>
-            </Style>
             <Style x:Key="ReviewListItem" TargetType="ListBoxItem">
                 <Setter Property="Padding" Value="10,7" />
                 <Setter Property="Margin" Value="3,2" />
@@ -119,15 +68,15 @@
                          Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
                          ToolTip="{localization:PreviewMessage Review_Search_Placeholder}"
                          AutomationProperties.Name="{localization:PreviewMessage Review_Search_Placeholder}" />
-                <ComboBox Grid.Column="2" Style="{StaticResource ReviewComboBox}"
+                <ComboBox Grid.Column="2" Style="{StaticResource PreviewComboBox}"
                           ItemsSource="{Binding ReviewFilters}" SelectedItem="{Binding SelectedReviewFilter}"
                           Visibility="{Binding IsReviewMode, Converter={StaticResource BooleanToVisibility}}"
                           AutomationProperties.Name="{localization:PreviewMessage Review_Filter_State_Name}" />
-                <ComboBox Grid.Column="2" Style="{StaticResource ReviewComboBox}"
+                <ComboBox Grid.Column="2" Style="{StaticResource PreviewComboBox}"
                           ItemsSource="{Binding SeverityFilters}" SelectedItem="{Binding SelectedSeverityFilter}"
                           Visibility="{Binding IsQualityMode, Converter={StaticResource BooleanToVisibility}}"
                           AutomationProperties.Name="{localization:PreviewMessage Quality_Filter_Severity_Name}" />
-                <ComboBox Grid.Column="4" Style="{StaticResource ReviewComboBox}"
+                <ComboBox Grid.Column="4" Style="{StaticResource PreviewComboBox}"
                           ItemsSource="{Binding FindingTypeFilters}" SelectedItem="{Binding SelectedFindingTypeFilter}"
                           Visibility="{Binding IsQualityMode, Converter={StaticResource BooleanToVisibility}}"
                           AutomationProperties.Name="{localization:PreviewMessage Quality_Filter_Type_Name}" />

--- a/Phoenix_Translator/UIManagement/Preview/PreviewSettingsView.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewSettingsView.xaml
@@ -1,0 +1,346 @@
+<UserControl x:Class="PhoenixTranslator.UIManagement.Preview.PreviewSettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:localization="clr-namespace:PhoenixTranslator.UIManagement.Localization"
+             AutomationProperties.Name="{localization:PreviewMessage Settings_Title}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Themes/PreviewControlStyles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <BooleanToVisibilityConverter x:Key="BooleanToVisibility" />
+            <Style x:Key="SettingsCard" TargetType="Border">
+                <Setter Property="Margin" Value="0,0,0,12" />
+                <Setter Property="Padding" Value="18" />
+                <Setter Property="Background" Value="{StaticResource PreviewBrushSurfacePrimary}" />
+                <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushBorder}" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="CornerRadius" Value="5" />
+            </Style>
+            <Style x:Key="SettingsLabel" TargetType="TextBlock">
+                <Setter Property="Margin" Value="0,0,0,5" />
+                <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextSecondary}" />
+            </Style>
+            <Style x:Key="SettingsSectionTitle" TargetType="TextBlock">
+                <Setter Property="Margin" Value="0,0,0,14" />
+                <Setter Property="FontSize" Value="16" />
+                <Setter Property="FontWeight" Value="SemiBold" />
+                <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
+            </Style>
+            <Style x:Key="SettingsNavItem" TargetType="ListBoxItem">
+                <Setter Property="Padding" Value="14,9" />
+                <Setter Property="Margin" Value="0,0,4,0" />
+                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextSecondary}" />
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="FocusVisualStyle" Value="{StaticResource PreviewFocusVisual}" />
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True"><Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceInteractive}" /></Trigger>
+                    <Trigger Property="IsSelected" Value="True">
+                        <Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceInteractive}" />
+                        <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
+                        <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushAccentGold}" />
+                        <Setter Property="BorderThickness" Value="0,0,0,3" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+            <Style x:Key="SettingsCheckBox" TargetType="CheckBox">
+                <Setter Property="Margin" Value="0,5,0,8" />
+                <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
+                <Setter Property="FocusVisualStyle" Value="{StaticResource PreviewFocusVisual}" />
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <UserControl.InputBindings>
+        <KeyBinding Modifiers="Control" Key="S" Command="{Binding ApplyCommand}" />
+        <KeyBinding Key="Escape" Command="{Binding CancelCommand}" />
+    </UserControl.InputBindings>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="12" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="12" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Border Padding="10" Style="{StaticResource SettingsCard}" Margin="0">
+            <Grid>
+                <Grid.ColumnDefinitions><ColumnDefinition /><ColumnDefinition Width="12" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                <TextBox Style="{StaticResource PreviewTextBox}" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
+                         ToolTip="{localization:PreviewMessage Settings_Search_Placeholder}"
+                         AutomationProperties.Name="{localization:PreviewMessage Settings_Search_Placeholder}" />
+                <Button Grid.Column="2" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding OpenLegacyWorkspaceCommand}"
+                        Content="{localization:PreviewMessage Settings_Action_OpenLegacy}" />
+            </Grid>
+        </Border>
+
+        <Grid Grid.Row="2">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="12" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <Border Style="{StaticResource SettingsCard}" Margin="0" Padding="6">
+                <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
+                    <ListBox ItemsSource="{Binding VisibleCategories}" SelectedItem="{Binding SelectedCategory}"
+                             ItemContainerStyle="{StaticResource SettingsNavItem}" Background="Transparent" BorderThickness="0"
+                             AutomationProperties.Name="{localization:PreviewMessage Accessibility_Settings_CategoryList_Name}">
+                        <ListBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Horizontal" />
+                            </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock FontWeight="SemiBold" Text="{Binding Label}" ToolTip="{Binding Description}" />
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </ScrollViewer>
+            </Border>
+
+            <Grid Grid.Row="2">
+                <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="10" /><RowDefinition Height="*" /></Grid.RowDefinitions>
+                <TextBlock FontSize="12" Foreground="{StaticResource PreviewBrushTextSecondary}"
+                           Text="{Binding CurrentDescription}" TextWrapping="Wrap" />
+                <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                    <Grid>
+                        <StackPanel Visibility="{Binding IsGeneralVisible, Converter={StaticResource BooleanToVisibility}}">
+                            <Border Style="{StaticResource SettingsCard}">
+                                <StackPanel>
+                                    <TextBlock Style="{StaticResource SettingsSectionTitle}" Text="{localization:PreviewMessage Settings_Card_LanguageDefaults_Title}" />
+                                    <Grid>
+                                        <Grid.ColumnDefinitions><ColumnDefinition /><ColumnDefinition Width="16" /><ColumnDefinition /></Grid.ColumnDefinitions>
+                                        <StackPanel>
+                                            <TextBlock Style="{StaticResource SettingsLabel}" Text="{localization:PreviewMessage Settings_Field_SourceLanguage_Label}" />
+                                            <ComboBox Style="{StaticResource PreviewComboBox}" ItemsSource="{Binding LanguageOptions}"
+                                                      SelectedItem="{Binding Settings.SourceLanguage}" />
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="2">
+                                            <TextBlock Style="{StaticResource SettingsLabel}" Text="{localization:PreviewMessage Settings_Field_TargetLanguage_Label}" />
+                                            <ComboBox Style="{StaticResource PreviewComboBox}" ItemsSource="{Binding LanguageOptions}"
+                                                      SelectedItem="{Binding Settings.TargetLanguage}" />
+                                        </StackPanel>
+                                    </Grid>
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+
+                        <StackPanel Visibility="{Binding IsProvidersVisible, Converter={StaticResource BooleanToVisibility}}">
+                            <Border Style="{StaticResource SettingsCard}">
+                                <StackPanel>
+                                    <TextBlock Style="{StaticResource SettingsSectionTitle}" Text="{localization:PreviewMessage Settings_Providers_Cloud_Title}" />
+                                    <TextBlock Margin="0,0,0,12" Foreground="{StaticResource PreviewBrushWarning}" Text="{Binding ProviderDependencyText}" TextWrapping="Wrap" />
+                                    <Grid IsEnabled="{Binding HasProviders}">
+                                        <Grid.ColumnDefinitions><ColumnDefinition /><ColumnDefinition Width="16" /><ColumnDefinition /></Grid.ColumnDefinitions>
+                                        <StackPanel>
+                                            <TextBlock Style="{StaticResource SettingsLabel}" Text="{localization:PreviewMessage Settings_Providers_Provider_Label}" />
+                                            <ComboBox Style="{StaticResource PreviewComboBox}" ItemsSource="{Binding ProviderOptions}" SelectedItem="{Binding SelectedProvider}" />
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="2">
+                                            <TextBlock Style="{StaticResource SettingsLabel}" Text="{localization:PreviewMessage Settings_Providers_Model_Label}" />
+                                            <ComboBox Style="{StaticResource PreviewComboBox}" IsEditable="True" ItemsSource="{Binding ModelOptions}"
+                                                      Text="{Binding Settings.ProviderModel, UpdateSourceTrigger=PropertyChanged}" />
+                                        </StackPanel>
+                                    </Grid>
+                                    <CheckBox Style="{StaticResource SettingsCheckBox}" IsChecked="{Binding Settings.ProviderEnabled}"
+                                              Content="{localization:PreviewMessage Settings_Field_Enabled_Label}" IsEnabled="{Binding HasProviders}" />
+                                    <StackPanel Margin="0,8,0,0">
+                                        <StackPanel.Style>
+                                            <Style TargetType="StackPanel">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                                <Style.Triggers><DataTrigger Binding="{Binding IsLocalProvider}" Value="True"><Setter Property="Visibility" Value="Collapsed" /></DataTrigger></Style.Triggers>
+                                            </Style>
+                                        </StackPanel.Style>
+                                        <TextBlock Style="{StaticResource SettingsLabel}" Text="{localization:PreviewMessage Settings_Providers_ApiKey_Label}" />
+                                        <PasswordBox x:Name="ProviderCredential" Style="{StaticResource PreviewPasswordBox}"
+                                                     PasswordChanged="ProviderCredential_PasswordChanged"
+                                                     AutomationProperties.Name="{localization:PreviewMessage Settings_Providers_ApiKey_Label}" />
+                                        <TextBlock Margin="0,6,0,0" FontSize="11" Foreground="{StaticResource PreviewBrushSuccess}"
+                                                   Text="{localization:PreviewMessage Settings_Providers_ApiKey_Stored}"
+                                                   Visibility="{Binding Settings.HasStoredCredential, Converter={StaticResource BooleanToVisibility}}" />
+                                        <TextBlock Margin="0,6,0,0" FontSize="11" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                                   Text="{localization:PreviewMessage Settings_Providers_CredentialReplace_Hint}" />
+                                    </StackPanel>
+                                    <StackPanel Margin="0,8,0,0">
+                                        <StackPanel.Style>
+                                            <Style TargetType="StackPanel">
+                                                <Setter Property="Visibility" Value="Collapsed" />
+                                                <Style.Triggers><DataTrigger Binding="{Binding IsLocalProvider}" Value="True"><Setter Property="Visibility" Value="Visible" /></DataTrigger></Style.Triggers>
+                                            </Style>
+                                        </StackPanel.Style>
+                                        <TextBlock Style="{StaticResource SettingsLabel}" Text="{localization:PreviewMessage Settings_Providers_Endpoint_Label}" />
+                                        <TextBox Style="{StaticResource PreviewTextBox}" Text="{Binding Settings.LocalPortText, UpdateSourceTrigger=PropertyChanged}" />
+                                    </StackPanel>
+                                    <WrapPanel Margin="0,16,0,0">
+                                        <Button Style="{StaticResource PreviewButtonPrimary}" Command="{Binding TestProviderCommand}"
+                                                Content="{localization:PreviewMessage Settings_Providers_Test_Action}" />
+                                        <Button Margin="8,0,0,0" Style="{StaticResource PreviewButtonSecondary}"
+                                                Command="{Binding CancelProviderTestCommand}"
+                                                Content="{localization:PreviewMessage Settings_Providers_Test_Cancel_Action}"
+                                                Visibility="{Binding IsTestingProvider, Converter={StaticResource BooleanToVisibility}}" />
+                                    </WrapPanel>
+                                    <TextBlock Margin="0,8,0,0" FontSize="11" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                               Text="{localization:PreviewMessage Settings_Providers_Test_Privacy}" TextWrapping="Wrap" />
+                                    <TextBlock Margin="0,8,0,0" Foreground="{StaticResource PreviewBrushTextSecondary}"
+                                               Text="{Binding ProviderTestStatusText}" TextWrapping="Wrap" />
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+
+                        <StackPanel Visibility="{Binding IsTranslationVisible, Converter={StaticResource BooleanToVisibility}}">
+                            <Border Style="{StaticResource SettingsCard}">
+                                <StackPanel>
+                                    <TextBlock Style="{StaticResource SettingsSectionTitle}" Text="{localization:PreviewMessage Settings_Card_Context_Title}" />
+                                    <CheckBox Style="{StaticResource SettingsCheckBox}" IsChecked="{Binding Settings.EnableContext}"
+                                              Content="{localization:PreviewMessage Settings_Field_ContextEnabled_Label}" />
+                                    <TextBlock Style="{StaticResource SettingsLabel}" Text="{localization:PreviewMessage Settings_Field_ContextLimit_Label}" />
+                                    <TextBox Style="{StaticResource PreviewTextBox}" IsEnabled="{Binding Settings.EnableContext}"
+                                             Text="{Binding Settings.ContextLimitText, UpdateSourceTrigger=PropertyChanged}" />
+                                    <TextBlock Margin="0,5,0,8" FontSize="11" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                               Text="{localization:PreviewMessage Settings_Dependency_ContextDisabled}">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Visibility" Value="Collapsed" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Settings.EnableContext}" Value="False">
+                                                        <Setter Property="Visibility" Value="Visible" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                    <CheckBox Style="{StaticResource SettingsCheckBox}" IsChecked="{Binding Settings.EnableLanguageDetection}"
+                                              Content="{localization:PreviewMessage Settings_Field_LanguageDetection_Label}" />
+                                </StackPanel>
+                            </Border>
+                            <Border Style="{StaticResource SettingsCard}">
+                                <StackPanel>
+                                    <TextBlock Style="{StaticResource SettingsSectionTitle}" Text="{localization:PreviewMessage Settings_Card_Prompt_Title}" />
+                                    <TextBlock Style="{StaticResource SettingsLabel}" Text="{localization:PreviewMessage Settings_Field_AdditionalPrompt_Label}" />
+                                    <TextBox Height="100" AcceptsReturn="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto"
+                                             Style="{StaticResource PreviewTextBox}" Text="{Binding Settings.AdditionalPrompt, UpdateSourceTrigger=PropertyChanged}" />
+                                    <TextBlock Margin="0,14,0,5" Foreground="{StaticResource PreviewBrushTextSecondary}"
+                                               Text="{localization:PreviewMessage Settings_Field_PlaceholderPattern_Label}" />
+                                    <TextBox Style="{StaticResource PreviewTextBox}" Text="{Binding Settings.PlaceholderPattern, UpdateSourceTrigger=PropertyChanged}" />
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+
+                        <StackPanel Visibility="{Binding IsFilesVisible, Converter={StaticResource BooleanToVisibility}}">
+                            <Border Style="{StaticResource SettingsCard}">
+                                <StackPanel>
+                                    <TextBlock Style="{StaticResource SettingsSectionTitle}" Text="{localization:PreviewMessage Settings_Card_GamePath_Title}" />
+                                    <TextBlock Style="{StaticResource SettingsLabel}" Text="{localization:PreviewMessage Settings_Field_GamePath_Label}" />
+                                    <TextBox Style="{StaticResource PreviewTextBox}" Text="{Binding Settings.GamePath, UpdateSourceTrigger=PropertyChanged}" />
+                                    <CheckBox Style="{StaticResource SettingsCheckBox}" IsChecked="{Binding Settings.ShowAssembly}"
+                                              Content="{localization:PreviewMessage Settings_Field_ShowAssembly_Label}" />
+                                    <CheckBox Style="{StaticResource SettingsCheckBox}" IsChecked="{Binding Settings.GenerateCSharp}"
+                                              Content="{localization:PreviewMessage Settings_Field_GenerateCSharp_Label}" />
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+
+                        <StackPanel Visibility="{Binding IsHistoryDataVisible, Converter={StaticResource BooleanToVisibility}}">
+                            <Border Style="{StaticResource SettingsCard}">
+                                <StackPanel>
+                                    <TextBlock Style="{StaticResource SettingsSectionTitle}" Text="{localization:PreviewMessage Settings_Card_TranslationData_Title}" />
+                                    <CheckBox Style="{StaticResource SettingsCheckBox}" IsChecked="{Binding Settings.AutoUpdateDatabase}"
+                                              Content="{localization:PreviewMessage Settings_Field_AutoUpdateDatabase_Label}" />
+                                    <CheckBox Style="{StaticResource SettingsCheckBox}" IsChecked="{Binding Settings.EnableGlobalSearch}"
+                                              Content="{localization:PreviewMessage Settings_Field_GlobalSearch_Label}" />
+                                    <Button Margin="0,10,0,0" HorizontalAlignment="Left" Style="{StaticResource PreviewButtonSecondary}"
+                                            Command="{Binding OpenLegacyWorkspaceCommand}" Content="{localization:PreviewMessage Settings_Data_OpenManager_Action}" />
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+
+                        <StackPanel Visibility="{Binding IsAppearanceVisible, Converter={StaticResource BooleanToVisibility}}">
+                            <Border Style="{StaticResource SettingsCard}">
+                                <StackPanel>
+                                    <TextBlock Style="{StaticResource SettingsSectionTitle}" Text="{localization:PreviewMessage Settings_Card_Appearance_Title}" />
+                                    <Grid>
+                                        <Grid.ColumnDefinitions><ColumnDefinition /><ColumnDefinition Width="16" /><ColumnDefinition /></Grid.ColumnDefinitions>
+                                        <StackPanel>
+                                            <TextBlock Style="{StaticResource SettingsLabel}" Text="{localization:PreviewMessage Settings_Field_UiLanguage_Label}" />
+                                            <ComboBox Style="{StaticResource PreviewComboBox}" ItemsSource="{Binding LanguageOptions}" SelectedItem="{Binding Settings.UiLanguage}" />
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="2">
+                                            <TextBlock Style="{StaticResource SettingsLabel}" Text="{localization:PreviewMessage Settings_Field_Density_Label}" />
+                                            <ComboBox Style="{StaticResource PreviewComboBox}" ItemsSource="{Binding DensityOptions}" SelectedItem="{Binding Settings.Density}" />
+                                        </StackPanel>
+                                    </Grid>
+                                    <CheckBox Style="{StaticResource SettingsCheckBox}" IsChecked="{Binding Settings.RightToLeft}"
+                                              Content="{localization:PreviewMessage Settings_Field_RightToLeft_Label}" />
+                                    <TextBlock Margin="0,8,0,0" Foreground="{StaticResource PreviewBrushTextMuted}" Text="{localization:PreviewMessage Settings_Restart_Hint}" />
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+
+                        <StackPanel Visibility="{Binding IsAdvancedVisible, Converter={StaticResource BooleanToVisibility}}">
+                            <Border Style="{StaticResource SettingsCard}">
+                                <StackPanel>
+                                    <TextBlock Style="{StaticResource SettingsSectionTitle}" Text="{localization:PreviewMessage Settings_Card_Proxy_Title}" />
+                                    <TextBlock Style="{StaticResource SettingsLabel}" Text="{localization:PreviewMessage Settings_Field_ProxyUrl_Label}" />
+                                    <TextBox Style="{StaticResource PreviewTextBox}" Text="{Binding Settings.ProxyUrl, UpdateSourceTrigger=PropertyChanged}" />
+                                    <TextBlock Margin="0,12,0,5" Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{localization:PreviewMessage Settings_Field_ProxyUser_Label}" />
+                                    <TextBox Style="{StaticResource PreviewTextBox}" Text="{Binding Settings.ProxyUserName, UpdateSourceTrigger=PropertyChanged}" />
+                                    <TextBlock Margin="0,12,0,5" Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{localization:PreviewMessage Settings_Field_ProxyPassword_Label}" />
+                                    <PasswordBox x:Name="ProxyPassword" Style="{StaticResource PreviewPasswordBox}"
+                                                 PasswordChanged="ProxyPassword_PasswordChanged" />
+                                    <TextBlock Margin="0,6,0,0" FontSize="11" Foreground="{StaticResource PreviewBrushSuccess}"
+                                               Text="{localization:PreviewMessage Settings_Providers_ApiKey_Stored}"
+                                               Visibility="{Binding Settings.HasStoredProxyPassword, Converter={StaticResource BooleanToVisibility}}" />
+                                </StackPanel>
+                            </Border>
+                            <Border Style="{StaticResource SettingsCard}">
+                                <StackPanel>
+                                    <TextBlock Style="{StaticResource SettingsSectionTitle}" Text="{localization:PreviewMessage Settings_Card_Performance_Title}" />
+                                    <Grid>
+                                        <Grid.ColumnDefinitions><ColumnDefinition /><ColumnDefinition Width="12" /><ColumnDefinition /><ColumnDefinition Width="12" /><ColumnDefinition /></Grid.ColumnDefinitions>
+                                        <StackPanel>
+                                            <TextBlock Style="{StaticResource SettingsLabel}" Text="{localization:PreviewMessage Settings_Field_MaxThreads_Label}" />
+                                            <TextBox Style="{StaticResource PreviewTextBox}" Text="{Binding Settings.MaxThreadCountText, UpdateSourceTrigger=PropertyChanged}" />
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="2">
+                                            <TextBlock Style="{StaticResource SettingsLabel}" Text="{localization:PreviewMessage Settings_Field_ThrottleRatio_Label}" />
+                                            <TextBox Style="{StaticResource PreviewTextBox}" Text="{Binding Settings.ThrottleRatioText, UpdateSourceTrigger=PropertyChanged}" />
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="4">
+                                            <TextBlock Style="{StaticResource SettingsLabel}" Text="{localization:PreviewMessage Settings_Field_ThrottleDelay_Label}" />
+                                            <TextBox Style="{StaticResource PreviewTextBox}" Text="{Binding Settings.ThrottleDelayText, UpdateSourceTrigger=PropertyChanged}" />
+                                        </StackPanel>
+                                    </Grid>
+                                    <Button Margin="0,16,0,0" HorizontalAlignment="Left" Style="{StaticResource PreviewButtonSecondary}"
+                                            Command="{Binding OpenLegacyWorkspaceCommand}" Content="{localization:PreviewMessage Settings_Advanced_OpenPipeline_Action}" />
+                                </StackPanel>
+                            </Border>
+                        </StackPanel>
+                    </Grid>
+                </ScrollViewer>
+            </Grid>
+        </Grid>
+
+        <Border Grid.Row="4" Padding="12" Style="{StaticResource SettingsCard}" Margin="0">
+            <Grid>
+                <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                <StackPanel>
+                    <TextBlock FontWeight="SemiBold" Foreground="{StaticResource PreviewBrushTextPrimary}" Text="{Binding StateText}" />
+                    <ItemsControl Margin="0,5,0,0" ItemsSource="{Binding ValidationMessages}"
+                                  AutomationProperties.Name="{localization:PreviewMessage Accessibility_Settings_Validation_Name}">
+                        <ItemsControl.ItemTemplate><DataTemplate><TextBlock Foreground="{StaticResource PreviewBrushError}" Text="{Binding}" TextWrapping="Wrap" /></DataTemplate></ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+                <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Top">
+                    <Button Margin="0,0,8,0" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding ResetCommand}" Content="{localization:PreviewMessage Settings_Action_Reset}" />
+                    <Button Margin="0,0,8,0" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding CancelCommand}" Content="{localization:PreviewMessage Settings_Action_Cancel}" />
+                    <Button Style="{StaticResource PreviewButtonPrimary}" Command="{Binding ApplyCommand}" Content="{localization:PreviewMessage Settings_Action_Apply}" />
+                </StackPanel>
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/Phoenix_Translator/UIManagement/Preview/PreviewSettingsView.xaml.cs
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewSettingsView.xaml.cs
@@ -1,0 +1,66 @@
+using System.Windows;
+using System.Windows.Controls;
+using PhoenixTranslator.ApplicationLayer;
+
+namespace PhoenixTranslator.UIManagement.Preview
+{
+    /// <summary>
+    /// Presents the unified searchable Settings Center.
+    /// </summary>
+    public partial class PreviewSettingsView : UserControl
+    {
+        /// <summary>
+        /// Creates the Settings Center view.
+        /// </summary>
+        public PreviewSettingsView()
+        {
+            InitializeComponent();
+            DataContextChanged += PreviewSettingsViewDataContextChanged;
+        }
+
+        private void PreviewSettingsViewDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            var previous = e.OldValue as PreviewSettingsViewModel;
+            if (previous != null)
+            {
+                previous.SecretsCleared -= ViewModelSecretsCleared;
+                previous.ProviderCredentialCleared -= ViewModelProviderCredentialCleared;
+            }
+
+            var current = e.NewValue as PreviewSettingsViewModel;
+            if (current != null)
+            {
+                current.SecretsCleared += ViewModelSecretsCleared;
+                current.ProviderCredentialCleared += ViewModelProviderCredentialCleared;
+            }
+
+            ClearSecrets();
+        }
+
+        private void ViewModelSecretsCleared(object sender, System.EventArgs e)
+        {
+            ClearSecrets();
+        }
+
+        private void ViewModelProviderCredentialCleared(object sender, System.EventArgs e)
+        {
+            ProviderCredential.Clear();
+        }
+
+        private void ClearSecrets()
+        {
+            ProviderCredential.Clear();
+            ProxyPassword.Clear();
+        }
+
+        private void ProviderCredential_PasswordChanged(object sender, RoutedEventArgs e)
+        {
+            (DataContext as PreviewSettingsViewModel)?.StageProviderCredential(ProviderCredential.Password);
+        }
+
+        private void ProxyPassword_PasswordChanged(object sender, RoutedEventArgs e)
+        {
+            (DataContext as PreviewSettingsViewModel)?.StageProxyPassword(ProxyPassword.Password);
+        }
+    }
+}

--- a/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml
@@ -201,6 +201,10 @@
                         Visibility="{Binding DataContext.IsHistoryUpdateWorkspaceVisible,
                             RelativeSource={RelativeSource AncestorType={x:Type Window}},
                             Converter={StaticResource BooleanToVisibility}}" />
+                <preview:PreviewSettingsView x:Name="SettingsWorkspace" Grid.Row="2"
+                        Visibility="{Binding DataContext.IsSettingsWorkspaceVisible,
+                            RelativeSource={RelativeSource AncestorType={x:Type Window}},
+                            Converter={StaticResource BooleanToVisibility}}" />
             </Grid>
         </Grid>
 

--- a/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml.cs
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml.cs
@@ -15,6 +15,7 @@ namespace PhoenixTranslator.UIManagement.Preview
         private readonly PreviewTranslationWorkspaceViewModel _translationWorkspaceViewModel;
         private readonly PreviewReviewQualityViewModel _reviewQualityViewModel;
         private readonly PreviewHistoryUpdateViewModel _historyUpdateViewModel;
+        private readonly PreviewSettingsViewModel _settingsViewModel;
 
         /// <summary>
         /// Creates the preview application shell in its no-project state.
@@ -45,10 +46,17 @@ namespace PhoenixTranslator.UIManagement.Preview
                 ConfirmConflictReuse,
                 ConfirmBulkReuse,
                 OpenLegacyWorkspace);
+            _settingsViewModel = new PreviewSettingsViewModel(
+                shellViewModel,
+                new LegacyPreviewSettingsStore(),
+                ConfirmSettingsReset,
+                ConfirmSettingsDiscard,
+                OpenLegacyWorkspace);
             DataContext = shellViewModel;
             TranslationWorkspace.DataContext = _translationWorkspaceViewModel;
             ReviewQualityWorkspace.DataContext = _reviewQualityViewModel;
             HistoryUpdateWorkspace.DataContext = _historyUpdateViewModel;
+            SettingsWorkspace.DataContext = _settingsViewModel;
         }
 
         private bool ConfirmBulkApproval(int entryCount)
@@ -108,6 +116,28 @@ namespace PhoenixTranslator.UIManagement.Preview
                 MessageBoxResult.Cancel) == MessageBoxResult.OK;
         }
 
+        private bool ConfirmSettingsReset()
+        {
+            return MessageBox.Show(
+                this,
+                PreviewMessageCatalog.Get("Settings_Reset_Confirmation"),
+                PreviewMessageCatalog.Get("Settings_Reset_ConfirmationTitle"),
+                MessageBoxButton.OKCancel,
+                MessageBoxImage.Warning,
+                MessageBoxResult.Cancel) == MessageBoxResult.OK;
+        }
+
+        private bool ConfirmSettingsDiscard()
+        {
+            return MessageBox.Show(
+                this,
+                PreviewMessageCatalog.Get("Settings_Discard_Confirmation"),
+                PreviewMessageCatalog.Get("Settings_Discard_ConfirmationTitle"),
+                MessageBoxButton.OKCancel,
+                MessageBoxImage.Warning,
+                MessageBoxResult.Cancel) == MessageBoxResult.OK;
+        }
+
         private void OpenLegacyWorkspace()
         {
             if (_legacyWorkspace == null)
@@ -133,6 +163,13 @@ namespace PhoenixTranslator.UIManagement.Preview
 
         private void Window_Closing(object sender, CancelEventArgs e)
         {
+            if (!_settingsViewModel.TryDiscardForClose())
+            {
+                e.Cancel = true;
+                return;
+            }
+
+            _settingsViewModel.Dispose();
             _historyUpdateViewModel.Dispose();
             _reviewQualityViewModel.Dispose();
             _translationWorkspaceViewModel.Dispose();

--- a/Phoenix_Translator/UIManagement/Preview/PreviewTranslationWorkspaceView.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewTranslationWorkspaceView.xaml
@@ -9,58 +9,6 @@
                 <ResourceDictionary Source="/Themes/PreviewControlStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibility" />
-            <Style x:Key="WorkspaceComboBox" TargetType="ComboBox">
-            <Setter Property="MinHeight" Value="32" />
-            <Setter Property="Padding" Value="8,3" />
-            <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
-            <Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceCanvas}" />
-            <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushBorder}" />
-            <Setter Property="FocusVisualStyle" Value="{StaticResource PreviewFocusVisual}" />
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="ComboBox">
-                        <Grid>
-                            <ToggleButton Focusable="False" Background="Transparent" BorderThickness="0"
-                                          IsChecked="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}">
-                                <ToggleButton.Template>
-                                    <ControlTemplate TargetType="ToggleButton">
-                                        <Border Background="{StaticResource PreviewBrushSurfaceCanvas}"
-                                                BorderBrush="{StaticResource PreviewBrushBorder}" BorderThickness="1"
-                                                CornerRadius="{StaticResource PreviewRadiusMedium}">
-                                            <Path Width="8" Height="5" Margin="0,0,10,0" HorizontalAlignment="Right"
-                                                  VerticalAlignment="Center" Fill="{StaticResource PreviewBrushTextSecondary}"
-                                                  Data="M 0 0 L 8 0 L 4 5 Z" />
-                                        </Border>
-                                    </ControlTemplate>
-                                </ToggleButton.Template>
-                            </ToggleButton>
-                            <ContentPresenter Margin="10,0,28,0" VerticalAlignment="Center"
-                                              IsHitTestVisible="False" Content="{TemplateBinding SelectionBoxItem}"
-                                              ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" />
-                            <Popup x:Name="PART_Popup" Placement="Bottom" AllowsTransparency="True"
-                                   IsOpen="{TemplateBinding IsDropDownOpen}">
-                                <Border MinWidth="{TemplateBinding ActualWidth}" MaxHeight="320"
-                                        Background="{StaticResource PreviewBrushSurfaceRaised}"
-                                        BorderBrush="{StaticResource PreviewBrushBorderStrong}" BorderThickness="1">
-                                    <ScrollViewer><ItemsPresenter /></ScrollViewer>
-                                </Border>
-                            </Popup>
-                        </Grid>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-            </Style>
-            <Style TargetType="ComboBoxItem">
-                <Setter Property="Padding" Value="10,6" />
-                <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
-                <Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceRaised}" />
-                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                <Style.Triggers>
-                    <Trigger Property="IsHighlighted" Value="True">
-                        <Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceInteractive}" />
-                    </Trigger>
-                </Style.Triggers>
-            </Style>
             <Style x:Key="WorkspaceEntryItem" TargetType="ListBoxItem">
             <Setter Property="Padding" Value="12,8" />
             <Setter Property="Margin" Value="4,2" />
@@ -119,11 +67,11 @@
                          Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}"
                          ToolTip="{localization:PreviewMessage Workspace_Search_Placeholder}"
                          AutomationProperties.Name="{localization:PreviewMessage Workspace_Search_Placeholder}" />
-                <ComboBox Grid.Column="2" Style="{StaticResource WorkspaceComboBox}"
+                <ComboBox Grid.Column="2" Style="{StaticResource PreviewComboBox}"
                           ItemsSource="{Binding StateFilters}" DisplayMemberPath="Label"
                           SelectedItem="{Binding SelectedStateFilter}"
                           AutomationProperties.Name="{localization:PreviewMessage Workspace_Filter_State_Name}" />
-                <ComboBox Grid.Column="4" Style="{StaticResource WorkspaceComboBox}"
+                <ComboBox Grid.Column="4" Style="{StaticResource PreviewComboBox}"
                           ItemsSource="{Binding TypeFilters}" SelectedItem="{Binding SelectedTypeFilter}"
                           AutomationProperties.Name="{localization:PreviewMessage Workspace_Filter_Type_Name}" />
                 <Button Grid.Column="6" Style="{StaticResource PreviewButtonSecondary}"

--- a/docs/settings/legacy-entrypoint-map.md
+++ b/docs/settings/legacy-entrypoint-map.md
@@ -1,0 +1,62 @@
+# Settings consolidation map
+
+Phoenix Translator currently exposes configuration through several tabs, popovers, dialogs, and project tools.
+The preview replaces that distribution with one Settings Center hosted by the application shell. Search, intent
+categories, staged edits, and a persistent action bar keep the complete surface understandable without removing
+power-user options.
+
+## Central information architecture
+
+| Settings Center category | User intent | Consolidated legacy sources |
+| --- | --- | --- |
+| General | Choose application-level defaults and startup behavior. | Main Settings shell, game selection, source and target language defaults. |
+| Providers | Choose providers, models, credentials, and local endpoints; validate configuration. | `Request & ApiKey`, `PlatformConfigStyleWin`, provider-specific cards. |
+| Translation | Control presets, context, language detection, punctuation, placeholders, and preprocessing. | `AI Configs`, `Engine Configs`, translation preset controls, relevant `TranslateConfig` options. |
+| Files & formats | Configure game paths, ESP and PEX behavior, code generation, and import or export defaults. | `Game Configs`, format controls, global import and export actions from `TranslateConfig`. |
+| History & data | Configure caches, translation memory, automatic database updates, and retention behavior. | Cache controls, database viewer entry points, terminology and history persistence options. |
+| Appearance & accessibility | Choose density, text direction, language, and accessible presentation defaults. | `UI Configs`, theme actions, text-layout controls. |
+| Advanced | Configure the provider pipeline, custom providers, proxies, concurrency, throttling, and diagnostic behavior. | Node menu, `NodeStyleWin`, `CustomWizard`, proxy controls, advanced Engine settings. |
+
+Terminology entries and database records remain project or data content rather than preference values. The
+Settings Center owns their global behavior and offers one route to the relevant manager, but does not mix record
+editing into ordinary settings forms.
+
+## Legacy entry points
+
+| Legacy entry point | Current behavior | Preview destination |
+| --- | --- | --- |
+| Main `Settings` destination | Hosts five implementation-oriented tabs. | Open the Settings Center overview. |
+| `Request & ApiKey` tab | Edits proxy values, credentials, provider models, and local ports. | Providers; proxy fields move to Advanced. |
+| `AI Configs` tab | Edits the global additional prompt. | Translation. |
+| `Game Configs` tab | Mixes file-format and game-specific parser options. | General and Files & formats. |
+| `UI Configs` tab | Edits text direction and theme behavior. | Appearance & accessibility. |
+| `Engine Configs` tab | Mixes presets, context, concurrency, database, and language behavior. | Translation, History & data, and Advanced. |
+| Provider configuration cards | Save model, key, and endpoint changes immediately. | Providers with staged changes and masked credentials. |
+| Node menu | Enables or disables providers and preprocessing immediately. | Advanced provider pipeline. |
+| Custom provider wizard | Creates request templates and tests calls in a separate window. | Advanced custom-provider editor with an explicit test action. |
+| Translation configuration window | Mixes terminology content, preprocessing, languages, and data transfer. | Translation and History & data routes; terminology content remains in its dedicated manager. |
+| Database viewer | Opens global terminology data outside a clear settings hierarchy. | History & data route to the data manager. |
+| Theme and language event handlers | Persist individual values as soon as controls change. | Appearance & accessibility with Apply, Cancel, and restart guidance. |
+
+## Overview and navigation behavior
+
+- A horizontally scrollable tab row contains the seven stable intent categories without duplicating the shell's
+  vertical navigation. Category descriptions remain available as tab tooltips and compact page context.
+- A global search matches labels, descriptions, legacy terms, and common synonyms such as `API key`, `node`,
+  `dictionary`, `PEX`, `context`, and `theme`.
+- Search filters the category tabs by labels, descriptions, legacy terms, and common synonyms.
+- Each category starts with a short outcome-oriented description and uses a small number of cohesive cards.
+- Advanced dependencies are collapsed by default and explain why unavailable controls are disabled.
+- A persistent footer shows `Clean`, `Modified`, or `Invalid` and always keeps Apply, Cancel, and Reset reachable.
+- Credentials are write-only: existing values appear only as `Stored securely`; replacement values are never
+  copied into diagnostics, notifications, screenshots, or searchable text.
+- Provider tests use staged values without saving, send no project or translation text, read no response body,
+  and can be cancelled explicitly.
+- The legacy settings workspace remains one explicit fallback during preview. It is not presented as another
+  primary settings destination.
+
+## Migration rule
+
+Every old settings action must either navigate to one Settings Center category, navigate to a content manager, or
+be documented as intentionally retired. No new configuration field may introduce another top-level window or
+immediate persistence event.

--- a/docs/settings/provider-connectivity-test.md
+++ b/docs/settings/provider-connectivity-test.md
@@ -1,0 +1,37 @@
+# Provider connectivity test
+
+The Settings Center provides one explicit, cancellable availability test for built-in translation providers.
+The test validates staged settings without persisting them and never performs a translation request.
+
+## Privacy and security boundary
+
+- No project name, path, source text, target text, prompt, terminology, or translation-memory content is sent.
+- Credentials and proxy passwords remain write-only and are never included in bindings, status messages, logs,
+  exception text, or response parsing.
+- The response body is not read. Only the HTTP status is classified into a small sanitized result set.
+- Requests use normal platform TLS validation. No certificate callback or TLS override is installed.
+- Each request has a ten-second timeout and accepts cooperative cancellation.
+- Staged proxy settings are honored for cloud providers. Local LM Studio tests bypass proxies.
+
+## Built-in endpoints
+
+| Provider | Read-only request | Authentication |
+| --- | --- | --- |
+| OpenAI | `GET https://api.openai.com/v1/models` | `Authorization: Bearer` |
+| Gemini | `GET https://generativelanguage.googleapis.com/v1beta/models` | `x-goog-api-key` |
+| DeepSeek | `GET https://api.deepseek.com/models` | `Authorization: Bearer` |
+| DeepL API Pro | `GET https://api.deepl.com/v2/usage` | `Authorization: DeepL-Auth-Key` |
+| DeepL API Free | `GET https://api-free.deepl.com/v2/usage` | `Authorization: DeepL-Auth-Key` |
+| LM Studio | `GET http://localhost:{port}/v1/models` | None |
+
+The endpoints follow the providers' official model-list or usage documentation:
+
+- [OpenAI model listing](https://developers.openai.com/api/reference/resources/models/methods/list)
+- [Gemini model listing](https://ai.google.dev/api/models)
+- [DeepSeek model listing](https://api-docs.deepseek.com/api/list-models/)
+- [DeepL usage and limits](https://developers.deepl.com/api-reference/usage-and-quota/check-usage-and-limits)
+- [LM Studio OpenAI-compatible API](https://lmstudio.ai/docs/developer/openai-compat)
+
+Custom and interactive providers are intentionally not probed from the central Settings Center. Their arbitrary
+request definitions require the advanced provider manager, where the user can inspect the endpoint and request
+shape before testing.


### PR DESCRIPTION
Closes #33

## Summary

- replace the scattered preview settings surfaces with one searchable, intent-based Settings Center
- stage all changes until Apply, with explicit Cancel, Reset, validation, and unsaved-change handling
- keep credentials write-only and add bounded, cancellable provider connectivity tests that send no translation content
- consolidate preview text fields, password fields, dropdowns, and reactive dark-mode scrollbars into shared styles
- retain one explicit legacy fallback while the preview migration is in progress
- document the legacy entry-point mapping and provider-test security boundary
- bump the application version to 2.0.0.11

## Validation

- Visual Studio MSBuild Release x64: passed
- PhoenixTranslator.PresetTests: 31 passed, 0 failed
- provider tests do not persist staged values or read response bodies
- existing compiler warnings remain unchanged