### PR TITLE
Add export, terminology, and workspace tools

### DIFF
--- a/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
+++ b/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
@@ -98,6 +98,12 @@
     <Compile Include="..\Phoenix_Translator\Application\PreviewTranslationWorkspaceViewModel.cs">
       <Link>PreviewTranslationWorkspaceViewModel.cs</Link>
     </Compile>
+    <Compile Include="..\Phoenix_Translator\Application\PreviewWorkspaceToolsViewModel.cs">
+      <Link>PreviewWorkspaceToolsViewModel.cs</Link>
+    </Compile>
+    <Compile Include="..\Phoenix_Translator\Application\PreviewWorkspaceToolServices.cs">
+      <Link>PreviewWorkspaceToolServices.cs</Link>
+    </Compile>
     <Compile Include="..\Phoenix_Translator\Application\TranslationPresetService.cs">
       <Link>TranslationPresetService.cs</Link>
     </Compile>

--- a/PhoenixTranslator.PresetTests/Program.cs
+++ b/PhoenixTranslator.PresetTests/Program.cs
@@ -42,6 +42,10 @@ namespace PhoenixTranslator.PresetTests
                 { nameof(HandlesPreviewTranslationFailures), HandlesPreviewTranslationFailures },
                 { nameof(CancelsPreviewTranslationWork), CancelsPreviewTranslationWork },
                 { nameof(FiltersLargePreviewTranslationProject), FiltersLargePreviewTranslationProject },
+                { nameof(PreviewsAppliesAndUndoesWorkspaceReplacement), PreviewsAppliesAndUndoesWorkspaceReplacement },
+                { nameof(RoundTripsBoundedTranslationTable), RoundTripsBoundedTranslationTable },
+                { nameof(ValidatesInteractiveProviderRequestIdentity), ValidatesInteractiveProviderRequestIdentity },
+                { nameof(StagesWritingVariantAndTracksExportReadiness), StagesWritingVariantAndTracksExportReadiness },
                 { nameof(AnalyzesMixedQualityFindings), AnalyzesMixedQualityFindings },
                 { nameof(TracksReviewDecisionsAndBulkUndo), TracksReviewDecisionsAndBulkUndo },
                 { nameof(PersistsPrivateReviewMetadata), PersistsPrivateReviewMetadata },
@@ -659,6 +663,115 @@ namespace PhoenixTranslator.PresetTests
             viewModel.Dispose();
         }
 
+        private static void PreviewsAppliesAndUndoesWorkspaceReplacement()
+        {
+            var entries = new[]
+            {
+                CreateEntry("one", "Source one", "old value"),
+                CreateEntry("two", "Source two", "another old value")
+            };
+            PreviewWorkspaceToolsViewModel tools = CreateWorkspaceTools(entries, entries);
+            tools.SelectedScope = tools.ScopeOptions.Single(option => option.Value == PreviewWorkspaceToolScope.All);
+            tools.FindText = "old";
+            tools.ReplacementText = "new";
+
+            AssertEqual(2, tools.PreviewCount, "Replacement preview must report the exact affected entry count.");
+            AssertEqual(2, tools.ApplyReplace(), "Replacement must affect the previewed scope.");
+            AssertEqual("new value", entries[0].TargetText, "Replacement must stage normalized target text.");
+            AssertEqual(true, tools.CanUndo, "A staged workspace tool must expose undo.");
+
+            tools.UndoCommand.Execute(null);
+            AssertEqual("old value", entries[0].TargetText, "Undo must restore the exact prior target.");
+            AssertEqual("another old value", entries[1].TargetText, "Undo must restore every affected target.");
+        }
+
+        private static void RoundTripsBoundedTranslationTable()
+        {
+            string directory = Path.Combine(Path.GetTempPath(), "PhoenixTranslatorTools-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+            try
+            {
+                string path = Path.Combine(directory, "translations.tsv");
+                var entries = new[] { CreateEntry("key-1", "Line\nOne", "Target\tOne") };
+                PreviewWorkspaceToolsViewModel tools = CreateWorkspaceTools(entries, entries);
+                tools.ExportTable(path);
+                entries[0].TargetText = string.Empty;
+
+                tools.ImportTable(path);
+
+                AssertEqual("Target\tOne", entries[0].TargetText, "Table import must restore escaped target content by stable key.");
+                AssertEqual(true, tools.CanUndo, "Imported table changes must remain undoable before save.");
+            }
+            finally
+            {
+                Directory.Delete(directory, true);
+            }
+        }
+
+        private static void ValidatesInteractiveProviderRequestIdentity()
+        {
+            var entries = new[] { CreateEntry("key-1", "Translate me", string.Empty) };
+            PreviewWorkspaceToolsViewModel tools = CreateWorkspaceTools(entries, entries);
+            tools.PrepareInteractiveCommand.Execute(null);
+            Match requestId = Regex.Match(tools.InteractiveRequest, @"<!-- Request ID: ([a-z0-9]+) -->");
+            AssertEqual(true, requestId.Success, "Interactive requests must contain a stable correlation identifier.");
+
+            tools.InteractiveResponse = "Translated\r\n<!-- Request ID: wrong -->";
+            AssertEqual(false, tools.CanApplyInteractive, "A mismatched provider response must remain blocked.");
+            tools.InteractiveResponse = "Translated\r\n<!-- Request ID: " + requestId.Groups[1].Value + " -->";
+            AssertEqual(true, tools.CanApplyInteractive, "A matching provider response must be applicable.");
+            tools.ApplyInteractiveCommand.Execute(null);
+            AssertEqual("Translated", entries[0].TargetText, "The request marker must not enter project content.");
+        }
+
+        private static PreviewWorkspaceToolsViewModel CreateWorkspaceTools(
+            IReadOnlyList<PreviewTranslationEntry> allEntries,
+            IReadOnlyList<PreviewTranslationEntry> visibleEntries,
+            Func<string, CancellationToken, string> converter = null)
+        {
+            return new PreviewWorkspaceToolsViewModel(
+                () => allEntries,
+                () => visibleEntries,
+                () => allEntries.FirstOrDefault(),
+                () => { },
+                null,
+                null,
+                null,
+                null,
+                converter,
+                null,
+                null);
+        }
+
+        private static PreviewTranslationEntry CreateEntry(string key, string source, string target)
+        {
+            return new PreviewTranslationEntry(key, "XML", key, source, target, 100);
+        }
+
+        private static void StagesWritingVariantAndTracksExportReadiness()
+        {
+            PreviewTranslationEntry entry = CreateEntry("one", "Source", string.Empty);
+            PreviewWorkspaceToolsViewModel tools = CreateWorkspaceTools(
+                new[] { entry },
+                new[] { entry },
+                (value, cancellationToken) => "Converted");
+            AssertEqual(true, tools.IsExportBlocked, "Draft entries must block project export.");
+
+            tools.ConvertCommand.Execute(null);
+            SpinWait.SpinUntil(() => !tools.IsBusy, 2000);
+            AssertEqual(string.Empty, entry.TargetText, "Writing conversion must not change content before explicit apply.");
+            AssertEqual(true, tools.CanApplyConversion, "A completed conversion preview must be explicitly applicable.");
+            tools.ApplyConversionCommand.Execute(null);
+            AssertEqual("Converted", entry.TargetText, "Applying a conversion preview must stage the converted target.");
+            AssertEqual(false, tools.IsExportBlocked, "A complete non-rejected project must pass the blocking readiness gate.");
+            entry.SetReviewState(PreviewReviewState.Approved);
+            tools.RefreshReadiness();
+            AssertEqual(
+                PreviewMessageCatalog.Get("Workspace_Tools_Export_Ready"),
+                tools.ExportReadinessText,
+                "Approved content must report ready export state.");
+        }
+
         private static void AnalyzesMixedQualityFindings()
         {
             var entries = new[]
@@ -1192,6 +1305,14 @@ namespace PhoenixTranslator.PresetTests
             public void Save()
             {
             }
+
+            public void Export(string path, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                ExportPath = path;
+            }
+
+            public string ExportPath { get; private set; }
 
             public void Dispose()
             {

--- a/Phoenix_Translator/Application/IPreviewTranslationProject.cs
+++ b/Phoenix_Translator/Application/IPreviewTranslationProject.cs
@@ -36,5 +36,12 @@ namespace PhoenixTranslator.ApplicationLayer
         /// Persists staged targets through the format-specific writer and backup boundary.
         /// </summary>
         void Save();
+
+        /// <summary>
+        /// Writes the staged project to a new destination without replacing an existing file.
+        /// </summary>
+        /// <param name="path">The new project destination.</param>
+        /// <param name="cancellationToken">Cancels work before the atomic final move.</param>
+        void Export(string path, CancellationToken cancellationToken);
     }
 }

--- a/Phoenix_Translator/Application/PreviewTranslationProject.cs
+++ b/Phoenix_Translator/Application/PreviewTranslationProject.cs
@@ -155,6 +155,80 @@ namespace PhoenixTranslator.ApplicationLayer
             _modFile.Save();
         }
 
+        /// <summary>
+        /// Writes staged targets to a validated new destination and leaves the source project unchanged.
+        /// </summary>
+        /// <param name="path">The destination path, which must not already exist.</param>
+        /// <param name="cancellationToken">Cancels work before the destination becomes visible.</param>
+        public void Export(string path, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException("An export path is required.", nameof(path));
+            }
+
+            string destination = System.IO.Path.GetFullPath(path);
+            string source = System.IO.Path.GetFullPath(Path);
+            if (string.Equals(destination, source, StringComparison.OrdinalIgnoreCase) || File.Exists(destination))
+            {
+                throw new IOException("Export requires a new destination file.");
+            }
+
+            string sourceExtension = System.IO.Path.GetExtension(source);
+            if (!string.Equals(
+                System.IO.Path.GetExtension(destination),
+                sourceExtension,
+                StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidDataException("The export destination must preserve the project format.");
+            }
+
+            string directory = System.IO.Path.GetDirectoryName(destination);
+            Directory.CreateDirectory(directory);
+            string temporaryPath = System.IO.Path.Combine(
+                directory,
+                "." + System.IO.Path.GetFileNameWithoutExtension(destination) + "." +
+                Guid.NewGuid().ToString("N") + sourceExtension);
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                File.Copy(source, temporaryPath, false);
+                using (PreviewTranslationProject exportedProject = Open(temporaryPath))
+                {
+                    Dictionary<string, PreviewTranslationEntry> stagedTargets = Entries
+                        .GroupBy(entry => entry.Key, StringComparer.Ordinal)
+                        .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+                    foreach (PreviewTranslationEntry exportedEntry in exportedProject.Entries)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        PreviewTranslationEntry stagedEntry;
+                        if (stagedTargets.TryGetValue(exportedEntry.Key, out stagedEntry))
+                        {
+                            exportedEntry.TargetText = stagedEntry.TargetText;
+                        }
+                    }
+
+                    exportedProject.Save();
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!File.Exists(temporaryPath) || new FileInfo(temporaryPath).Length == 0)
+                {
+                    throw new InvalidDataException("The exported project failed output validation.");
+                }
+
+                File.Move(temporaryPath, destination);
+            }
+            finally
+            {
+                if (File.Exists(temporaryPath))
+                {
+                    File.Delete(temporaryPath);
+                }
+            }
+        }
+
         /// <inheritdoc />
         public void Dispose()
         {

--- a/Phoenix_Translator/Application/PreviewTranslationWorkspaceViewModel.cs
+++ b/Phoenix_Translator/Application/PreviewTranslationWorkspaceViewModel.cs
@@ -87,12 +87,24 @@ namespace PhoenixTranslator.ApplicationLayer
         /// <param name="shell">The persistent shell status owner.</param>
         /// <param name="openProject">Opens the selected path through the parser boundary.</param>
         /// <param name="requestProjectOpen">Optionally routes user-initiated opens through the Project Hub.</param>
+        /// <param name="chooseTableImportPath">Selects a bounded translation table for import.</param>
+        /// <param name="chooseTableExportPath">Selects a new translation-table destination.</param>
+        /// <param name="chooseProjectExportPath">Selects a new translated-project destination.</param>
+        /// <param name="convertToTraditional">
+        /// Converts one target through the configured writing-variant boundary.
+        /// </param>
+        /// <param name="copyText">Copies an interactive-provider request without exposing it to diagnostics.</param>
         internal PreviewTranslationWorkspaceViewModel(
             Func<string> chooseProjectPath,
             Action openLegacyWorkspace,
             PreviewShellViewModel shell,
             Func<string, IPreviewTranslationProject> openProject,
-            Func<string, Task<bool>> requestProjectOpen = null)
+            Func<string, Task<bool>> requestProjectOpen = null,
+            Func<string> chooseTableImportPath = null,
+            Func<string> chooseTableExportPath = null,
+            Func<string> chooseProjectExportPath = null,
+            Func<string, CancellationToken, string> convertToTraditional = null,
+            Action<string> copyText = null)
         {
             _chooseProjectPath = chooseProjectPath ?? throw new ArgumentNullException(nameof(chooseProjectPath));
             _openLegacyWorkspace = openLegacyWorkspace ?? throw new ArgumentNullException(nameof(openLegacyWorkspace));
@@ -116,17 +128,31 @@ namespace PhoenixTranslator.ApplicationLayer
             };
             _selectedTypeFilter = TypeFilters[0];
             Entries = new List<PreviewTranslationEntry>();
+            Tools = new PreviewWorkspaceToolsViewModel(
+                () => _allEntries,
+                () => Entries,
+                () => SelectedEntry,
+                OnEntryStateChanged,
+                chooseTableImportPath,
+                chooseTableExportPath,
+                chooseProjectExportPath,
+                ExportProjectAsync,
+                convertToTraditional,
+                copyText,
+                OnToolsBusyChanged);
 
-            OpenProjectCommand = new PreviewShellCommand(parameter => OpenSelectedProject());
+            OpenProjectCommand = new PreviewShellCommand(
+                parameter => OpenSelectedProject(),
+                parameter => !IsBusy && !Tools.IsBusy);
             SaveCommand = new PreviewShellCommand(
                 parameter => SaveProject(),
-                parameter => HasProject && IsModified && !IsBusy);
+                parameter => HasProject && IsModified && !IsBusy && !Tools.IsBusy);
             TranslateEntryCommand = new PreviewShellCommand(
                 parameter => TranslateSelectedEntry(),
-                parameter => SelectedEntry != null && !IsBusy);
+                parameter => SelectedEntry != null && !IsBusy && !Tools.IsBusy);
             TranslateScopeCommand = new PreviewShellCommand(
                 parameter => TranslateScope(),
-                parameter => Entries.Count > 0 && !IsBusy);
+                parameter => Entries.Count > 0 && !IsBusy && !Tools.IsBusy);
             CancelOperationCommand = new PreviewShellCommand(
                 parameter => CancelOperation(),
                 parameter => CanCancelOperation);
@@ -171,6 +197,11 @@ namespace PhoenixTranslator.ApplicationLayer
         /// Gets the record types available in the current project.
         /// </summary>
         public ObservableCollection<string> TypeFilters { get; private set; }
+
+        /// <summary>
+        /// Gets the cohesive editing, table, export, conversion, and interactive-provider tools.
+        /// </summary>
+        public PreviewWorkspaceToolsViewModel Tools { get; private set; }
 
         /// <summary>
         /// Gets the command that selects and opens a supported project.
@@ -228,6 +259,7 @@ namespace PhoenixTranslator.ApplicationLayer
                 _selectedEntry = value;
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(HasSelection));
+                Tools?.RefreshPreview();
                 RaiseCommandAvailability();
             }
         }
@@ -373,7 +405,7 @@ namespace PhoenixTranslator.ApplicationLayer
         /// <param name="path">The selected private project path.</param>
         internal async Task<bool> OpenProjectAsync(string path)
         {
-            if (string.IsNullOrWhiteSpace(path) || IsBusy)
+            if (string.IsNullOrWhiteSpace(path) || IsBusy || Tools.IsBusy)
             {
                 return false;
             }
@@ -402,7 +434,7 @@ namespace PhoenixTranslator.ApplicationLayer
         /// </summary>
         internal async Task SaveProjectAsync()
         {
-            if (_project == null || IsBusy)
+            if (_project == null || IsBusy || Tools.IsBusy)
             {
                 return;
             }
@@ -430,13 +462,24 @@ namespace PhoenixTranslator.ApplicationLayer
             }
         }
 
+        private Task ExportProjectAsync(string path, CancellationToken cancellationToken)
+        {
+            IPreviewTranslationProject project = _project;
+            if (project == null)
+            {
+                throw new InvalidOperationException("A project must be open before export.");
+            }
+
+            return Task.Run(() => project.Export(path, cancellationToken), cancellationToken);
+        }
+
         /// <summary>
         /// Translates a stable entry snapshot sequentially with cooperative cancellation and bounded progress.
         /// </summary>
         /// <param name="entries">The selected or filtered entry snapshot.</param>
         internal async Task TranslateEntriesAsync(IReadOnlyList<PreviewTranslationEntry> entries)
         {
-            if (_project == null || entries == null || entries.Count == 0 || IsBusy)
+            if (_project == null || entries == null || entries.Count == 0 || IsBusy || Tools.IsBusy)
             {
                 return;
             }
@@ -531,6 +574,7 @@ namespace PhoenixTranslator.ApplicationLayer
             OnPropertyChanged(nameof(EntryCountText));
             OnPropertyChanged(nameof(DraftCountText));
             RaiseCommandAvailability();
+            Tools?.RefreshPreview();
         }
 
         /// <inheritdoc />
@@ -641,8 +685,10 @@ namespace PhoenixTranslator.ApplicationLayer
 
             SelectedTypeFilter = TypeFilters[0];
             RefreshFilter();
+            Tools.RefreshProjectState();
             OnPropertyChanged(nameof(HasProject));
             RaiseCommandAvailability();
+            Tools?.RefreshPreview();
             ProjectChanged?.Invoke(this, EventArgs.Empty);
         }
 
@@ -705,6 +751,10 @@ namespace PhoenixTranslator.ApplicationLayer
             {
                 UpdateTrackedState((PreviewTranslationEntry)sender);
                 OnEntryStateChanged();
+            }
+            else if (e.PropertyName == nameof(PreviewTranslationEntry.ReviewState))
+            {
+                Tools.RefreshReadiness();
             }
         }
 
@@ -785,6 +835,11 @@ namespace PhoenixTranslator.ApplicationLayer
             RaiseCanExecuteChanged(CancelOperationCommand);
             RaiseCanExecuteChanged(PreviousEntryCommand);
             RaiseCanExecuteChanged(ApplyEntryCommand);
+        }
+
+        private void OnToolsBusyChanged(bool isBusy)
+        {
+            RaiseCommandAvailability();
         }
 
         private static void RaiseCanExecuteChanged(ICommand command)

--- a/Phoenix_Translator/Application/PreviewWorkspaceToolServices.cs
+++ b/Phoenix_Translator/Application/PreviewWorkspaceToolServices.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Reads and writes bounded, key-addressed Phoenix translation tables.
+    /// </summary>
+    internal sealed class PreviewTranslationTableService
+    {
+        private const int MaximumTableRows = 500000;
+        private const long MaximumTableBytes = 64L * 1024L * 1024L;
+
+        /// <summary>
+        /// Imports targets only for draft entries so reviewed or existing content is never replaced implicitly.
+        /// </summary>
+        /// <param name="path">The bounded UTF-8 TSV input.</param>
+        /// <param name="entries">The normalized project entries addressed by stable key.</param>
+        /// <returns>The previous targets for entries changed by the import.</returns>
+        internal Dictionary<PreviewTranslationEntry, string> ImportDraftTargets(
+            string path,
+            IReadOnlyList<PreviewTranslationEntry> entries)
+        {
+            ValidateReadableTable(path);
+            string[] lines = File.ReadAllLines(path, Encoding.UTF8);
+            if (lines.Length > MaximumTableRows + 1)
+            {
+                throw new InvalidDataException("The translation table contains too many rows.");
+            }
+
+            Dictionary<string, PreviewTranslationEntry> entriesByKey = entries
+                .GroupBy(entry => entry.Key, StringComparer.Ordinal)
+                .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+            var changes = new Dictionary<PreviewTranslationEntry, string>();
+            for (int index = 1; index < lines.Length; index++)
+            {
+                string[] fields = lines[index].Split(new[] { '\t' }, 4);
+                if (fields.Length != 4)
+                {
+                    throw new InvalidDataException("The translation table contains a malformed row.");
+                }
+
+                PreviewTranslationEntry entry;
+                if (entriesByKey.TryGetValue(Unescape(fields[0]), out entry) && entry.IsDraft)
+                {
+                    string target = Unescape(fields[3]);
+                    if (!string.Equals(target, entry.TargetText, StringComparison.Ordinal))
+                    {
+                        if (!changes.ContainsKey(entry))
+                        {
+                            changes.Add(entry, entry.TargetText);
+                        }
+
+                        entry.TargetText = target;
+                    }
+                }
+            }
+
+            return changes;
+        }
+
+        /// <summary>
+        /// Writes a complete translation table through a temporary file and refuses implicit replacement.
+        /// </summary>
+        /// <param name="path">The new TSV destination.</param>
+        /// <param name="entries">The normalized project entries to export.</param>
+        internal void Export(string path, IReadOnlyList<PreviewTranslationEntry> entries)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException("An export path is required.", nameof(path));
+            }
+
+            string directory = Path.GetDirectoryName(Path.GetFullPath(path));
+            Directory.CreateDirectory(directory);
+            string temporaryPath = Path.Combine(
+                directory,
+                "." + Path.GetFileName(path) + "." + Guid.NewGuid().ToString("N") + ".tmp");
+            try
+            {
+                using (var writer = new StreamWriter(temporaryPath, false, new UTF8Encoding(false)))
+                {
+                    writer.WriteLine("Key\tType\tSource\tTarget");
+                    foreach (PreviewTranslationEntry entry in entries)
+                    {
+                        writer.WriteLine(string.Join(
+                            "\t",
+                            Escape(entry.Key),
+                            Escape(entry.Type),
+                            Escape(entry.SourceText),
+                            Escape(entry.TargetText)));
+                    }
+                }
+
+                if (File.Exists(path))
+                {
+                    throw new IOException("The selected export file already exists.");
+                }
+
+                File.Move(temporaryPath, path);
+            }
+            finally
+            {
+                if (File.Exists(temporaryPath))
+                {
+                    File.Delete(temporaryPath);
+                }
+            }
+        }
+
+        private static void ValidateReadableTable(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path) ||
+                !File.Exists(path) ||
+                new FileInfo(path).Length > MaximumTableBytes)
+            {
+                throw new InvalidDataException(
+                    "The translation table is unavailable or exceeds the supported size limit.");
+            }
+        }
+
+        private static string Escape(string value)
+        {
+            return (value ?? string.Empty)
+                .Replace("\\", "\\\\")
+                .Replace("\t", "\\t")
+                .Replace("\r", "\\r")
+                .Replace("\n", "\\n");
+        }
+
+        private static string Unescape(string value)
+        {
+            var result = new StringBuilder();
+            bool escaped = false;
+            foreach (char character in value ?? string.Empty)
+            {
+                if (escaped)
+                {
+                    result.Append(
+                        character == 't'
+                            ? '\t'
+                            : character == 'r' ? '\r' : character == 'n' ? '\n' : character);
+                    escaped = false;
+                }
+                else if (character == '\\')
+                {
+                    escaped = true;
+                }
+                else
+                {
+                    result.Append(character);
+                }
+            }
+
+            if (escaped)
+            {
+                result.Append('\\');
+            }
+
+            return result.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Creates and validates privacy-preserving manual provider exchanges.
+    /// </summary>
+    internal sealed class PreviewInteractiveExchangeService
+    {
+        private static readonly Regex RequestIdRegex = new Regex(
+            @"<!--\s*Request ID:\s*([A-Za-z0-9-]+)\s*-->",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        /// <summary>
+        /// Creates a request containing a non-content correlation identifier.
+        /// </summary>
+        /// <param name="source">The selected source text.</param>
+        /// <param name="requestId">Receives the identifier required in the response.</param>
+        /// <returns>The complete copyable request.</returns>
+        internal string Prepare(string source, out string requestId)
+        {
+            requestId = Guid.NewGuid().ToString("N");
+            return string.Format(
+                "Translate the following text and preserve the request comment exactly.\r\n\r\n" +
+                "{0}\r\n\r\n<!-- Request ID: {1} -->",
+                source ?? string.Empty,
+                requestId);
+        }
+
+        /// <summary>
+        /// Validates response identity and removes the transport-only request marker.
+        /// </summary>
+        /// <param name="response">The untrusted manual provider response.</param>
+        /// <param name="requestId">The identifier issued with the request.</param>
+        /// <param name="target">Receives the normalized target without the request marker.</param>
+        /// <returns><c>true</c> only when the response contains the matching identifier.</returns>
+        internal bool TryExtractTarget(string response, string requestId, out string target)
+        {
+            target = string.Empty;
+            if (string.IsNullOrWhiteSpace(response) || string.IsNullOrWhiteSpace(requestId))
+            {
+                return false;
+            }
+
+            Match match = RequestIdRegex.Match(response);
+            if (!match.Success || !string.Equals(match.Groups[1].Value, requestId, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            target = RequestIdRegex.Replace(response, string.Empty).Trim();
+            return !string.IsNullOrWhiteSpace(target);
+        }
+    }
+}

--- a/Phoenix_Translator/Application/PreviewWorkspaceToolsViewModel.cs
+++ b/Phoenix_Translator/Application/PreviewWorkspaceToolsViewModel.cs
@@ -1,0 +1,846 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Identifies the normalized entry scope used by a workspace tool.
+    /// </summary>
+    internal enum PreviewWorkspaceToolScope
+    {
+        /// <summary>Uses only the selected entry.</summary>
+        Current,
+        /// <summary>Uses entries visible through the current workspace filters.</summary>
+        Visible,
+        /// <summary>Uses every normalized project entry.</summary>
+        All
+    }
+
+    /// <summary>
+    /// Describes one selectable workspace-tool scope.
+    /// </summary>
+    internal sealed class PreviewWorkspaceToolScopeOption
+    {
+        /// <summary>Creates a localized selectable scope.</summary>
+        /// <param name="value">The scope behavior.</param>
+        /// <param name="label">The localized visible label.</param>
+        internal PreviewWorkspaceToolScopeOption(PreviewWorkspaceToolScope value, string label)
+        {
+            Value = value;
+            Label = label;
+        }
+
+        /// <summary>Gets the scope behavior.</summary>
+        public PreviewWorkspaceToolScope Value { get; private set; }
+
+        /// <summary>Gets the localized visible label.</summary>
+        public string Label { get; private set; }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return Label;
+        }
+    }
+
+    /// <summary>
+    /// Represents an editable project terminology pair.
+    /// </summary>
+    internal sealed class PreviewTerminologyEntry : INotifyPropertyChanged
+    {
+        private string _source;
+        private string _target;
+
+        /// <summary>Creates an editable terminology pair.</summary>
+        /// <param name="source">The source term.</param>
+        /// <param name="target">The preferred target term.</param>
+        internal PreviewTerminologyEntry(string source, string target)
+        {
+            _source = source ?? string.Empty;
+            _target = target ?? string.Empty;
+        }
+
+        /// <inheritdoc />
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>Gets or sets the source terminology text.</summary>
+        public string Source
+        {
+            get => _source;
+            set
+            {
+                string normalized = value ?? string.Empty;
+                if (string.Equals(_source, normalized, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                _source = normalized;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>Gets or sets the preferred target terminology text.</summary>
+        public string Target
+        {
+            get => _target;
+            set
+            {
+                string normalized = value ?? string.Empty;
+                if (string.Equals(_target, normalized, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                _target = normalized;
+                OnPropertyChanged();
+            }
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+
+    /// <summary>
+    /// Owns preview, undo, terminology, table, export, and interactive-provider tools for the workspace.
+    /// </summary>
+    internal sealed class PreviewWorkspaceToolsViewModel : INotifyPropertyChanged
+    {
+        private readonly Func<IReadOnlyList<PreviewTranslationEntry>> _getAllEntries;
+        private readonly Func<IReadOnlyList<PreviewTranslationEntry>> _getVisibleEntries;
+        private readonly Func<PreviewTranslationEntry> _getSelectedEntry;
+        private readonly Action _notifyEntriesChanged;
+        private readonly Func<string> _chooseImportPath;
+        private readonly Func<string> _chooseTableExportPath;
+        private readonly Func<string> _chooseProjectExportPath;
+        private readonly Func<string, CancellationToken, Task> _exportProject;
+        private readonly Func<string, CancellationToken, string> _convertToTraditional;
+        private readonly Action<string> _copyText;
+        private readonly Action<bool> _busyChanged;
+        private readonly PreviewTranslationTableService _tableService;
+        private readonly PreviewInteractiveExchangeService _interactiveService;
+        private Dictionary<PreviewTranslationEntry, string> _undoTargets;
+        private Dictionary<PreviewTranslationEntry, string> _pendingConversion;
+        private string _findText;
+        private string _replacementText;
+        private string _terminologySearch;
+        private string _interactiveRequest;
+        private string _interactiveResponse;
+        private string _interactiveRequestId;
+        private string _statusText;
+        private int _previewCount;
+        private bool _isBusy;
+        private PreviewWorkspaceToolScopeOption _selectedScope;
+        private PreviewTerminologyEntry _selectedTerm;
+        private CancellationTokenSource _cancellation;
+
+        /// <summary>Creates tools over the shared normalized workspace state and injected UI boundaries.</summary>
+        /// <param name="getAllEntries">Gets the complete project entry set.</param>
+        /// <param name="getVisibleEntries">Gets the current filtered entry set.</param>
+        /// <param name="getSelectedEntry">Gets the selected entry.</param>
+        /// <param name="notifyEntriesChanged">Notifies workspace consumers after staged mutations.</param>
+        /// <param name="chooseImportPath">Selects a translation table to import.</param>
+        /// <param name="chooseTableExportPath">Selects a new translation-table destination.</param>
+        /// <param name="chooseProjectExportPath">Selects a new translated-project destination.</param>
+        /// <param name="exportProject">Writes the current staged project through its format boundary.</param>
+        /// <param name="convertToTraditional">Converts one value through the writing-variant provider.</param>
+        /// <param name="copyText">Copies a manual provider request.</param>
+        /// <param name="busyChanged">Notifies the parent workspace when long-running tool work changes state.</param>
+        internal PreviewWorkspaceToolsViewModel(
+            Func<IReadOnlyList<PreviewTranslationEntry>> getAllEntries,
+            Func<IReadOnlyList<PreviewTranslationEntry>> getVisibleEntries,
+            Func<PreviewTranslationEntry> getSelectedEntry,
+            Action notifyEntriesChanged,
+            Func<string> chooseImportPath,
+            Func<string> chooseTableExportPath,
+            Func<string> chooseProjectExportPath,
+            Func<string, CancellationToken, Task> exportProject,
+            Func<string, CancellationToken, string> convertToTraditional,
+            Action<string> copyText,
+            Action<bool> busyChanged = null)
+        {
+            _getAllEntries = getAllEntries ?? throw new ArgumentNullException(nameof(getAllEntries));
+            _getVisibleEntries = getVisibleEntries ?? throw new ArgumentNullException(nameof(getVisibleEntries));
+            _getSelectedEntry = getSelectedEntry ?? throw new ArgumentNullException(nameof(getSelectedEntry));
+            _notifyEntriesChanged = notifyEntriesChanged ??
+                throw new ArgumentNullException(nameof(notifyEntriesChanged));
+            _chooseImportPath = chooseImportPath ?? (() => string.Empty);
+            _chooseTableExportPath = chooseTableExportPath ?? (() => string.Empty);
+            _chooseProjectExportPath = chooseProjectExportPath ?? (() => string.Empty);
+            _exportProject = exportProject;
+            _convertToTraditional = convertToTraditional;
+            _copyText = copyText ?? (value => { });
+            _busyChanged = busyChanged ?? (value => { });
+            _tableService = new PreviewTranslationTableService();
+            _interactiveService = new PreviewInteractiveExchangeService();
+            _findText = string.Empty;
+            _replacementText = string.Empty;
+            _terminologySearch = string.Empty;
+            _interactiveRequest = string.Empty;
+            _interactiveResponse = string.Empty;
+            _statusText = PreviewMessageCatalog.Get("Workspace_Tools_Ready");
+            Terminology = new ObservableCollection<PreviewTerminologyEntry>();
+            ScopeOptions = new[]
+            {
+                new PreviewWorkspaceToolScopeOption(
+                    PreviewWorkspaceToolScope.Current,
+                    PreviewMessageCatalog.Get("Workspace_Tools_Scope_Current")),
+                new PreviewWorkspaceToolScopeOption(
+                    PreviewWorkspaceToolScope.Visible,
+                    PreviewMessageCatalog.Get("Workspace_Tools_Scope_Visible")),
+                new PreviewWorkspaceToolScopeOption(
+                    PreviewWorkspaceToolScope.All,
+                    PreviewMessageCatalog.Get("Workspace_Tools_Scope_All"))
+            };
+            _selectedScope = ScopeOptions[1];
+
+            PreviewReplaceCommand = new PreviewShellCommand(parameter => RefreshPreview());
+            ApplyReplaceCommand = new PreviewShellCommand(
+                parameter => ApplyReplace(),
+                parameter => PreviewCount > 0 && !IsBusy);
+            UndoCommand = new PreviewShellCommand(parameter => Undo(), parameter => CanUndo && !IsBusy);
+            AddSelectedTermCommand = new PreviewShellCommand(
+                parameter => AddSelectedTerm(),
+                parameter => _getSelectedEntry() != null);
+            RemoveTermCommand = new PreviewShellCommand(
+                parameter => RemoveSelectedTerm(),
+                parameter => SelectedTerm != null);
+            ApplyTerminologyCommand = new PreviewShellCommand(
+                parameter => ApplyTerminology(),
+                parameter => Terminology.Count > 0 && !IsBusy);
+            ImportTableCommand = new PreviewShellCommand(parameter => ImportTable(), parameter => !IsBusy);
+            ExportTableCommand = new PreviewShellCommand(
+                parameter => ExportTable(),
+                parameter => _getAllEntries().Count > 0 && !IsBusy);
+            ExportProjectCommand = new PreviewShellCommand(
+                parameter => ExportProject(),
+                parameter => _exportProject != null && !IsExportBlocked && !IsBusy);
+            ConvertCommand = new PreviewShellCommand(
+                parameter => ConvertToTraditional(),
+                parameter => _convertToTraditional != null && !IsBusy);
+            ApplyConversionCommand = new PreviewShellCommand(
+                parameter => ApplyConversion(),
+                parameter => CanApplyConversion && !IsBusy);
+            PrepareInteractiveCommand = new PreviewShellCommand(
+                parameter => PrepareInteractive(),
+                parameter => _getSelectedEntry() != null && !IsBusy);
+            CopyInteractiveCommand = new PreviewShellCommand(
+                parameter => _copyText(InteractiveRequest),
+                parameter => !string.IsNullOrWhiteSpace(InteractiveRequest));
+            ApplyInteractiveCommand = new PreviewShellCommand(
+                parameter => ApplyInteractive(),
+                parameter => CanApplyInteractive && !IsBusy);
+            CancelCommand = new PreviewShellCommand(
+                parameter => _cancellation?.Cancel(),
+                parameter => _cancellation != null);
+        }
+
+        /// <inheritdoc />
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>Gets the localized operation scopes.</summary>
+        public IReadOnlyList<PreviewWorkspaceToolScopeOption> ScopeOptions { get; private set; }
+
+        /// <summary>Gets the editable project terminology pairs.</summary>
+        public ObservableCollection<PreviewTerminologyEntry> Terminology { get; private set; }
+
+        /// <summary>Gets the command that refreshes the replacement preview.</summary>
+        public ICommand PreviewReplaceCommand { get; private set; }
+        /// <summary>Gets the command that applies the previewed replacement.</summary>
+        public ICommand ApplyReplaceCommand { get; private set; }
+        /// <summary>Gets the command that restores targets changed by the last tool.</summary>
+        public ICommand UndoCommand { get; private set; }
+        /// <summary>Gets the command that creates a terminology pair from the selected entry.</summary>
+        public ICommand AddSelectedTermCommand { get; private set; }
+        /// <summary>Gets the command that removes the selected terminology pair.</summary>
+        public ICommand RemoveTermCommand { get; private set; }
+        /// <summary>Gets the command that applies exact terminology matches to draft targets.</summary>
+        public ICommand ApplyTerminologyCommand { get; private set; }
+        /// <summary>Gets the command that imports draft targets from a bounded table.</summary>
+        public ICommand ImportTableCommand { get; private set; }
+        /// <summary>Gets the command that exports the normalized translation table.</summary>
+        public ICommand ExportTableCommand { get; private set; }
+        /// <summary>Gets the command that exports the translated project through its format writer.</summary>
+        public ICommand ExportProjectCommand { get; private set; }
+        /// <summary>Gets the command that prepares a writing-variant conversion preview.</summary>
+        public ICommand ConvertCommand { get; private set; }
+        /// <summary>Gets the command that applies the prepared writing-variant conversion.</summary>
+        public ICommand ApplyConversionCommand { get; private set; }
+        /// <summary>Gets the command that prepares a manual provider request.</summary>
+        public ICommand PrepareInteractiveCommand { get; private set; }
+        /// <summary>Gets the command that copies the prepared provider request.</summary>
+        public ICommand CopyInteractiveCommand { get; private set; }
+        /// <summary>Gets the command that validates and applies a provider response.</summary>
+        public ICommand ApplyInteractiveCommand { get; private set; }
+        /// <summary>Gets the command that cancels active conversion or export work.</summary>
+        public ICommand CancelCommand { get; private set; }
+
+        /// <summary>Gets or sets the exact target text to find.</summary>
+        public string FindText
+        {
+            get => _findText;
+            set
+            {
+                if (SetField(ref _findText, value ?? string.Empty))
+                {
+                    RefreshPreview();
+                }
+            }
+        }
+
+        /// <summary>Gets or sets the replacement target text.</summary>
+        public string ReplacementText
+        {
+            get => _replacementText;
+            set => SetField(ref _replacementText, value ?? string.Empty);
+        }
+
+        /// <summary>Gets or sets the scope used by editing tools.</summary>
+        public PreviewWorkspaceToolScopeOption SelectedScope
+        {
+            get => _selectedScope;
+            set
+            {
+                if (value != null && SetField(ref _selectedScope, value))
+                {
+                    RefreshPreview();
+                }
+            }
+        }
+
+        /// <summary>Gets the number of entries affected by the replacement preview.</summary>
+        public int PreviewCount
+        {
+            get => _previewCount;
+            private set
+            {
+                if (SetField(ref _previewCount, value))
+                {
+                    OnPropertyChanged(nameof(PreviewText));
+                    RaiseCommands();
+                }
+            }
+        }
+
+        /// <summary>Gets the localized replacement preview summary.</summary>
+        public string PreviewText => PreviewMessageCatalog.Format("Workspace_Tools_ReplacePreview", PreviewCount);
+
+        /// <summary>Gets whether draft or rejected content blocks project export.</summary>
+        public bool IsExportBlocked => _getAllEntries().Count == 0 ||
+            _getAllEntries().Any(entry => entry.IsDraft || entry.ReviewState == PreviewReviewState.Rejected);
+
+        /// <summary>Gets the localized ready, warning, or blocked export state.</summary>
+        public string ExportReadinessText
+        {
+            get
+            {
+                IReadOnlyList<PreviewTranslationEntry> entries = _getAllEntries();
+                if (entries.Count == 0)
+                {
+                    return PreviewMessageCatalog.Get("Workspace_Tools_Export_NoProject");
+                }
+
+                int blocked = entries.Count(entry => entry.IsDraft || entry.ReviewState == PreviewReviewState.Rejected);
+                if (blocked > 0)
+                {
+                    return PreviewMessageCatalog.Format("Workspace_Tools_Export_Blocked", blocked);
+                }
+
+                int unapproved = entries.Count(entry => entry.ReviewState != PreviewReviewState.Approved);
+                return unapproved == 0
+                    ? PreviewMessageCatalog.Get("Workspace_Tools_Export_Ready")
+                    : PreviewMessageCatalog.Format("Workspace_Tools_Export_Warning", unapproved);
+            }
+        }
+
+        /// <summary>Gets or sets the terminology search query.</summary>
+        public string TerminologySearch
+        {
+            get => _terminologySearch;
+            set
+            {
+                if (SetField(ref _terminologySearch, value ?? string.Empty))
+                {
+                    OnPropertyChanged(nameof(FilteredTerminology));
+                }
+            }
+        }
+
+        /// <summary>Gets terminology pairs matching the current query.</summary>
+        public IReadOnlyList<PreviewTerminologyEntry> FilteredTerminology => Terminology
+            .Where(term => string.IsNullOrWhiteSpace(TerminologySearch) ||
+                Contains(term.Source, TerminologySearch) || Contains(term.Target, TerminologySearch))
+            .ToList();
+
+        /// <summary>Gets or sets the selected terminology pair.</summary>
+        public PreviewTerminologyEntry SelectedTerm
+        {
+            get => _selectedTerm;
+            set
+            {
+                if (SetField(ref _selectedTerm, value))
+                {
+                    RaiseCommands();
+                }
+            }
+        }
+
+        /// <summary>Gets the prepared manual provider request.</summary>
+        public string InteractiveRequest
+        {
+            get => _interactiveRequest;
+            private set
+            {
+                if (SetField(ref _interactiveRequest, value ?? string.Empty))
+                {
+                    RaiseCommands();
+                }
+            }
+        }
+
+        /// <summary>Gets or sets the untrusted manual provider response.</summary>
+        public string InteractiveResponse
+        {
+            get => _interactiveResponse;
+            set
+            {
+                if (SetField(ref _interactiveResponse, value ?? string.Empty))
+                {
+                    OnPropertyChanged(nameof(CanApplyInteractive));
+                    RaiseCommands();
+                }
+            }
+        }
+
+        /// <summary>Gets whether the response contains the matching request identity and a target.</summary>
+        public bool CanApplyInteractive
+        {
+            get
+            {
+                string target;
+                return _interactiveService.TryExtractTarget(InteractiveResponse, _interactiveRequestId, out target);
+            }
+        }
+
+        /// <summary>Gets the localized status of the last workspace-tool operation.</summary>
+        public string StatusText
+        {
+            get => _statusText;
+            private set => SetField(ref _statusText, value ?? string.Empty);
+        }
+
+        /// <summary>Gets whether a cancellable workspace-tool operation is active.</summary>
+        public bool IsBusy
+        {
+            get => _isBusy;
+            private set
+            {
+                if (SetField(ref _isBusy, value))
+                {
+                    _busyChanged(value);
+                    RaiseCommands();
+                }
+            }
+        }
+
+        /// <summary>Gets whether the last applied tool mutation can be restored.</summary>
+        public bool CanUndo => _undoTargets != null && _undoTargets.Count > 0;
+
+        /// <summary>Gets whether a writing-variant preview is ready to apply.</summary>
+        public bool CanApplyConversion => _pendingConversion != null && _pendingConversion.Count > 0;
+
+        /// <summary>Gets the localized writing-variant preview summary.</summary>
+        public string ConversionPreviewText => PreviewMessageCatalog.Format(
+            "Workspace_Tools_ConversionPreview",
+            _pendingConversion == null ? 0 : _pendingConversion.Count);
+
+        internal void RefreshProjectState()
+        {
+            _undoTargets = null;
+            _pendingConversion = null;
+            PreviewCount = 0;
+            InteractiveRequest = string.Empty;
+            InteractiveResponse = string.Empty;
+            _interactiveRequestId = null;
+            StatusText = PreviewMessageCatalog.Get("Workspace_Tools_Ready");
+            OnPropertyChanged(nameof(CanUndo));
+            OnPropertyChanged(nameof(CanApplyConversion));
+            OnPropertyChanged(nameof(ConversionPreviewText));
+            OnPropertyChanged(nameof(IsExportBlocked));
+            OnPropertyChanged(nameof(ExportReadinessText));
+            RaiseCommands();
+        }
+
+        internal void RefreshPreview()
+        {
+            PreviewCount = string.IsNullOrEmpty(FindText)
+                ? 0
+                : GetScopeEntries().Count(entry => ContainsOrdinal(entry.TargetText, FindText));
+        }
+
+        internal void RefreshReadiness()
+        {
+            OnPropertyChanged(nameof(IsExportBlocked));
+            OnPropertyChanged(nameof(ExportReadinessText));
+            RaiseCommands();
+        }
+
+        internal int ApplyReplace()
+        {
+            if (string.IsNullOrEmpty(FindText))
+            {
+                return 0;
+            }
+
+            Dictionary<PreviewTranslationEntry, string> changes = GetScopeEntries()
+                .Where(entry => ContainsOrdinal(entry.TargetText, FindText))
+                .ToDictionary(entry => entry, entry => entry.TargetText);
+            foreach (KeyValuePair<PreviewTranslationEntry, string> change in changes)
+            {
+                change.Key.TargetText = change.Value.Replace(FindText, ReplacementText);
+            }
+
+            RecordMutation(changes, "Workspace_Tools_ReplaceApplied");
+            RefreshPreview();
+            return changes.Count;
+        }
+
+        internal int ApplyTerminology()
+        {
+            Dictionary<string, string> validTerms = Terminology
+                .Where(term => !string.IsNullOrEmpty(term.Source) && !string.IsNullOrEmpty(term.Target))
+                .GroupBy(term => term.Source, StringComparer.CurrentCulture)
+                .ToDictionary(group => group.Key, group => group.Last().Target, StringComparer.CurrentCulture);
+            var changes = new Dictionary<PreviewTranslationEntry, string>();
+            foreach (PreviewTranslationEntry entry in GetScopeEntries())
+            {
+                string target;
+                if (entry.IsDraft && validTerms.TryGetValue(entry.SourceText, out target))
+                {
+                    changes.Add(entry, entry.TargetText);
+                    entry.TargetText = target;
+                }
+            }
+
+            RecordMutation(changes, "Workspace_Tools_TerminologyApplied");
+            return changes.Count;
+        }
+
+        internal void ImportTable(string path)
+        {
+            Dictionary<PreviewTranslationEntry, string> changes =
+                _tableService.ImportDraftTargets(path, _getAllEntries());
+            RecordMutation(changes, "Workspace_Tools_TableImported");
+        }
+
+        internal void ExportTable(string path)
+        {
+            _tableService.Export(path, _getAllEntries());
+        }
+
+        private void AddSelectedTerm()
+        {
+            PreviewTranslationEntry entry = _getSelectedEntry();
+            if (entry == null)
+            {
+                return;
+            }
+
+            var term = new PreviewTerminologyEntry(entry.SourceText, entry.TargetText);
+            Terminology.Add(term);
+            SelectedTerm = term;
+            OnPropertyChanged(nameof(FilteredTerminology));
+            RaiseCommands();
+        }
+
+        private void RemoveSelectedTerm()
+        {
+            if (SelectedTerm != null)
+            {
+                Terminology.Remove(SelectedTerm);
+                SelectedTerm = null;
+                OnPropertyChanged(nameof(FilteredTerminology));
+            }
+        }
+
+        private void Undo()
+        {
+            Dictionary<PreviewTranslationEntry, string> changes = _undoTargets;
+            _undoTargets = null;
+            if (changes == null)
+            {
+                return;
+            }
+
+            foreach (KeyValuePair<PreviewTranslationEntry, string> change in changes)
+            {
+                change.Key.TargetText = change.Value;
+            }
+
+            _notifyEntriesChanged();
+            StatusText = PreviewMessageCatalog.Format("Workspace_Tools_Undone", changes.Count);
+            OnPropertyChanged(nameof(CanUndo));
+            RaiseCommands();
+        }
+
+        private async void ConvertToTraditional()
+        {
+            IReadOnlyList<PreviewTranslationEntry> entries = GetScopeEntries();
+            var cancellation = new CancellationTokenSource();
+            _cancellation = cancellation;
+            IsBusy = true;
+            StatusText = PreviewMessageCatalog.Get("Workspace_Tools_Converting");
+            RaiseCommands();
+            try
+            {
+                var staged = await Task.Run(() =>
+                {
+                    var values = new Dictionary<PreviewTranslationEntry, string>();
+                    foreach (PreviewTranslationEntry entry in entries)
+                    {
+                        cancellation.Token.ThrowIfCancellationRequested();
+                        string source = string.IsNullOrWhiteSpace(entry.TargetText)
+                            ? entry.SourceText
+                            : entry.TargetText;
+                        string converted = _convertToTraditional(source, cancellation.Token);
+                        if (!string.IsNullOrWhiteSpace(converted) &&
+                            !string.Equals(converted, entry.TargetText, StringComparison.Ordinal))
+                        {
+                            values.Add(entry, converted);
+                        }
+                    }
+
+                    return values;
+                });
+                cancellation.Token.ThrowIfCancellationRequested();
+                _pendingConversion = staged;
+                StatusText = PreviewMessageCatalog.Format("Workspace_Tools_ConversionPreview", staged.Count);
+                OnPropertyChanged(nameof(CanApplyConversion));
+                OnPropertyChanged(nameof(ConversionPreviewText));
+            }
+            catch (OperationCanceledException)
+            {
+                StatusText = PreviewMessageCatalog.Get("Workspace_Tools_Cancelled");
+            }
+            catch (Exception)
+            {
+                StatusText = PreviewMessageCatalog.Get("Workspace_Tools_OperationFailed");
+            }
+            finally
+            {
+                _cancellation.Dispose();
+                _cancellation = null;
+                IsBusy = false;
+                RaiseCommands();
+            }
+        }
+
+        private void ApplyConversion()
+        {
+            Dictionary<PreviewTranslationEntry, string> staged = _pendingConversion;
+            _pendingConversion = null;
+            if (staged == null)
+            {
+                return;
+            }
+
+            var changes = staged.ToDictionary(pair => pair.Key, pair => pair.Key.TargetText);
+            foreach (KeyValuePair<PreviewTranslationEntry, string> value in staged)
+            {
+                value.Key.TargetText = value.Value;
+            }
+
+            OnPropertyChanged(nameof(CanApplyConversion));
+            OnPropertyChanged(nameof(ConversionPreviewText));
+            RecordMutation(changes, "Workspace_Tools_ConversionApplied");
+        }
+
+        private async void ExportProject()
+        {
+            string path = _chooseProjectExportPath();
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return;
+            }
+
+            var cancellation = new CancellationTokenSource();
+            _cancellation = cancellation;
+            IsBusy = true;
+            StatusText = PreviewMessageCatalog.Get("Workspace_Tools_Exporting");
+            RaiseCommands();
+            try
+            {
+                await _exportProject(path, cancellation.Token);
+                StatusText = PreviewMessageCatalog.Get("Workspace_Tools_Exported");
+            }
+            catch (OperationCanceledException)
+            {
+                StatusText = PreviewMessageCatalog.Get("Workspace_Tools_Cancelled");
+            }
+            catch (Exception)
+            {
+                StatusText = PreviewMessageCatalog.Get("Workspace_Tools_OperationFailed");
+            }
+            finally
+            {
+                _cancellation.Dispose();
+                _cancellation = null;
+                IsBusy = false;
+                RaiseCommands();
+            }
+        }
+
+        private void ImportTable()
+        {
+            string path = _chooseImportPath();
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return;
+            }
+
+            try
+            {
+                ImportTable(path);
+            }
+            catch (Exception)
+            {
+                StatusText = PreviewMessageCatalog.Get("Workspace_Tools_OperationFailed");
+            }
+        }
+
+        private void ExportTable()
+        {
+            string path = _chooseTableExportPath();
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return;
+            }
+
+            try
+            {
+                ExportTable(path);
+                StatusText = PreviewMessageCatalog.Get("Workspace_Tools_TableExported");
+            }
+            catch (Exception)
+            {
+                StatusText = PreviewMessageCatalog.Get("Workspace_Tools_OperationFailed");
+            }
+        }
+
+        private void PrepareInteractive()
+        {
+            PreviewTranslationEntry entry = _getSelectedEntry();
+            if (entry == null)
+            {
+                return;
+            }
+
+            InteractiveRequest = _interactiveService.Prepare(entry.SourceText, out _interactiveRequestId);
+            InteractiveResponse = string.Empty;
+            OnPropertyChanged(nameof(CanApplyInteractive));
+            StatusText = PreviewMessageCatalog.Get("Workspace_Tools_InteractivePrepared");
+        }
+
+        private void ApplyInteractive()
+        {
+            if (!CanApplyInteractive)
+            {
+                StatusText = PreviewMessageCatalog.Get("Workspace_Tools_InteractiveMismatch");
+                return;
+            }
+
+            PreviewTranslationEntry entry = _getSelectedEntry();
+            if (entry == null)
+            {
+                return;
+            }
+
+            var changes = new Dictionary<PreviewTranslationEntry, string> { { entry, entry.TargetText } };
+            string target;
+            if (!_interactiveService.TryExtractTarget(InteractiveResponse, _interactiveRequestId, out target))
+            {
+                StatusText = PreviewMessageCatalog.Get("Workspace_Tools_InteractiveMismatch");
+                return;
+            }
+
+            entry.ApplyGeneratedTarget(target);
+            RecordMutation(changes, "Workspace_Tools_InteractiveApplied");
+        }
+
+        private IReadOnlyList<PreviewTranslationEntry> GetScopeEntries()
+        {
+            switch (SelectedScope.Value)
+            {
+                case PreviewWorkspaceToolScope.Current:
+                    PreviewTranslationEntry selected = _getSelectedEntry();
+                    return selected == null ? new PreviewTranslationEntry[0] : new[] { selected };
+                case PreviewWorkspaceToolScope.Visible:
+                    return _getVisibleEntries();
+                default:
+                    return _getAllEntries();
+            }
+        }
+
+        private void RecordMutation(Dictionary<PreviewTranslationEntry, string> changes, string messageId)
+        {
+            _undoTargets = changes.Count == 0 ? null : changes;
+            _notifyEntriesChanged();
+            StatusText = PreviewMessageCatalog.Format(messageId, changes.Count);
+            OnPropertyChanged(nameof(CanUndo));
+            OnPropertyChanged(nameof(IsExportBlocked));
+            OnPropertyChanged(nameof(ExportReadinessText));
+            RaiseCommands();
+        }
+
+        private static bool Contains(string value, string search)
+        {
+            return value != null && value.IndexOf(search, StringComparison.CurrentCultureIgnoreCase) >= 0;
+        }
+
+        private static bool ContainsOrdinal(string value, string search)
+        {
+            return value != null && value.IndexOf(search, StringComparison.Ordinal) >= 0;
+        }
+
+        private bool SetField<T>(ref T field, T value, [CallerMemberName] string propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+            {
+                return false;
+            }
+
+            field = value;
+            OnPropertyChanged(propertyName);
+            return true;
+        }
+
+        private void RaiseCommands()
+        {
+            foreach (ICommand command in new[]
+            {
+                ApplyReplaceCommand, UndoCommand, AddSelectedTermCommand, RemoveTermCommand,
+                ApplyTerminologyCommand, ImportTableCommand, ExportTableCommand, ExportProjectCommand,
+                ConvertCommand, ApplyConversionCommand, PrepareInteractiveCommand, CopyInteractiveCommand,
+                ApplyInteractiveCommand, CancelCommand
+            })
+            {
+                var previewCommand = command as PreviewShellCommand;
+                previewCommand?.RaiseCanExecuteChanged();
+            }
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/Phoenix_Translator/PhoenixTranslator.csproj
+++ b/Phoenix_Translator/PhoenixTranslator.csproj
@@ -126,6 +126,8 @@
     <Compile Include="Application\PreviewTranslationEntry.cs" />
     <Compile Include="Application\PreviewTranslationProject.cs" />
     <Compile Include="Application\PreviewTranslationWorkspaceViewModel.cs" />
+    <Compile Include="Application\PreviewWorkspaceToolsViewModel.cs" />
+    <Compile Include="Application\PreviewWorkspaceToolServices.cs" />
     <Compile Include="Application\LegacyTranslationPresetStore.cs" />
     <Compile Include="Application\TranslationPresetService.cs" />
     <Compile Include="FileManagement\ZipHelper.cs" />

--- a/Phoenix_Translator/Properties/AssemblyInfo.cs
+++ b/Phoenix_Translator/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Windows;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.0.0.13")]
-[assembly: AssemblyFileVersion("2.0.0.13")]
+[assembly: AssemblyVersion("2.0.0.14")]
+[assembly: AssemblyFileVersion("2.0.0.14")]

--- a/Phoenix_Translator/Properties/Resources.resx
+++ b/Phoenix_Translator/Properties/Resources.resx
@@ -211,6 +211,60 @@
   <data name="Workspace_Operation_Cancelling" xml:space="preserve"><value>Cancelling translation…</value><comment>Operation status while cooperative cancellation is pending.</comment></data>
   <data name="Workspace_Operation_CompletedWithFailures" xml:space="preserve"><value>Translation completed with {0} failed entries.</value><comment>Batch completion summary. Placeholders: {0}=non-negative integer failure count.</comment></data>
   <data name="Workspace_Save_Failed" xml:space="preserve"><value>The project could not be saved. Your changes are still available.</value><comment>Safe save-failure message that confirms recoverable user input.</comment></data>
+  <data name="Workspace_Tools_Title" xml:space="preserve"><value>Tools</value><comment>Workspace inspector tab for editing and delivery tools.</comment></data>
+  <data name="Workspace_Tools_Edit_Tab" xml:space="preserve"><value>Edit</value><comment>Workspace tool category for scoped text changes.</comment></data>
+  <data name="Workspace_Tools_Terms_Tab" xml:space="preserve"><value>Terms</value><comment>Workspace tool category for project terminology.</comment></data>
+  <data name="Workspace_Tools_Deliver_Tab" xml:space="preserve"><value>Deliver</value><comment>Workspace tool category for tables and project export.</comment></data>
+  <data name="Workspace_Tools_Interactive_Tab" xml:space="preserve"><value>Interactive</value><comment>Workspace tool category for manual provider exchange.</comment></data>
+  <data name="Workspace_Tools_Find_Label" xml:space="preserve"><value>Find in target text</value><comment>Find field label in scoped replacement.</comment></data>
+  <data name="Workspace_Tools_Replace_Label" xml:space="preserve"><value>Replace with</value><comment>Replacement field label.</comment></data>
+  <data name="Workspace_Tools_Scope_Label" xml:space="preserve"><value>Scope</value><comment>Shared operation-scope field label.</comment></data>
+  <data name="Workspace_Tools_Scope_Current" xml:space="preserve"><value>Current entry</value><comment>Tool scope containing only the selected entry.</comment></data>
+  <data name="Workspace_Tools_Scope_Visible" xml:space="preserve"><value>Visible entries</value><comment>Tool scope containing the filtered workspace entries.</comment></data>
+  <data name="Workspace_Tools_Scope_All" xml:space="preserve"><value>All entries</value><comment>Tool scope containing the entire project.</comment></data>
+  <data name="Workspace_Tools_Preview_Action" xml:space="preserve"><value>Preview</value><comment>Refreshes a non-destructive operation preview.</comment></data>
+  <data name="Workspace_Tools_Apply_Action" xml:space="preserve"><value>Apply</value><comment>Applies the previewed scoped operation.</comment></data>
+  <data name="Workspace_Tools_Undo_Action" xml:space="preserve"><value>Undo last tool</value><comment>Restores targets changed by the last workspace tool.</comment></data>
+  <data name="Workspace_Tools_ReplacePreview" xml:space="preserve"><value>{0} matching entries</value><comment>Replacement preview count. Placeholder: {0}=entry count.</comment></data>
+  <data name="Workspace_Tools_ReplaceApplied" xml:space="preserve"><value>Replaced text in {0} entries.</value><comment>Replacement completion. Placeholder: {0}=entry count.</comment></data>
+  <data name="Workspace_Tools_Undone" xml:space="preserve"><value>Restored {0} entries.</value><comment>Undo completion. Placeholder: {0}=entry count.</comment></data>
+  <data name="Workspace_Tools_Ready" xml:space="preserve"><value>Choose a tool. Changes remain staged until Save.</value><comment>Default workspace-tools status.</comment></data>
+  <data name="Workspace_Tools_Convert_Action" xml:space="preserve"><value>Preview Traditional Chinese</value><comment>Previews scoped Chinese writing-variant conversion.</comment></data>
+  <data name="Workspace_Tools_ApplyConversion_Action" xml:space="preserve"><value>Apply conversion</value><comment>Applies the staged writing-variant conversion preview.</comment></data>
+  <data name="Workspace_Tools_Converting" xml:space="preserve"><value>Converting the selected scope…</value><comment>Status during writing-variant conversion.</comment></data>
+  <data name="Workspace_Tools_ConversionApplied" xml:space="preserve"><value>Converted {0} entries.</value><comment>Writing conversion completion. Placeholder: {0}=entry count.</comment></data>
+  <data name="Workspace_Tools_ConversionPreview" xml:space="preserve"><value>{0} converted entries ready to apply.</value><comment>Writing conversion preview. Placeholder: {0}=entry count.</comment></data>
+  <data name="Workspace_Tools_TermSearch" xml:space="preserve"><value>Search terminology</value><comment>Project terminology search field hint.</comment></data>
+  <data name="Workspace_Tools_AddTerm_Action" xml:space="preserve"><value>Add selected entry</value><comment>Adds the selected source and target as an editable terminology pair.</comment></data>
+  <data name="Workspace_Tools_RemoveTerm_Action" xml:space="preserve"><value>Remove term</value><comment>Removes the selected project terminology pair.</comment></data>
+  <data name="Workspace_Tools_ApplyTerms_Action" xml:space="preserve"><value>Apply terms to scope</value><comment>Applies valid project terminology pairs to the selected scope.</comment></data>
+  <data name="Workspace_Tools_TerminologyApplied" xml:space="preserve"><value>Applied terminology to {0} entries.</value><comment>Terminology completion. Placeholder: {0}=entry count.</comment></data>
+  <data name="Workspace_Tools_Source_Label" xml:space="preserve"><value>Source</value><comment>Terminology source column label.</comment></data>
+  <data name="Workspace_Tools_Target_Label" xml:space="preserve"><value>Target</value><comment>Terminology target column label.</comment></data>
+  <data name="Workspace_Tools_ImportTable_Action" xml:space="preserve"><value>Import table</value><comment>Imports a bounded Phoenix translation TSV table.</comment></data>
+  <data name="Workspace_Tools_ExportTable_Action" xml:space="preserve"><value>Export table</value><comment>Exports a Phoenix translation TSV table.</comment></data>
+  <data name="Workspace_Tools_ExportProject_Action" xml:space="preserve"><value>Export project</value><comment>Writes staged translations to a new validated project file.</comment></data>
+  <data name="Workspace_Tools_ImportTable_Title" xml:space="preserve"><value>Import translation table</value><comment>Translation-table import dialog title.</comment></data>
+  <data name="Workspace_Tools_ExportTable_Title" xml:space="preserve"><value>Export translation table</value><comment>Translation-table export dialog title.</comment></data>
+  <data name="Workspace_Tools_ExportProject_Title" xml:space="preserve"><value>Export translated project</value><comment>Translated-project export dialog title.</comment></data>
+  <data name="Workspace_Tools_Table_Filter" xml:space="preserve"><value>Phoenix translation table|*.tsv</value><comment>Translation-table file picker filter.</comment></data>
+  <data name="Workspace_Tools_TableImported" xml:space="preserve"><value>Imported targets for {0} entries.</value><comment>Table import completion. Placeholder: {0}=entry count.</comment></data>
+  <data name="Workspace_Tools_TableExported" xml:space="preserve"><value>The translation table was exported.</value><comment>Table export completion.</comment></data>
+  <data name="Workspace_Tools_Exporting" xml:space="preserve"><value>Validating and exporting the project…</value><comment>Status during safe project export.</comment></data>
+  <data name="Workspace_Tools_Exported" xml:space="preserve"><value>The translated project was exported successfully.</value><comment>Project export completion.</comment></data>
+  <data name="Workspace_Tools_Export_NoProject" xml:space="preserve"><value>Open a project to check export readiness.</value><comment>Export readiness without a loaded project.</comment></data>
+  <data name="Workspace_Tools_Export_Blocked" xml:space="preserve"><value>Export blocked: {0} draft or rejected entries.</value><comment>Blocked export readiness. Placeholder: {0}=entry count.</comment></data>
+  <data name="Workspace_Tools_Export_Warning" xml:space="preserve"><value>Ready with warning: {0} entries are not approved.</value><comment>Warning export readiness. Placeholder: {0}=entry count.</comment></data>
+  <data name="Workspace_Tools_Export_Ready" xml:space="preserve"><value>Ready to export: all entries are approved.</value><comment>Successful export readiness.</comment></data>
+  <data name="Workspace_Tools_Cancelled" xml:space="preserve"><value>The operation was cancelled before changes were applied.</value><comment>Safe cancellation result for staged tools.</comment></data>
+  <data name="Workspace_Tools_OperationFailed" xml:space="preserve"><value>The operation failed. Existing project content was preserved.</value><comment>Safe generic workspace-tool failure.</comment></data>
+  <data name="Workspace_Tools_PrepareInteractive_Action" xml:space="preserve"><value>Prepare selected entry</value><comment>Builds an interactive-provider request for the selected entry.</comment></data>
+  <data name="Workspace_Tools_CopyRequest_Action" xml:space="preserve"><value>Copy request</value><comment>Copies the bounded interactive-provider request.</comment></data>
+  <data name="Workspace_Tools_Response_Label" xml:space="preserve"><value>Provider response</value><comment>Interactive-provider response field label.</comment></data>
+  <data name="Workspace_Tools_ApplyResponse_Action" xml:space="preserve"><value>Validate and apply</value><comment>Validates request identity before applying an interactive response.</comment></data>
+  <data name="Workspace_Tools_InteractivePrepared" xml:space="preserve"><value>The request is ready to copy.</value><comment>Interactive request preparation result.</comment></data>
+  <data name="Workspace_Tools_InteractiveMismatch" xml:space="preserve"><value>The response does not contain the matching request identifier.</value><comment>Interactive response validation failure.</comment></data>
+  <data name="Workspace_Tools_InteractiveApplied" xml:space="preserve"><value>Applied the validated response to {0} entry.</value><comment>Interactive response completion. Placeholder: {0}=entry count.</comment></data>
   <data name="Settings_Title" xml:space="preserve"><value>Settings</value><comment>Settings workflow title.</comment></data>
   <data name="Settings_Navigation_Providers" xml:space="preserve"><value>Providers</value><comment>Settings navigation destination.</comment></data>
   <data name="Settings_Navigation_TranslationBehavior" xml:space="preserve"><value>Translation behavior</value><comment>Settings navigation destination.</comment></data>

--- a/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml.cs
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml.cs
@@ -1,9 +1,12 @@
 using System;
 using System.ComponentModel;
+using System.IO;
+using System.Threading;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Threading;
 using Microsoft.Win32;
+using PhoenixEngine.Language;
 using PhoenixTranslator.ApplicationLayer;
 
 namespace PhoenixTranslator.UIManagement.Preview
@@ -33,7 +36,12 @@ namespace PhoenixTranslator.UIManagement.Preview
                 OpenLegacyWorkspace,
                 _shellViewModel,
                 PreviewTranslationProject.Open,
-                OpenProjectFromWorkflowAsync);
+                OpenProjectFromWorkflowAsync,
+                SelectTranslationTableImport,
+                SelectTranslationTableExport,
+                SelectProjectExport,
+                ConvertToTraditional,
+                CopyWorkspaceText);
             _projectHubViewModel = new PreviewProjectHubViewModel(
                 _translationWorkspaceViewModel,
                 _shellViewModel,
@@ -128,6 +136,82 @@ namespace PhoenixTranslator.UIManagement.Preview
             bool? result = dialog.ShowDialog(this);
             RestoreFocus(previousFocus);
             return result == true ? dialog.FileName : string.Empty;
+        }
+
+        private string SelectTranslationTableImport()
+        {
+            return ShowOpenDialog(
+                PreviewMessageCatalog.Get("Workspace_Tools_ImportTable_Title"),
+                PreviewMessageCatalog.Get("Workspace_Tools_Table_Filter"));
+        }
+
+        private string SelectTranslationTableExport()
+        {
+            return ShowSaveDialog(
+                PreviewMessageCatalog.Get("Workspace_Tools_ExportTable_Title"),
+                PreviewMessageCatalog.Get("Workspace_Tools_Table_Filter"),
+                "translation-table.tsv");
+        }
+
+        private string SelectProjectExport()
+        {
+            string sourcePath = _translationWorkspaceViewModel.ProjectPath;
+            if (string.IsNullOrWhiteSpace(sourcePath))
+            {
+                return string.Empty;
+            }
+
+            string extension = Path.GetExtension(sourcePath);
+            string filter = string.Format("{0} project|*{0}", extension);
+            string fileName = Path.GetFileNameWithoutExtension(sourcePath) + "-export" + extension;
+            return ShowSaveDialog(PreviewMessageCatalog.Get("Workspace_Tools_ExportProject_Title"), filter, fileName);
+        }
+
+        private string ShowOpenDialog(string title, string filter)
+        {
+            IInputElement previousFocus = Keyboard.FocusedElement;
+            var dialog = new OpenFileDialog
+            {
+                Title = title,
+                Filter = filter,
+                CheckFileExists = true,
+                Multiselect = false
+            };
+            bool? result = dialog.ShowDialog(this);
+            RestoreFocus(previousFocus);
+            return result == true ? dialog.FileName : string.Empty;
+        }
+
+        private string ShowSaveDialog(string title, string filter, string fileName)
+        {
+            IInputElement previousFocus = Keyboard.FocusedElement;
+            var dialog = new SaveFileDialog
+            {
+                Title = title,
+                Filter = filter,
+                FileName = fileName,
+                AddExtension = true,
+                OverwritePrompt = true
+            };
+            bool? result = dialog.ShowDialog(this);
+            RestoreFocus(previousFocus);
+            return result == true ? dialog.FileName : string.Empty;
+        }
+
+        private static string ConvertToTraditional(string value, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string converted = ChineseVariantMap.SimplifiedToTraditionalByReq(value ?? string.Empty);
+            cancellationToken.ThrowIfCancellationRequested();
+            return converted;
+        }
+
+        private static void CopyWorkspaceText(string value)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                Clipboard.SetText(value);
+            }
         }
 
         private bool ConfirmConflictReuse(int entryCount)

--- a/Phoenix_Translator/UIManagement/Preview/PreviewTranslationWorkspaceView.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewTranslationWorkspaceView.xaml
@@ -29,6 +29,47 @@
                 </Trigger>
             </Style.Triggers>
             </Style>
+            <Style x:Key="WorkspaceToolTab" TargetType="TabItem">
+                <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextSecondary}" />
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderThickness" Value="0,0,0,2" />
+                <Setter Property="BorderBrush" Value="Transparent" />
+                <Setter Property="Padding" Value="8,6" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="TabItem">
+                            <Border x:Name="Chrome" Padding="{TemplateBinding Padding}" Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+                                <ContentPresenter ContentSource="Header" HorizontalAlignment="Center" />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
+                                </Trigger>
+                                <Trigger Property="IsSelected" Value="True">
+                                    <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" />
+                                    <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushAccentGold}" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+            <Style x:Key="WorkspaceToolTabControl" TargetType="TabControl">
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="TabControl">
+                            <Grid KeyboardNavigation.TabNavigation="Local">
+                                <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="*" /></Grid.RowDefinitions>
+                                <TabPanel IsItemsHost="True" Background="Transparent" />
+                                <ContentPresenter Grid.Row="1" Margin="0,14,0,0" ContentSource="SelectedContent" />
+                            </Grid>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -120,11 +161,11 @@
 
                 <Grid Visibility="{Binding HasProject, Converter={StaticResource BooleanToVisibility}}">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="280" MinWidth="220" />
+                        <ColumnDefinition Width="240" MinWidth="200" />
                         <ColumnDefinition Width="5" />
-                        <ColumnDefinition Width="*" MinWidth="300" />
+                        <ColumnDefinition Width="*" MinWidth="260" />
                         <ColumnDefinition Width="5" />
-                        <ColumnDefinition Width="220" MinWidth="190" />
+                        <ColumnDefinition Width="280" MinWidth="250" />
                     </Grid.ColumnDefinitions>
                     <Grid Grid.Column="0">
                         <Grid.RowDefinitions><RowDefinition Height="42" /><RowDefinition Height="*" /></Grid.RowDefinitions>
@@ -186,25 +227,103 @@
                     </Grid>
                     <GridSplitter Grid.Column="3" Width="5" HorizontalAlignment="Stretch"
                                   Background="{StaticResource PreviewBrushBorder}" />
-                    <StackPanel Grid.Column="4" Margin="18"
+                    <TabControl Grid.Column="4" Margin="14" Style="{StaticResource WorkspaceToolTabControl}"
                                 AutomationProperties.Name="{localization:PreviewMessage Accessibility_Workspace_ContextInspector_Name}">
-                        <TextBlock FontSize="16" FontWeight="SemiBold" Foreground="{StaticResource PreviewBrushTextPrimary}"
-                                   Text="{localization:PreviewMessage Workspace_Context_Title}" />
-                        <TextBlock Margin="0,24,0,4" FontSize="11" Foreground="{StaticResource PreviewBrushTextMuted}"
-                                   Text="{localization:PreviewMessage Workspace_Context_Record_Label}" />
-                        <TextBlock Foreground="{StaticResource PreviewBrushTextSecondary}" TextWrapping="Wrap"
-                                   Text="{Binding SelectedEntry.Record}" />
-                        <TextBlock Margin="0,18,0,4" FontSize="11" Foreground="{StaticResource PreviewBrushTextMuted}"
-                                   Text="{localization:PreviewMessage Workspace_Context_Type_Label}" />
-                        <TextBlock Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{Binding SelectedEntry.Type}" />
-                        <TextBlock Margin="0,18,0,4" FontSize="11" Foreground="{StaticResource PreviewBrushTextMuted}"
-                                   Text="{localization:PreviewMessage Workspace_Context_Key_Label}" />
-                        <TextBox Padding="8" IsReadOnly="True" TextWrapping="Wrap" Style="{StaticResource PreviewTextBox}"
-                                 Text="{Binding SelectedEntry.Key, Mode=OneWay}" />
-                        <TextBlock Margin="0,18,0,4" FontSize="11" Foreground="{StaticResource PreviewBrushTextMuted}"
-                                   Text="{localization:PreviewMessage Workspace_Context_Score_Label}" />
-                        <TextBlock Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{Binding SelectedEntry.Score}" />
-                    </StackPanel>
+                        <TabItem Style="{StaticResource WorkspaceToolTab}" Header="{localization:PreviewMessage Workspace_Context_Title}">
+                            <StackPanel>
+                                <TextBlock Margin="0,8,0,4" FontSize="11" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                           Text="{localization:PreviewMessage Workspace_Context_Record_Label}" />
+                                <TextBlock Foreground="{StaticResource PreviewBrushTextSecondary}" TextWrapping="Wrap"
+                                           Text="{Binding SelectedEntry.Record}" />
+                                <TextBlock Margin="0,18,0,4" FontSize="11" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                           Text="{localization:PreviewMessage Workspace_Context_Type_Label}" />
+                                <TextBlock Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{Binding SelectedEntry.Type}" />
+                                <TextBlock Margin="0,18,0,4" FontSize="11" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                           Text="{localization:PreviewMessage Workspace_Context_Key_Label}" />
+                                <TextBox Padding="8" IsReadOnly="True" TextWrapping="Wrap" Style="{StaticResource PreviewTextBox}"
+                                         Text="{Binding SelectedEntry.Key, Mode=OneWay}" />
+                                <TextBlock Margin="0,18,0,4" FontSize="11" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                           Text="{localization:PreviewMessage Workspace_Context_Score_Label}" />
+                                <TextBlock Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{Binding SelectedEntry.Score}" />
+                            </StackPanel>
+                        </TabItem>
+                        <TabItem Style="{StaticResource WorkspaceToolTab}" Header="{localization:PreviewMessage Workspace_Tools_Title}">
+                            <Grid DataContext="{Binding Tools}">
+                                <Grid.RowDefinitions><RowDefinition Height="*" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
+                                <TabControl Style="{StaticResource WorkspaceToolTabControl}">
+                                    <TabItem Style="{StaticResource WorkspaceToolTab}" Header="{localization:PreviewMessage Workspace_Tools_Edit_Tab}">
+                                        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                                            <StackPanel Margin="0,0,4,0">
+                                                <TextBlock Foreground="{StaticResource PreviewBrushTextMuted}" Text="{localization:PreviewMessage Workspace_Tools_Find_Label}" />
+                                                <TextBox Margin="0,5,0,10" Style="{StaticResource PreviewTextBox}" Text="{Binding FindText, UpdateSourceTrigger=PropertyChanged}" />
+                                                <TextBlock Foreground="{StaticResource PreviewBrushTextMuted}" Text="{localization:PreviewMessage Workspace_Tools_Replace_Label}" />
+                                                <TextBox Margin="0,5,0,10" Style="{StaticResource PreviewTextBox}" Text="{Binding ReplacementText, UpdateSourceTrigger=PropertyChanged}" />
+                                                <TextBlock Foreground="{StaticResource PreviewBrushTextMuted}" Text="{localization:PreviewMessage Workspace_Tools_Scope_Label}" />
+                                                <ComboBox Margin="0,5,0,8" Style="{StaticResource PreviewComboBox}" ItemsSource="{Binding ScopeOptions}" SelectedItem="{Binding SelectedScope}" />
+                                                <TextBlock Margin="0,0,0,8" Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{Binding PreviewText}" />
+                                                <WrapPanel>
+                                                    <Button Style="{StaticResource PreviewButtonSecondary}" Command="{Binding PreviewReplaceCommand}" Content="{localization:PreviewMessage Workspace_Tools_Preview_Action}" />
+                                                    <Button Margin="6,0,0,0" Style="{StaticResource PreviewButtonPrimary}" Command="{Binding ApplyReplaceCommand}" Content="{localization:PreviewMessage Workspace_Tools_Apply_Action}" />
+                                                </WrapPanel>
+                                                <Button Margin="0,16,0,0" HorizontalAlignment="Left" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding ConvertCommand}" Content="{localization:PreviewMessage Workspace_Tools_Convert_Action}" />
+                                                <TextBlock Margin="0,6,0,0" Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{Binding ConversionPreviewText}" />
+                                                <Button Margin="0,6,0,0" HorizontalAlignment="Left" Style="{StaticResource PreviewButtonPrimary}" Command="{Binding ApplyConversionCommand}" Content="{localization:PreviewMessage Workspace_Tools_ApplyConversion_Action}" />
+                                                <Button Margin="0,8,0,0" HorizontalAlignment="Left" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding UndoCommand}" Content="{localization:PreviewMessage Workspace_Tools_Undo_Action}" />
+                                            </StackPanel>
+                                        </ScrollViewer>
+                                    </TabItem>
+                                    <TabItem Style="{StaticResource WorkspaceToolTab}" Header="{localization:PreviewMessage Workspace_Tools_Terms_Tab}">
+                                        <Grid>
+                                            <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="*" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
+                                            <TextBox Style="{StaticResource PreviewTextBox}" ToolTip="{localization:PreviewMessage Workspace_Tools_TermSearch}"
+                                                     Text="{Binding TerminologySearch, UpdateSourceTrigger=PropertyChanged}" />
+                                            <ListBox Grid.Row="1" Margin="0,8" ItemsSource="{Binding FilteredTerminology}" SelectedItem="{Binding SelectedTerm}"
+                                                     Background="Transparent" BorderBrush="{StaticResource PreviewBrushBorder}" BorderThickness="1">
+                                                <ListBox.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <StackPanel Margin="4">
+                                                            <TextBox Style="{StaticResource PreviewTextBox}" Text="{Binding Source, UpdateSourceTrigger=PropertyChanged}" />
+                                                            <TextBox Margin="0,4,0,0" Style="{StaticResource PreviewTextBox}" Text="{Binding Target, UpdateSourceTrigger=PropertyChanged}" />
+                                                        </StackPanel>
+                                                    </DataTemplate>
+                                                </ListBox.ItemTemplate>
+                                            </ListBox>
+                                            <WrapPanel Grid.Row="2">
+                                                <Button Style="{StaticResource PreviewButtonSecondary}" Command="{Binding AddSelectedTermCommand}" Content="{localization:PreviewMessage Workspace_Tools_AddTerm_Action}" />
+                                                <Button Margin="5,0,0,0" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding RemoveTermCommand}" Content="{localization:PreviewMessage Workspace_Tools_RemoveTerm_Action}" />
+                                                <Button Margin="0,6,0,0" Style="{StaticResource PreviewButtonPrimary}" Command="{Binding ApplyTerminologyCommand}" Content="{localization:PreviewMessage Workspace_Tools_ApplyTerms_Action}" />
+                                            </WrapPanel>
+                                        </Grid>
+                                    </TabItem>
+                                    <TabItem Style="{StaticResource WorkspaceToolTab}" Header="{localization:PreviewMessage Workspace_Tools_Deliver_Tab}">
+                                        <StackPanel>
+                                            <TextBlock Margin="0,0,0,14" Foreground="{StaticResource PreviewBrushTextSecondary}" TextWrapping="Wrap" Text="{Binding ExportReadinessText}" />
+                                            <Button HorizontalAlignment="Left" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding ImportTableCommand}" Content="{localization:PreviewMessage Workspace_Tools_ImportTable_Action}" />
+                                            <Button Margin="0,8,0,0" HorizontalAlignment="Left" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding ExportTableCommand}" Content="{localization:PreviewMessage Workspace_Tools_ExportTable_Action}" />
+                                            <Button Margin="0,20,0,0" HorizontalAlignment="Left" Style="{StaticResource PreviewButtonPrimary}" Command="{Binding ExportProjectCommand}" Content="{localization:PreviewMessage Workspace_Tools_ExportProject_Action}" />
+                                            <Button Margin="0,8,0,0" HorizontalAlignment="Left" Style="{StaticResource PreviewButtonDanger}" Command="{Binding CancelCommand}" Content="{localization:PreviewMessage Workspace_Cancel_Action}" />
+                                        </StackPanel>
+                                    </TabItem>
+                                    <TabItem Style="{StaticResource WorkspaceToolTab}" Header="{localization:PreviewMessage Workspace_Tools_Interactive_Tab}">
+                                        <Grid>
+                                            <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="*" /><RowDefinition Height="Auto" /><RowDefinition Height="*" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
+                                            <WrapPanel>
+                                                <Button Style="{StaticResource PreviewButtonSecondary}" Command="{Binding PrepareInteractiveCommand}" Content="{localization:PreviewMessage Workspace_Tools_PrepareInteractive_Action}" />
+                                                <Button Margin="5,0,0,0" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding CopyInteractiveCommand}" Content="{localization:PreviewMessage Workspace_Tools_CopyRequest_Action}" />
+                                            </WrapPanel>
+                                            <TextBox Grid.Row="1" Margin="0,8" IsReadOnly="True" AcceptsReturn="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto"
+                                                     Style="{StaticResource PreviewTextBox}" Text="{Binding InteractiveRequest, Mode=OneWay}" />
+                                            <TextBlock Grid.Row="2" Foreground="{StaticResource PreviewBrushTextMuted}" Text="{localization:PreviewMessage Workspace_Tools_Response_Label}" />
+                                            <TextBox Grid.Row="3" Margin="0,5,0,8" AcceptsReturn="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto"
+                                                     Style="{StaticResource PreviewTextBox}" Text="{Binding InteractiveResponse, UpdateSourceTrigger=PropertyChanged}" />
+                                            <Button Grid.Row="4" HorizontalAlignment="Left" Style="{StaticResource PreviewButtonPrimary}" Command="{Binding ApplyInteractiveCommand}" Content="{localization:PreviewMessage Workspace_Tools_ApplyResponse_Action}" />
+                                        </Grid>
+                                    </TabItem>
+                                </TabControl>
+                                <TextBlock Grid.Row="1" Margin="0,10,0,0" Foreground="{StaticResource PreviewBrushTextMuted}" TextWrapping="Wrap" Text="{Binding StatusText}" />
+                            </Grid>
+                        </TabItem>
+                    </TabControl>
                 </Grid>
             </Grid>
         </Border>


### PR DESCRIPTION
## Summary

- move scoped Find and Replace, exact-match terminology, translation-table exchange, writing-variant conversion, and interactive provider exchange into the normalized preview workspace
- add safe project export with readiness gates, format preservation, cancellation, output validation, and atomic final placement
- preserve existing targets during table import, require explicit apply for conversion previews, and provide one-step undo for staged tool mutations
- add responsive dark-mode workspace tabs and stable English localization identifiers
- bump the application version to 2.0.0.14

## Validation

- Release x64 rebuild with Visual Studio 2022 MSBuild
- 38/38 preset regression tests passed
- visual verification at 1280 × 800 and the 1100 × 700 minimum
- startup and project-open smoke test with the synthetic mixed-review XML fixture
- no new compiler warnings; the six existing legacy warnings remain unchanged

Closes #58
