### PR TITLE
Dock code, record, and asset context inspectors

### DIFF
--- a/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
+++ b/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
@@ -39,6 +39,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WindowsBase" />
@@ -52,6 +53,15 @@
     </Compile>
     <Compile Include="..\Phoenix_Translator\Application\PreviewMessageCatalog.cs">
       <Link>PreviewMessageCatalog.cs</Link>
+    </Compile>
+    <Compile Include="..\Phoenix_Translator\Application\PreviewContextInspectorModels.cs">
+      <Link>PreviewContextInspectorModels.cs</Link>
+    </Compile>
+    <Compile Include="..\Phoenix_Translator\Application\PreviewAssetContextLoader.cs">
+      <Link>PreviewAssetContextLoader.cs</Link>
+    </Compile>
+    <Compile Include="..\Phoenix_Translator\Application\PreviewContextInspectorViewModel.cs">
+      <Link>PreviewContextInspectorViewModel.cs</Link>
     </Compile>
     <Compile Include="..\Phoenix_Translator\Application\PreviewQualityAnalyzer.cs">
       <Link>PreviewQualityAnalyzer.cs</Link>

--- a/PhoenixTranslator.PresetTests/Program.cs
+++ b/PhoenixTranslator.PresetTests/Program.cs
@@ -42,6 +42,10 @@ namespace PhoenixTranslator.PresetTests
                 { nameof(HandlesPreviewTranslationFailures), HandlesPreviewTranslationFailures },
                 { nameof(CancelsPreviewTranslationWork), CancelsPreviewTranslationWork },
                 { nameof(FiltersLargePreviewTranslationProject), FiltersLargePreviewTranslationProject },
+                { nameof(LoadsAndNavigatesPreviewContext), LoadsAndNavigatesPreviewContext },
+                { nameof(DiscardsStalePreviewContext), DiscardsStalePreviewContext },
+                { nameof(DistinguishesEmptyAndFailedPreviewContext), DistinguishesEmptyAndFailedPreviewContext },
+                { nameof(ValidatesBoundedPreviewAssets), ValidatesBoundedPreviewAssets },
                 { nameof(PreviewsAppliesAndUndoesWorkspaceReplacement), PreviewsAppliesAndUndoesWorkspaceReplacement },
                 { nameof(RoundTripsBoundedTranslationTable), RoundTripsBoundedTranslationTable },
                 { nameof(ValidatesInteractiveProviderRequestIdentity), ValidatesInteractiveProviderRequestIdentity },
@@ -661,6 +665,163 @@ namespace PhoenixTranslator.PresetTests
             AssertEqual(12500, viewModel.Entries.Count,
                 "Large-project type filtering must retain every matching record.");
             viewModel.Dispose();
+        }
+
+        private static void LoadsAndNavigatesPreviewContext()
+        {
+            var first = CreateEntry("first", "needle", string.Empty);
+            var second = CreateEntry("second", "Related source", string.Empty);
+            string code = string.Join("\n", Enumerable.Repeat("needle call", 205));
+            var context = new PreviewEntryContext(
+                code,
+                "PexInterface",
+                new[] { new PreviewContextMetadata("Function", "OnInit", "PexInterface") },
+                new[] { new PreviewContextRelation("second", "Related source", "INFO", "EspReader", "Dialogue") },
+                new[] { new PreviewNpcContext("second", "Aela", "Female", "FemaleNord") },
+                null);
+            PreviewTranslationEntry navigatedEntry = null;
+            var inspector = new PreviewContextInspectorViewModel(
+                (entry, cancellationToken) => context,
+                key => string.Equals(key, second.Key, StringComparison.Ordinal) ? second : null,
+                entry => navigatedEntry = entry);
+
+            inspector.SelectEntry(first);
+            AssertEqual(true, SpinWait.SpinUntil(() => inspector.State == PreviewContextState.Ready, 2000),
+                "A supported context snapshot must reach the ready state.");
+            AssertEqual(true, SpinWait.SpinUntil(() => inspector.CodeResults.Count == 200, 2000),
+                "Automatic code search must finish with its documented result bound.");
+            AssertEqual(1, inspector.CodeResults[0].LineNumber,
+                "Code search must retain exact one-based source line identity.");
+
+            inspector.SelectedRelation = context.Relations[0];
+            inspector.NavigateRelationCommand.Execute(null);
+            AssertEqual(second, navigatedEntry,
+                "Relationship navigation must resolve the stable normalized entry key.");
+
+            navigatedEntry = null;
+            inspector.SelectedNpc = context.Npcs[0];
+            inspector.NavigateNpcCommand.Execute(null);
+            AssertEqual(second, navigatedEntry,
+                "NPC navigation must resolve the stable normalized entry key.");
+            inspector.Dispose();
+        }
+
+        private static void DiscardsStalePreviewContext()
+        {
+            var first = CreateEntry("first", "First", string.Empty);
+            var second = CreateEntry("second", "Second", string.Empty);
+            bool firstStarted = false;
+            var inspector = new PreviewContextInspectorViewModel(
+                (entry, cancellationToken) =>
+                {
+                    if (ReferenceEquals(entry, first))
+                    {
+                        firstStarted = true;
+                        while (true)
+                        {
+                            cancellationToken.ThrowIfCancellationRequested();
+                            Thread.Sleep(5);
+                        }
+                    }
+
+                    return new PreviewEntryContext(
+                        string.Empty,
+                        string.Empty,
+                        new[] { new PreviewContextMetadata("Stable key", entry.Key, "Phoenix Translator") },
+                        new PreviewContextRelation[0],
+                        new PreviewNpcContext[0],
+                        null);
+                },
+                key => null,
+                entry => { });
+
+            inspector.SelectEntry(first);
+            AssertEqual(true, SpinWait.SpinUntil(() => firstStarted, 2000),
+                "The first synthetic context request must begin before selection changes.");
+            inspector.SelectEntry(second);
+            AssertEqual(true, SpinWait.SpinUntil(() => inspector.State == PreviewContextState.Ready, 2000),
+                "The replacement selection must load after cancelling stale work.");
+            AssertEqual("second", inspector.Context.Metadata[0].Value,
+                "Cancelled stale work must never replace the current entry context.");
+            inspector.Dispose();
+        }
+
+        private static void DistinguishesEmptyAndFailedPreviewContext()
+        {
+            var entry = CreateEntry("entry", "Source", string.Empty);
+            var emptyInspector = new PreviewContextInspectorViewModel(
+                (selected, cancellationToken) => new PreviewEntryContext(
+                    string.Empty,
+                    string.Empty,
+                    new PreviewContextMetadata[0],
+                    new PreviewContextRelation[0],
+                    new PreviewNpcContext[0],
+                    null),
+                key => null,
+                selected => { });
+            emptyInspector.SelectEntry(entry);
+            AssertEqual(true, SpinWait.SpinUntil(() => emptyInspector.State == PreviewContextState.Empty, 2000),
+                "Unsupported context must remain an explicit empty state.");
+            AssertEqual("No supported context is available for this entry.", emptyInspector.StateText,
+                "Unsupported context must not be presented as a failure.");
+            emptyInspector.Dispose();
+
+            var failedInspector = new PreviewContextInspectorViewModel(
+                (selected, cancellationToken) => { throw new InvalidDataException("Synthetic parser failure."); },
+                key => null,
+                selected => { });
+            failedInspector.SelectEntry(entry);
+            AssertEqual(true, SpinWait.SpinUntil(() => failedInspector.State == PreviewContextState.Failed, 2000),
+                "Parser failures must reach a distinct failed state.");
+            AssertEqual(true, failedInspector.RetryCommand.CanExecute(null),
+                "A failed context load must remain explicitly retryable.");
+            failedInspector.Dispose();
+        }
+
+        private static void ValidatesBoundedPreviewAssets()
+        {
+            string directory = Path.Combine(Path.GetTempPath(), "PhoenixAssetContextTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+            string projectPath = Path.Combine(directory, "fixture.xml");
+            File.WriteAllText(projectPath, "fixture");
+            try
+            {
+                string imagePath = Path.Combine(directory, "preview.png");
+                File.WriteAllBytes(imagePath, Convert.FromBase64String(
+                    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="));
+                PreviewAssetContext asset = PreviewAssetContextLoader.Load(
+                    projectPath,
+                    "preview.png",
+                    CancellationToken.None);
+                AssertEqual("preview.png", asset.DisplayName,
+                    "Validated asset context must expose only a safe file name.");
+                AssertEqual("1 × 1", asset.Dimensions,
+                    "Validated asset context must retain decoded dimensions.");
+                AssertEqual(null, PreviewAssetContextLoader.Load(
+                    projectPath,
+                    "../outside.png",
+                    CancellationToken.None),
+                    "Asset context must reject traversal outside the project directory.");
+
+                string malformedPath = Path.Combine(directory, "malformed.png");
+                File.WriteAllText(malformedPath, "not an image");
+                bool malformedRejected = false;
+                try
+                {
+                    PreviewAssetContextLoader.Load(projectPath, "malformed.png", CancellationToken.None);
+                }
+                catch (InvalidDataException)
+                {
+                    malformedRejected = true;
+                }
+
+                AssertEqual(true, malformedRejected,
+                    "Malformed visual assets must fail at the bounded context boundary.");
+            }
+            finally
+            {
+                Directory.Delete(directory, true);
+            }
         }
 
         private static void PreviewsAppliesAndUndoesWorkspaceReplacement()
@@ -1301,6 +1462,22 @@ namespace PhoenixTranslator.PresetTests
 
                 return "Translated " + entry.SourceText;
             }
+
+            public PreviewEntryContext LoadContext(
+                PreviewTranslationEntry entry,
+                CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return Context ?? new PreviewEntryContext(
+                    string.Empty,
+                    string.Empty,
+                    new PreviewContextMetadata[0],
+                    new PreviewContextRelation[0],
+                    new PreviewNpcContext[0],
+                    null);
+            }
+
+            internal PreviewEntryContext Context { get; set; }
 
             public void Save()
             {

--- a/Phoenix_Translator/Application/IPreviewTranslationProject.cs
+++ b/Phoenix_Translator/Application/IPreviewTranslationProject.cs
@@ -33,6 +33,14 @@ namespace PhoenixTranslator.ApplicationLayer
         string Translate(PreviewTranslationEntry entry, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Loads bounded code, record, NPC, relationship, and asset context for one stable entry.
+        /// </summary>
+        /// <param name="entry">The selected normalized entry.</param>
+        /// <param name="cancellationToken">Cancels parser and asset work cooperatively.</param>
+        /// <returns>The supported context snapshot, which may be empty.</returns>
+        PreviewEntryContext LoadContext(PreviewTranslationEntry entry, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Persists staged targets through the format-specific writer and backup boundary.
         /// </summary>
         void Save();

--- a/Phoenix_Translator/Application/PreviewAssetContextLoader.cs
+++ b/Phoenix_Translator/Application/PreviewAssetContextLoader.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Resolves and validates bounded visual assets beneath a project's directory.
+    /// </summary>
+    internal static class PreviewAssetContextLoader
+    {
+        private const long MaximumAssetBytes = 8L * 1024L * 1024L;
+        private const long MaximumAssetPixels = 40000000L;
+        private static readonly string[] SupportedExtensions = { ".png", ".jpg", ".jpeg", ".bmp" };
+
+        /// <summary>
+        /// Loads a safe in-memory asset snapshot when the source text names a supported relative image.
+        /// </summary>
+        /// <param name="projectPath">The private absolute path of the active project.</param>
+        /// <param name="sourceText">The untrusted source text that may contain a relative image path.</param>
+        /// <param name="cancellationToken">Cancels file and image validation cooperatively.</param>
+        /// <returns>The validated snapshot, or <c>null</c> when no supported reachable asset is named.</returns>
+        /// <exception cref="InvalidDataException">The named asset exceeds a safety limit or is malformed.</exception>
+        internal static PreviewAssetContext Load(
+            string projectPath,
+            string sourceText,
+            CancellationToken cancellationToken)
+        {
+            string candidate = (sourceText ?? string.Empty).Trim().Trim('"', '\'');
+            string extension = Path.GetExtension(candidate);
+            if (string.IsNullOrWhiteSpace(candidate) || Path.IsPathRooted(candidate) ||
+                !SupportedExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            string projectDirectory = Path.GetDirectoryName(Path.GetFullPath(projectPath));
+            string root = projectDirectory.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            string assetPath = Path.GetFullPath(Path.Combine(
+                root,
+                candidate.Replace('/', Path.DirectorySeparatorChar)));
+            if (!assetPath.StartsWith(root, StringComparison.OrdinalIgnoreCase) || !File.Exists(assetPath))
+            {
+                return null;
+            }
+
+            var fileInfo = new FileInfo(assetPath);
+            if (fileInfo.Length > MaximumAssetBytes)
+            {
+                throw new InvalidDataException("The related visual asset exceeds the supported size limit.");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            byte[] content = File.ReadAllBytes(assetPath);
+            try
+            {
+                using (var stream = new MemoryStream(content, false))
+                using (Image image = Image.FromStream(stream, true, true))
+                {
+                    if ((long)image.Width * image.Height > MaximumAssetPixels)
+                    {
+                        throw new InvalidDataException("The related visual asset exceeds the supported pixel limit.");
+                    }
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return new PreviewAssetContext(Path.GetFileName(assetPath), content, image.Width, image.Height);
+                }
+            }
+            catch (ArgumentException exception)
+            {
+                throw new InvalidDataException("The related visual asset is malformed.", exception);
+            }
+        }
+    }
+}

--- a/Phoenix_Translator/Application/PreviewContextInspectorModels.cs
+++ b/Phoenix_Translator/Application/PreviewContextInspectorModels.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Identifies the observable loading state of entry context.
+    /// </summary>
+    internal enum PreviewContextState
+    {
+        /// <summary>The inspector has no selected entry.</summary>
+        Empty,
+        /// <summary>The inspector is loading bounded context.</summary>
+        Loading,
+        /// <summary>The inspector loaded at least one supported context source.</summary>
+        Ready,
+        /// <summary>The inspector could not load parser or asset context.</summary>
+        Failed
+    }
+
+    /// <summary>
+    /// Describes one technical metadata value and its supporting repository source.
+    /// </summary>
+    internal sealed class PreviewContextMetadata
+    {
+        internal PreviewContextMetadata(string label, string value, string source)
+        {
+            Label = label ?? string.Empty;
+            Value = value ?? string.Empty;
+            Source = source ?? string.Empty;
+        }
+
+        /// <summary>Gets the short user-facing metadata label.</summary>
+        public string Label { get; private set; }
+
+        /// <summary>Gets the bounded metadata value.</summary>
+        public string Value { get; private set; }
+
+        /// <summary>Gets the repository boundary that supplied the value.</summary>
+        public string Source { get; private set; }
+    }
+
+    /// <summary>
+    /// Describes a stable related translation entry.
+    /// </summary>
+    internal sealed class PreviewContextRelation
+    {
+        internal PreviewContextRelation(
+            string entryKey,
+            string title,
+            string detail,
+            string source,
+            string relationship)
+        {
+            EntryKey = entryKey ?? string.Empty;
+            Title = title ?? string.Empty;
+            Detail = detail ?? string.Empty;
+            Source = source ?? string.Empty;
+            Relationship = relationship ?? string.Empty;
+        }
+
+        /// <summary>Gets the stable project-local key of the related entry.</summary>
+        public string EntryKey { get; private set; }
+
+        /// <summary>Gets the safe related-entry title.</summary>
+        public string Title { get; private set; }
+
+        /// <summary>Gets bounded parser detail about the relationship.</summary>
+        public string Detail { get; private set; }
+
+        /// <summary>Gets the repository boundary that supplied the relationship.</summary>
+        public string Source { get; private set; }
+
+        /// <summary>Gets the semantic relationship label.</summary>
+        public string Relationship { get; private set; }
+    }
+
+    /// <summary>
+    /// Describes one NPC owner linked to a stable translation entry.
+    /// </summary>
+    internal sealed class PreviewNpcContext
+    {
+        internal PreviewNpcContext(string entryKey, string name, string gender, string voiceType)
+        {
+            EntryKey = entryKey ?? string.Empty;
+            Name = name ?? string.Empty;
+            Gender = gender ?? string.Empty;
+            VoiceType = voiceType ?? string.Empty;
+        }
+
+        /// <summary>Gets the stable project-local key owned by the NPC context.</summary>
+        public string EntryKey { get; private set; }
+
+        /// <summary>Gets the NPC display name.</summary>
+        public string Name { get; private set; }
+
+        /// <summary>Gets the parser-provided NPC gender.</summary>
+        public string Gender { get; private set; }
+
+        /// <summary>Gets the parser-provided voice type.</summary>
+        public string VoiceType { get; private set; }
+    }
+
+    /// <summary>
+    /// Owns a bounded validated visual asset snapshot without exposing its absolute path.
+    /// </summary>
+    internal sealed class PreviewAssetContext
+    {
+        internal PreviewAssetContext(string displayName, byte[] content, int width, int height)
+        {
+            DisplayName = displayName ?? string.Empty;
+            Content = content ?? new byte[0];
+            Width = width;
+            Height = height;
+        }
+
+        /// <summary>Gets the safe asset file name without its private path.</summary>
+        public string DisplayName { get; private set; }
+
+        /// <summary>Gets the bounded validated image bytes owned by this snapshot.</summary>
+        public byte[] Content { get; private set; }
+
+        /// <summary>Gets the decoded image width in pixels.</summary>
+        public int Width { get; private set; }
+
+        /// <summary>Gets the decoded image height in pixels.</summary>
+        public int Height { get; private set; }
+
+        /// <summary>Gets the formatted decoded pixel dimensions.</summary>
+        public string Dimensions => string.Format("{0} × {1}", Width, Height);
+    }
+
+    /// <summary>
+    /// Contains bounded technical context for one normalized translation entry.
+    /// </summary>
+    internal sealed class PreviewEntryContext
+    {
+        internal PreviewEntryContext(
+            string code,
+            string codeSource,
+            IReadOnlyList<PreviewContextMetadata> metadata,
+            IReadOnlyList<PreviewContextRelation> relations,
+            IReadOnlyList<PreviewNpcContext> npcs,
+            PreviewAssetContext asset)
+        {
+            Code = code ?? string.Empty;
+            CodeSource = codeSource ?? string.Empty;
+            Metadata = metadata ?? new PreviewContextMetadata[0];
+            Relations = relations ?? new PreviewContextRelation[0];
+            Npcs = npcs ?? new PreviewNpcContext[0];
+            Asset = asset;
+        }
+
+        /// <summary>Gets bounded decompiled code associated with the entry.</summary>
+        public string Code { get; private set; }
+
+        /// <summary>Gets the repository boundary that supplied the code.</summary>
+        public string CodeSource { get; private set; }
+
+        /// <summary>Gets bounded parser and normalized record metadata.</summary>
+        public IReadOnlyList<PreviewContextMetadata> Metadata { get; private set; }
+
+        /// <summary>Gets bounded stable relationships to other normalized entries.</summary>
+        public IReadOnlyList<PreviewContextRelation> Relations { get; private set; }
+
+        /// <summary>Gets bounded NPC ownership context.</summary>
+        public IReadOnlyList<PreviewNpcContext> Npcs { get; private set; }
+
+        /// <summary>Gets the validated visual asset snapshot, or <c>null</c>.</summary>
+        public PreviewAssetContext Asset { get; private set; }
+
+        /// <summary>Gets whether at least one supported context source supplied data.</summary>
+        public bool HasAnyContext => !string.IsNullOrWhiteSpace(Code) ||
+            Metadata.Count > 0 || Relations.Count > 0 || Npcs.Count > 0 || Asset != null;
+    }
+
+    /// <summary>
+    /// Describes one bounded exact code-search result.
+    /// </summary>
+    internal sealed class PreviewCodeSearchResult
+    {
+        internal PreviewCodeSearchResult(int lineNumber, string text)
+        {
+            LineNumber = lineNumber;
+            Text = text ?? string.Empty;
+        }
+
+        /// <summary>Gets the exact one-based source line number.</summary>
+        public int LineNumber { get; private set; }
+
+        /// <summary>Gets the bounded matching source line text.</summary>
+        public string Text { get; private set; }
+
+        /// <summary>Gets the formatted line number and matching text.</summary>
+        public string DisplayText => string.Format("{0}: {1}", LineNumber, Text);
+    }
+}

--- a/Phoenix_Translator/Application/PreviewContextInspectorViewModel.cs
+++ b/Phoenix_Translator/Application/PreviewContextInspectorViewModel.cs
@@ -1,0 +1,440 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>
+    /// Loads and presents bounded technical context beside the selected workspace entry.
+    /// </summary>
+    internal sealed class PreviewContextInspectorViewModel : INotifyPropertyChanged, IDisposable
+    {
+        private const int MaximumSearchResults = 200;
+        private readonly Func<PreviewTranslationEntry, CancellationToken, PreviewEntryContext> _loadContext;
+        private readonly Func<string, PreviewTranslationEntry> _findEntry;
+        private readonly Action<PreviewTranslationEntry> _navigateToEntry;
+        private CancellationTokenSource _loadCancellation;
+        private CancellationTokenSource _searchCancellation;
+        private PreviewTranslationEntry _selectedEntry;
+        private PreviewEntryContext _context;
+        private PreviewContextState _state;
+        private string _stateText;
+        private string _codeSearchText;
+        private IReadOnlyList<PreviewCodeSearchResult> _codeResults;
+        private PreviewCodeSearchResult _selectedCodeResult;
+        private PreviewContextRelation _selectedRelation;
+        private PreviewNpcContext _selectedNpc;
+
+        /// <summary>
+        /// Creates an inspector over the project context and stable workspace navigation boundaries.
+        /// </summary>
+        /// <param name="loadContext">Loads context from the active parser project.</param>
+        /// <param name="findEntry">Finds a normalized entry by stable project-local key.</param>
+        /// <param name="navigateToEntry">Reveals an exact normalized entry in the workspace.</param>
+        internal PreviewContextInspectorViewModel(
+            Func<PreviewTranslationEntry, CancellationToken, PreviewEntryContext> loadContext,
+            Func<string, PreviewTranslationEntry> findEntry,
+            Action<PreviewTranslationEntry> navigateToEntry)
+        {
+            _loadContext = loadContext ?? throw new ArgumentNullException(nameof(loadContext));
+            _findEntry = findEntry ?? throw new ArgumentNullException(nameof(findEntry));
+            _navigateToEntry = navigateToEntry ?? throw new ArgumentNullException(nameof(navigateToEntry));
+            _state = PreviewContextState.Empty;
+            _stateText = PreviewMessageCatalog.Get("Workspace_Inspector_Empty");
+            _codeSearchText = string.Empty;
+            _codeResults = new PreviewCodeSearchResult[0];
+
+            RetryCommand = new PreviewShellCommand(parameter => LoadSelectedEntry(), parameter => _selectedEntry != null);
+            CancelCommand = new PreviewShellCommand(parameter => Cancel(), parameter => IsLoading);
+            SearchCodeCommand = new PreviewShellCommand(
+                parameter => SearchCode(),
+                parameter => HasCode && !string.IsNullOrWhiteSpace(CodeSearchText));
+            NavigateRelationCommand = new PreviewShellCommand(
+                parameter => Navigate(SelectedRelation?.EntryKey),
+                parameter => SelectedRelation != null);
+            NavigateNpcCommand = new PreviewShellCommand(
+                parameter => Navigate(SelectedNpc?.EntryKey),
+                parameter => SelectedNpc != null);
+        }
+
+        /// <inheritdoc />
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>Gets the command that retries loading the selected entry context.</summary>
+        public ICommand RetryCommand { get; private set; }
+
+        /// <summary>Gets the command that cancels active context work.</summary>
+        public ICommand CancelCommand { get; private set; }
+
+        /// <summary>Gets the command that performs a bounded exact code search.</summary>
+        public ICommand SearchCodeCommand { get; private set; }
+
+        /// <summary>Gets the command that navigates to the selected stable relationship.</summary>
+        public ICommand NavigateRelationCommand { get; private set; }
+
+        /// <summary>Gets the command that navigates to the selected NPC-owned entry.</summary>
+        public ICommand NavigateNpcCommand { get; private set; }
+
+        /// <summary>Gets the current context loading state.</summary>
+        public PreviewContextState State
+        {
+            get => _state;
+            private set
+            {
+                if (SetField(ref _state, value))
+                {
+                    OnPropertyChanged(nameof(IsLoading));
+                    OnPropertyChanged(nameof(IsReady));
+                    OnPropertyChanged(nameof(IsEmpty));
+                    OnPropertyChanged(nameof(IsFailed));
+                    RaiseCommands();
+                }
+            }
+        }
+
+        /// <summary>Gets the localized loading, empty, ready, or failure message.</summary>
+        public string StateText
+        {
+            get => _stateText;
+            private set => SetField(ref _stateText, value ?? string.Empty);
+        }
+
+        /// <summary>Gets the current immutable context snapshot.</summary>
+        public PreviewEntryContext Context
+        {
+            get => _context;
+            private set
+            {
+                if (SetField(ref _context, value))
+                {
+                    OnPropertyChanged(nameof(HasCode));
+                    OnPropertyChanged(nameof(IsCodeEmpty));
+                    OnPropertyChanged(nameof(HasMetadata));
+                    OnPropertyChanged(nameof(IsMetadataEmpty));
+                    OnPropertyChanged(nameof(HasRelations));
+                    OnPropertyChanged(nameof(IsRelationsEmpty));
+                    OnPropertyChanged(nameof(HasNpcs));
+                    OnPropertyChanged(nameof(IsNpcsEmpty));
+                    OnPropertyChanged(nameof(HasAsset));
+                    OnPropertyChanged(nameof(IsAssetEmpty));
+                    RaiseCommands();
+                }
+            }
+        }
+
+        /// <summary>Gets or sets the exact case-insensitive code-search query.</summary>
+        public string CodeSearchText
+        {
+            get => _codeSearchText;
+            set
+            {
+                if (SetField(ref _codeSearchText, value ?? string.Empty))
+                {
+                    RaiseCommands();
+                }
+            }
+        }
+
+        /// <summary>Gets the bounded code-search results.</summary>
+        public IReadOnlyList<PreviewCodeSearchResult> CodeResults
+        {
+            get => _codeResults;
+            private set
+            {
+                if (SetField(ref _codeResults, value ?? new PreviewCodeSearchResult[0]))
+                {
+                    OnPropertyChanged(nameof(CodeResultText));
+                }
+            }
+        }
+
+        /// <summary>Gets the localized code-search result count.</summary>
+        public string CodeResultText => PreviewMessageCatalog.Format(
+            "Workspace_Inspector_Code_ResultCount",
+            CodeResults.Count);
+
+        /// <summary>Gets or sets the code result selected for exact line navigation.</summary>
+        public PreviewCodeSearchResult SelectedCodeResult
+        {
+            get => _selectedCodeResult;
+            set => SetField(ref _selectedCodeResult, value);
+        }
+
+        /// <summary>Gets or sets the related entry selected for workspace navigation.</summary>
+        public PreviewContextRelation SelectedRelation
+        {
+            get => _selectedRelation;
+            set
+            {
+                if (SetField(ref _selectedRelation, value))
+                {
+                    RaiseCommands();
+                }
+            }
+        }
+
+        /// <summary>Gets or sets the NPC owner selected for workspace navigation.</summary>
+        public PreviewNpcContext SelectedNpc
+        {
+            get => _selectedNpc;
+            set
+            {
+                if (SetField(ref _selectedNpc, value))
+                {
+                    RaiseCommands();
+                }
+            }
+        }
+
+        /// <summary>Gets whether context work is active.</summary>
+        public bool IsLoading => State == PreviewContextState.Loading;
+
+        /// <summary>Gets whether supported context loaded successfully.</summary>
+        public bool IsReady => State == PreviewContextState.Ready;
+
+        /// <summary>Gets whether no supported context exists for the selection.</summary>
+        public bool IsEmpty => State == PreviewContextState.Empty;
+
+        /// <summary>Gets whether parser or asset context loading failed.</summary>
+        public bool IsFailed => State == PreviewContextState.Failed;
+
+        /// <summary>Gets whether decompiled PEX code is available.</summary>
+        public bool HasCode => !string.IsNullOrWhiteSpace(Context?.Code);
+
+        /// <summary>Gets whether the selected entry has no decompiled code.</summary>
+        public bool IsCodeEmpty => !HasCode;
+
+        /// <summary>Gets whether parser-owned record metadata is available.</summary>
+        public bool HasMetadata => Context?.Metadata.Count > 0;
+
+        /// <summary>Gets whether the selected entry has no parser-owned record metadata.</summary>
+        public bool IsMetadataEmpty => !HasMetadata;
+
+        /// <summary>Gets whether stable related entries are available.</summary>
+        public bool HasRelations => Context?.Relations.Count > 0;
+
+        /// <summary>Gets whether the selected entry has no stable relationships.</summary>
+        public bool IsRelationsEmpty => !HasRelations;
+
+        /// <summary>Gets whether NPC ownership context is available.</summary>
+        public bool HasNpcs => Context?.Npcs.Count > 0;
+
+        /// <summary>Gets whether the selected entry has no NPC ownership context.</summary>
+        public bool IsNpcsEmpty => !HasNpcs;
+
+        /// <summary>Gets whether a validated bounded visual asset is available.</summary>
+        public bool HasAsset => Context?.Asset != null;
+
+        /// <summary>Gets whether the selected entry has no validated visual asset.</summary>
+        public bool IsAssetEmpty => !HasAsset;
+
+        /// <summary>
+        /// Updates the selected stable entry and asynchronously loads its bounded context.
+        /// </summary>
+        /// <param name="entry">The newly selected normalized entry, or <c>null</c>.</param>
+        internal void SelectEntry(PreviewTranslationEntry entry)
+        {
+            _selectedEntry = entry;
+            LoadSelectedEntry();
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _loadCancellation?.Cancel();
+            _loadCancellation?.Dispose();
+            _searchCancellation?.Cancel();
+            _searchCancellation?.Dispose();
+        }
+
+        private async void LoadSelectedEntry()
+        {
+            _loadCancellation?.Cancel();
+            _loadCancellation?.Dispose();
+            _loadCancellation = null;
+            _searchCancellation?.Cancel();
+            CodeResults = new PreviewCodeSearchResult[0];
+            SelectedCodeResult = null;
+            SelectedRelation = null;
+            SelectedNpc = null;
+            Context = null;
+
+            PreviewTranslationEntry entry = _selectedEntry;
+            if (entry == null)
+            {
+                State = PreviewContextState.Empty;
+                StateText = PreviewMessageCatalog.Get("Workspace_Inspector_Empty");
+                return;
+            }
+
+            var cancellation = new CancellationTokenSource();
+            _loadCancellation = cancellation;
+            State = PreviewContextState.Loading;
+            StateText = PreviewMessageCatalog.Get("Workspace_Inspector_Loading");
+            try
+            {
+                PreviewEntryContext context = await Task.Run(
+                    () => _loadContext(entry, cancellation.Token),
+                    cancellation.Token);
+                cancellation.Token.ThrowIfCancellationRequested();
+                if (!ReferenceEquals(entry, _selectedEntry))
+                {
+                    return;
+                }
+
+                Context = context;
+                State = context != null && context.HasAnyContext
+                    ? PreviewContextState.Ready
+                    : PreviewContextState.Empty;
+                StateText = State == PreviewContextState.Ready
+                    ? PreviewMessageCatalog.Get("Workspace_Inspector_Ready")
+                    : PreviewMessageCatalog.Get("Workspace_Inspector_NoContext");
+                if (HasCode)
+                {
+                    CodeSearchText = entry.SourceText;
+                    SearchCode();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                if (ReferenceEquals(entry, _selectedEntry))
+                {
+                    State = PreviewContextState.Empty;
+                    StateText = PreviewMessageCatalog.Get("Workspace_Inspector_Cancelled");
+                }
+            }
+            catch (Exception)
+            {
+                if (ReferenceEquals(entry, _selectedEntry))
+                {
+                    State = PreviewContextState.Failed;
+                    StateText = PreviewMessageCatalog.Get("Workspace_Inspector_Failed");
+                }
+            }
+            finally
+            {
+                if (ReferenceEquals(_loadCancellation, cancellation))
+                {
+                    _loadCancellation = null;
+                }
+
+                cancellation.Dispose();
+                RaiseCommands();
+            }
+        }
+
+        private async void SearchCode()
+        {
+            _searchCancellation?.Cancel();
+            _searchCancellation?.Dispose();
+            var cancellation = new CancellationTokenSource();
+            _searchCancellation = cancellation;
+            string code = Context?.Code ?? string.Empty;
+            string query = CodeSearchText;
+            try
+            {
+                IReadOnlyList<PreviewCodeSearchResult> results = await Task.Run(
+                    () => FindCodeResults(code, query, cancellation.Token),
+                    cancellation.Token);
+                cancellation.Token.ThrowIfCancellationRequested();
+                CodeResults = results;
+                SelectedCodeResult = results.FirstOrDefault();
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            finally
+            {
+                if (ReferenceEquals(_searchCancellation, cancellation))
+                {
+                    _searchCancellation = null;
+                }
+
+                cancellation.Dispose();
+            }
+        }
+
+        private static IReadOnlyList<PreviewCodeSearchResult> FindCodeResults(
+            string code,
+            string query,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(code) || string.IsNullOrWhiteSpace(query))
+            {
+                return new PreviewCodeSearchResult[0];
+            }
+
+            var results = new List<PreviewCodeSearchResult>();
+            string[] lines = code.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+            for (int index = 0; index < lines.Length && results.Count < MaximumSearchResults; index++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                int match = lines[index].IndexOf(query, StringComparison.CurrentCultureIgnoreCase);
+                if (match >= 0)
+                {
+                    results.Add(new PreviewCodeSearchResult(index + 1, lines[index].Trim()));
+                }
+            }
+
+            return results;
+        }
+
+        private void Navigate(string entryKey)
+        {
+            if (string.IsNullOrWhiteSpace(entryKey))
+            {
+                return;
+            }
+
+            PreviewTranslationEntry entry = _findEntry(entryKey);
+            if (entry != null)
+            {
+                _navigateToEntry(entry);
+            }
+        }
+
+        private void Cancel()
+        {
+            _loadCancellation?.Cancel();
+            _searchCancellation?.Cancel();
+        }
+
+        private void RaiseCommands()
+        {
+            foreach (ICommand command in new[]
+            {
+                RetryCommand,
+                CancelCommand,
+                SearchCodeCommand,
+                NavigateRelationCommand,
+                NavigateNpcCommand
+            })
+            {
+                var previewCommand = command as PreviewShellCommand;
+                previewCommand?.RaiseCanExecuteChanged();
+            }
+        }
+
+        private bool SetField<T>(ref T field, T value, [CallerMemberName] string propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+            {
+                return false;
+            }
+
+            field = value;
+            OnPropertyChanged(propertyName);
+            return true;
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/Phoenix_Translator/Application/PreviewTranslationProject.cs
+++ b/Phoenix_Translator/Application/PreviewTranslationProject.cs
@@ -8,6 +8,7 @@ using PhoenixEngine.Memory;
 using PhoenixEngine.Translate;
 using PhoenixEngine.Unit;
 using PhoenixTranslator.SkyrimManagement;
+using static PexInterface.PexHeuristicAnalysis;
 
 namespace PhoenixTranslator.ApplicationLayer
 {
@@ -18,7 +19,10 @@ namespace PhoenixTranslator.ApplicationLayer
     {
         private const long MaximumProjectBytes = 512L * 1024L * 1024L;
         private const int MaximumEntryCount = 500000;
+        private const int MaximumContextRelations = 200;
+        private const int MaximumCodeCharacters = 2 * 1024 * 1024;
         private readonly ModFile _modFile;
+        private readonly object _contextSync = new object();
         private bool _disposed;
 
         private PreviewTranslationProject(string path, ModFile modFile, IReadOnlyList<PreviewTranslationEntry> entries)
@@ -135,6 +139,61 @@ namespace PhoenixTranslator.ApplicationLayer
         }
 
         /// <summary>
+        /// Loads bounded parser-owned context for one stable normalized entry.
+        /// </summary>
+        /// <param name="entry">The selected project entry.</param>
+        /// <param name="cancellationToken">Cancels relationship and asset work cooperatively.</param>
+        /// <returns>The supported context snapshot, which may be empty.</returns>
+        public PreviewEntryContext LoadContext(
+            PreviewTranslationEntry entry,
+            CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+            if (entry == null)
+            {
+                throw new ArgumentNullException(nameof(entry));
+            }
+
+            lock (_contextSync)
+            {
+                ThrowIfDisposed();
+                cancellationToken.ThrowIfCancellationRequested();
+                return LoadContextCore(entry, cancellationToken);
+            }
+        }
+
+        private PreviewEntryContext LoadContextCore(
+            PreviewTranslationEntry entry,
+            CancellationToken cancellationToken)
+        {
+            var metadata = new List<PreviewContextMetadata>();
+            var relations = new List<PreviewContextRelation>();
+            var npcs = new List<PreviewNpcContext>();
+            string code = string.Empty;
+            string codeSource = string.Empty;
+
+            AddCommonMetadata(entry, metadata);
+            AddExactSourceRelations(entry, relations, cancellationToken);
+            if (_modFile.Type == GameFileType.PEX)
+            {
+                LoadPexContext(entry, metadata, ref code, ref codeSource);
+            }
+            else if (_modFile.Type == GameFileType.ESP)
+            {
+                LoadEspContext(entry, metadata, relations, npcs, cancellationToken);
+            }
+
+            PreviewAssetContext asset = PreviewAssetContextLoader.Load(Path, entry.SourceText, cancellationToken);
+            return new PreviewEntryContext(
+                code,
+                codeSource,
+                metadata,
+                relations.Take(MaximumContextRelations).ToList(),
+                npcs,
+                asset);
+        }
+
+        /// <summary>
         /// Persists all staged entry targets using the existing format writer and backup boundary.
         /// </summary>
         public void Save()
@@ -232,13 +291,16 @@ namespace PhoenixTranslator.ApplicationLayer
         /// <inheritdoc />
         public void Dispose()
         {
-            if (_disposed)
+            lock (_contextSync)
             {
-                return;
-            }
+                if (_disposed)
+                {
+                    return;
+                }
 
-            _disposed = true;
-            _modFile.Close();
+                _disposed = true;
+                _modFile.Close();
+            }
         }
 
         private static List<PreviewTranslationEntry> CreateEntries(ModFile modFile)
@@ -275,6 +337,184 @@ namespace PhoenixTranslator.ApplicationLayer
                 default:
                     throw new InvalidDataException("The selected project format is unsupported.");
             }
+        }
+
+        private static void AddCommonMetadata(
+            PreviewTranslationEntry entry,
+            ICollection<PreviewContextMetadata> metadata)
+        {
+            metadata.Add(new PreviewContextMetadata("Record", entry.Record, "Phoenix Translator"));
+            metadata.Add(new PreviewContextMetadata("Type", entry.Type, "Phoenix Translator"));
+            metadata.Add(new PreviewContextMetadata("Stable key", entry.Key, "Phoenix Translator"));
+            metadata.Add(new PreviewContextMetadata("Confidence", entry.Score.ToString("0.##"), "Phoenix Translator"));
+        }
+
+        private void AddExactSourceRelations(
+            PreviewTranslationEntry selectedEntry,
+            ICollection<PreviewContextRelation> relations,
+            CancellationToken cancellationToken)
+        {
+            foreach (PreviewTranslationEntry entry in Entries)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (relations.Count >= MaximumContextRelations)
+                {
+                    return;
+                }
+
+                if (!ReferenceEquals(entry, selectedEntry) &&
+                    string.Equals(entry.SourceText, selectedEntry.SourceText, StringComparison.Ordinal))
+                {
+                    relations.Add(CreateRelation(entry, "Exact source match", "Phoenix Translator"));
+                }
+            }
+        }
+
+        private void LoadPexContext(
+            PreviewTranslationEntry entry,
+            ICollection<PreviewContextMetadata> metadata,
+            ref string code,
+            ref string codeSource)
+        {
+            PexStringItem item;
+            if (!_modFile.PexReader.Records.TryGetValue(entry.Key, out item))
+            {
+                return;
+            }
+
+            metadata.Add(new PreviewContextMetadata(
+                "String table ID",
+                item.StringTableID.ToString(),
+                "PexInterface"));
+            if (item.FunctionRef != null)
+            {
+                metadata.Add(new PreviewContextMetadata(
+                    "Function",
+                    item.FunctionRef.FunctionName,
+                    "PexInterface"));
+            }
+
+            string decompiledCode = _modFile.PexReader.PSCCode ?? string.Empty;
+            code = decompiledCode.Length <= MaximumCodeCharacters
+                ? decompiledCode
+                : decompiledCode.Substring(0, MaximumCodeCharacters);
+            codeSource = "PexInterface";
+        }
+
+        private void LoadEspContext(
+            PreviewTranslationEntry entry,
+            ICollection<PreviewContextMetadata> metadata,
+            ICollection<PreviewContextRelation> relations,
+            ICollection<PreviewNpcContext> npcs,
+            CancellationToken cancellationToken)
+        {
+            RecordItem record;
+            if (!_modFile.EspReader.Records.TryGetValue(entry.Key, out record))
+            {
+                return;
+            }
+
+            metadata.Add(new PreviewContextMetadata("Form ID", record.FormID, "EspReader"));
+            metadata.Add(new PreviewContextMetadata("Editor ID", record.EditorID, "EspReader"));
+            metadata.Add(new PreviewContextMetadata("Record signature", record.ParentSig, "EspReader"));
+            metadata.Add(new PreviewContextMetadata("Field signature", record.ChildSig, "EspReader"));
+            metadata.Add(new PreviewContextMetadata(
+                "Occurrence",
+                record.OccurrenceIndex.ToString(),
+                "EspReader"));
+
+            List<Character> characters;
+            if (_modFile.EspReader.GameCharacters.TryGetValue(entry.Key, out characters))
+            {
+                foreach (Character character in characters.Take(50))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    npcs.Add(new PreviewNpcContext(
+                        entry.Key,
+                        character.Name,
+                        character.Gender.ToString(),
+                        character.VoiceType));
+                }
+            }
+
+            if (record.ParentSig == "INFO" || record.ParentSig == "DIAL")
+            {
+                ManagedDialContext dialogue = _modFile.EspReader.GetDialContext(record);
+                if (dialogue != null)
+                {
+                    var nodes = new List<ManagedDialNode>();
+                    if (dialogue.Head != null)
+                    {
+                        nodes.Add(dialogue.Head);
+                    }
+
+                    nodes.AddRange(dialogue.Links ?? new List<ManagedDialNode>());
+                    foreach (ManagedDialNode node in nodes)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        RecordItem related = _modFile.EspReader.GetRecordItemByOffsets(
+                            false,
+                            node.RecordOffset,
+                            node.SubOffset);
+                        AddEspRelation(relations, related, "Dialogue", node.EmotionType);
+                    }
+                }
+            }
+            else if (record.ParentSig == "BOOK")
+            {
+                EspReader.BookInFoItem book = _modFile.EspReader.GetBookInFo(record);
+                if (book != null)
+                {
+                    AddEspRelation(
+                        relations,
+                        _modFile.EspReader.GetRecordItemByOffsets(false, book.RecordOffset, book.TittleSubOffset),
+                        "Book title",
+                        999);
+                    AddEspRelation(
+                        relations,
+                        _modFile.EspReader.GetRecordItemByOffsets(false, book.RecordOffset, book.ContentSubOffset),
+                        "Book content",
+                        999);
+                }
+            }
+        }
+
+        private void AddEspRelation(
+            ICollection<PreviewContextRelation> relations,
+            RecordItem record,
+            string relationship,
+            uint emotionType)
+        {
+            if (record == null || relations.Count >= MaximumContextRelations ||
+                relations.Any(relation => relation.EntryKey == record.UniqueKey &&
+                    relation.Relationship == relationship))
+            {
+                return;
+            }
+
+            PreviewTranslationEntry entry = Entries.FirstOrDefault(candidate => candidate.Key == record.UniqueKey);
+            string detail = emotionType == 999
+                ? record.ParentSig + " / " + record.ChildSig
+                : EmotionTypeHelper.FromRaw(emotionType) + " · " + record.ParentSig + " / " + record.ChildSig;
+            relations.Add(new PreviewContextRelation(
+                record.UniqueKey,
+                entry == null ? record.String : entry.SourceText,
+                detail,
+                "EspReader",
+                relationship));
+        }
+
+        private static PreviewContextRelation CreateRelation(
+            PreviewTranslationEntry entry,
+            string relationship,
+            string source)
+        {
+            return new PreviewContextRelation(
+                entry.Key,
+                entry.SourceText,
+                entry.Record,
+                source,
+                relationship);
         }
 
         private static PreviewTranslationEntry CreateEntry(

--- a/Phoenix_Translator/Application/PreviewTranslationWorkspaceViewModel.cs
+++ b/Phoenix_Translator/Application/PreviewTranslationWorkspaceViewModel.cs
@@ -140,6 +140,11 @@ namespace PhoenixTranslator.ApplicationLayer
                 convertToTraditional,
                 copyText,
                 OnToolsBusyChanged);
+            Inspectors = new PreviewContextInspectorViewModel(
+                LoadEntryContext,
+                key => _allEntries.FirstOrDefault(entry =>
+                    string.Equals(entry.Key, key, StringComparison.Ordinal)),
+                RevealEntry);
 
             OpenProjectCommand = new PreviewShellCommand(
                 parameter => OpenSelectedProject(),
@@ -204,6 +209,11 @@ namespace PhoenixTranslator.ApplicationLayer
         public PreviewWorkspaceToolsViewModel Tools { get; private set; }
 
         /// <summary>
+        /// Gets the docked code, record, NPC, relationship, and asset inspectors.
+        /// </summary>
+        public PreviewContextInspectorViewModel Inspectors { get; private set; }
+
+        /// <summary>
         /// Gets the command that selects and opens a supported project.
         /// </summary>
         public ICommand OpenProjectCommand { get; private set; }
@@ -260,6 +270,7 @@ namespace PhoenixTranslator.ApplicationLayer
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(HasSelection));
                 Tools?.RefreshPreview();
+                Inspectors?.SelectEntry(value);
                 RaiseCommandAvailability();
             }
         }
@@ -415,8 +426,12 @@ namespace PhoenixTranslator.ApplicationLayer
             {
                 IPreviewTranslationProject openedProject = await Task.Run(() => _openProject(path));
                 IPreviewTranslationProject previousProject = _project;
+                Inspectors.SelectEntry(null);
                 _project = openedProject;
-                previousProject?.Dispose();
+                if (previousProject != null)
+                {
+                    await Task.Run(() => previousProject.Dispose());
+                }
                 ReplaceEntries(openedProject.Entries);
                 _shell.SetProject(openedProject.DisplayName, false);
                 CompleteOperation();
@@ -446,8 +461,9 @@ namespace PhoenixTranslator.ApplicationLayer
                 await Task.Run(() => _project.Save());
                 IPreviewTranslationProject reloadedProject = await Task.Run(() => _openProject(projectPath));
                 IPreviewTranslationProject savedProject = _project;
+                Inspectors.SelectEntry(null);
                 _project = reloadedProject;
-                savedProject.Dispose();
+                await Task.Run(() => savedProject.Dispose());
                 ReplaceEntries(reloadedProject.Entries);
 
                 _shell.SetProject(_project.DisplayName, false);
@@ -582,8 +598,28 @@ namespace PhoenixTranslator.ApplicationLayer
         {
             _operationCancellation?.Cancel();
             _operationCancellation?.Dispose();
+            Inspectors.Dispose();
             _project?.Dispose();
             _project = null;
+        }
+
+        private PreviewEntryContext LoadEntryContext(
+            PreviewTranslationEntry entry,
+            CancellationToken cancellationToken)
+        {
+            IPreviewTranslationProject project = _project;
+            if (project == null)
+            {
+                return new PreviewEntryContext(
+                    string.Empty,
+                    string.Empty,
+                    new PreviewContextMetadata[0],
+                    new PreviewContextRelation[0],
+                    new PreviewNpcContext[0],
+                    null);
+            }
+
+            return project.LoadContext(entry, cancellationToken);
         }
 
         private static PreviewTranslationStateFilterOption CreateStateFilter(

--- a/Phoenix_Translator/PhoenixTranslator.csproj
+++ b/Phoenix_Translator/PhoenixTranslator.csproj
@@ -109,6 +109,9 @@
     <Compile Include="Application\AdvancedDictionaryQueryBuilder.cs" />
     <Compile Include="Application\IPreviewTranslationProject.cs" />
     <Compile Include="Application\PreviewMessageCatalog.cs" />
+    <Compile Include="Application\PreviewContextInspectorModels.cs" />
+    <Compile Include="Application\PreviewAssetContextLoader.cs" />
+    <Compile Include="Application\PreviewContextInspectorViewModel.cs" />
     <Compile Include="Application\PreviewQualityAnalyzer.cs" />
     <Compile Include="Application\PreviewQualityFinding.cs" />
     <Compile Include="Application\PreviewProjectComparison.cs" />

--- a/Phoenix_Translator/Properties/AssemblyInfo.cs
+++ b/Phoenix_Translator/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Windows;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.0.0.14")]
-[assembly: AssemblyFileVersion("2.0.0.14")]
+[assembly: AssemblyVersion("2.0.0.15")]
+[assembly: AssemblyFileVersion("2.0.0.15")]

--- a/Phoenix_Translator/Properties/Resources.resx
+++ b/Phoenix_Translator/Properties/Resources.resx
@@ -212,6 +212,30 @@
   <data name="Workspace_Operation_CompletedWithFailures" xml:space="preserve"><value>Translation completed with {0} failed entries.</value><comment>Batch completion summary. Placeholders: {0}=non-negative integer failure count.</comment></data>
   <data name="Workspace_Save_Failed" xml:space="preserve"><value>The project could not be saved. Your changes are still available.</value><comment>Safe save-failure message that confirms recoverable user input.</comment></data>
   <data name="Workspace_Tools_Title" xml:space="preserve"><value>Tools</value><comment>Workspace inspector tab for editing and delivery tools.</comment></data>
+  <data name="Workspace_Inspector_Title" xml:space="preserve"><value>Inspectors</value><comment>Workspace tab for docked technical context.</comment></data>
+  <data name="Workspace_Inspector_Code_Tab" xml:space="preserve"><value>Code</value><comment>Inspector tab for decompiled PEX code.</comment></data>
+  <data name="Workspace_Inspector_Record_Tab" xml:space="preserve"><value>Record</value><comment>Inspector tab for parser-owned record metadata.</comment></data>
+  <data name="Workspace_Inspector_Related_Tab" xml:space="preserve"><value>Related</value><comment>Inspector tab for stable record relationships.</comment></data>
+  <data name="Workspace_Inspector_Npc_Tab" xml:space="preserve"><value>NPC</value><comment>Inspector tab for NPC dialogue ownership.</comment></data>
+  <data name="Workspace_Inspector_Asset_Tab" xml:space="preserve"><value>Asset</value><comment>Inspector tab for bounded visual assets.</comment></data>
+  <data name="Workspace_Inspector_Empty" xml:space="preserve"><value>Select an entry to inspect its technical context.</value><comment>Inspector state without a selected entry.</comment></data>
+  <data name="Workspace_Inspector_Loading" xml:space="preserve"><value>Loading bounded context…</value><comment>Inspector state while parser context loads.</comment></data>
+  <data name="Workspace_Inspector_Ready" xml:space="preserve"><value>Context follows the selected stable entry.</value><comment>Inspector state after supported context loads.</comment></data>
+  <data name="Workspace_Inspector_NoContext" xml:space="preserve"><value>No supported context is available for this entry.</value><comment>Inspector empty state distinguished from a loading failure.</comment></data>
+  <data name="Workspace_Inspector_Failed" xml:space="preserve"><value>Context could not be loaded. Project content was not changed.</value><comment>Inspector parser or asset failure state.</comment></data>
+  <data name="Workspace_Inspector_Cancelled" xml:space="preserve"><value>Context loading was cancelled.</value><comment>Inspector cancellation state.</comment></data>
+  <data name="Workspace_Inspector_Retry_Action" xml:space="preserve"><value>Retry</value><comment>Retries bounded context loading for the selected entry.</comment></data>
+  <data name="Workspace_Inspector_Code_Search" xml:space="preserve"><value>Search decompiled code</value><comment>Code inspector search field hint.</comment></data>
+  <data name="Workspace_Inspector_Code_Search_Action" xml:space="preserve"><value>Search</value><comment>Starts bounded exact code search.</comment></data>
+  <data name="Workspace_Inspector_Code_ResultCount" xml:space="preserve"><value>{0} code matches</value><comment>Bounded code result count. Placeholder: {0}=match count.</comment></data>
+  <data name="Workspace_Inspector_Code_Results_Name" xml:space="preserve"><value>Code search results</value><comment>Accessible name for exact code search results.</comment></data>
+  <data name="Workspace_Inspector_Code_Editor_Name" xml:space="preserve"><value>Decompiler output</value><comment>Accessible name for the read-only decompiled code editor.</comment></data>
+  <data name="Workspace_Inspector_Navigate_Action" xml:space="preserve"><value>Go to entry</value><comment>Navigates to the selected stable related entry.</comment></data>
+  <data name="Workspace_Inspector_Code_Empty" xml:space="preserve"><value>No decompiled code is available for this entry.</value><comment>Empty state within the code inspector tab.</comment></data>
+  <data name="Workspace_Inspector_Record_Empty" xml:space="preserve"><value>No parser-owned record metadata is available.</value><comment>Empty state within the record inspector tab.</comment></data>
+  <data name="Workspace_Inspector_Related_Empty" xml:space="preserve"><value>No related translation entries were found.</value><comment>Empty state within the relationship inspector tab.</comment></data>
+  <data name="Workspace_Inspector_Npc_Empty" xml:space="preserve"><value>No NPC ownership context is available.</value><comment>Empty state within the NPC inspector tab.</comment></data>
+  <data name="Workspace_Inspector_Asset_Empty" xml:space="preserve"><value>No supported visual asset is referenced by this entry.</value><comment>Empty state within the asset inspector tab.</comment></data>
   <data name="Workspace_Tools_Edit_Tab" xml:space="preserve"><value>Edit</value><comment>Workspace tool category for scoped text changes.</comment></data>
   <data name="Workspace_Tools_Terms_Tab" xml:space="preserve"><value>Terms</value><comment>Workspace tool category for project terminology.</comment></data>
   <data name="Workspace_Tools_Deliver_Tab" xml:space="preserve"><value>Deliver</value><comment>Workspace tool category for tables and project export.</comment></data>

--- a/Phoenix_Translator/UIManagement/Preview/PreviewTranslationWorkspaceView.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewTranslationWorkspaceView.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:localization="clr-namespace:PhoenixTranslator.UIManagement.Localization"
+             xmlns:preview="clr-namespace:PhoenixTranslator.UIManagement.Preview"
              AutomationProperties.Name="{localization:PreviewMessage Workspace_Title}">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -9,6 +10,7 @@
                 <ResourceDictionary Source="/Themes/PreviewControlStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibility" />
+            <preview:PreviewAssetImageConverter x:Key="PreviewAssetImageConverter" />
             <Style x:Key="WorkspaceEntryItem" TargetType="ListBoxItem">
             <Setter Property="Padding" Value="12,8" />
             <Setter Property="Margin" Value="4,2" />
@@ -246,6 +248,159 @@
                                            Text="{localization:PreviewMessage Workspace_Context_Score_Label}" />
                                 <TextBlock Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{Binding SelectedEntry.Score}" />
                             </StackPanel>
+                        </TabItem>
+                        <TabItem Style="{StaticResource WorkspaceToolTab}" Header="{localization:PreviewMessage Workspace_Inspector_Title}">
+                            <Grid DataContext="{Binding Inspectors}">
+                                <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="*" /></Grid.RowDefinitions>
+                                <Grid>
+                                    <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                    <TextBlock VerticalAlignment="Center" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                               TextWrapping="Wrap" Text="{Binding StateText}" />
+                                    <WrapPanel Grid.Column="1" Margin="6,0,0,0">
+                                        <Button Style="{StaticResource PreviewButtonSecondary}" Command="{Binding RetryCommand}"
+                                                Content="{localization:PreviewMessage Workspace_Inspector_Retry_Action}" />
+                                        <Button Margin="5,0,0,0" Style="{StaticResource PreviewButtonDanger}" Command="{Binding CancelCommand}"
+                                                Content="{localization:PreviewMessage Workspace_Cancel_Action}" />
+                                    </WrapPanel>
+                                </Grid>
+                                <TabControl Grid.Row="1" Margin="0,8,0,0" Style="{StaticResource WorkspaceToolTabControl}">
+                                    <TabItem Style="{StaticResource WorkspaceToolTab}" Header="{localization:PreviewMessage Workspace_Inspector_Code_Tab}">
+                                        <Grid>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto" /><RowDefinition Height="Auto" />
+                                                <RowDefinition Height="90" /><RowDefinition Height="*" />
+                                            </Grid.RowDefinitions>
+                                            <Grid>
+                                                <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                                                <TextBox x:Name="CodeSearchBox" Style="{StaticResource PreviewTextBox}"
+                                                         Text="{Binding CodeSearchText, UpdateSourceTrigger=PropertyChanged}"
+                                                         ToolTip="{localization:PreviewMessage Workspace_Inspector_Code_Search}" />
+                                                <Button Grid.Column="1" Margin="5,0,0,0" Style="{StaticResource PreviewButtonSecondary}"
+                                                        Command="{Binding SearchCodeCommand}"
+                                                        Content="{localization:PreviewMessage Workspace_Inspector_Code_Search_Action}" />
+                                            </Grid>
+                                            <TextBlock Grid.Row="1" Margin="0,5" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                                       Text="{Binding CodeResultText}" />
+                                            <ListBox Grid.Row="2" ItemsSource="{Binding CodeResults}" SelectedItem="{Binding SelectedCodeResult}"
+                                                     SelectionChanged="CodeResultSelectionChanged" Background="Transparent"
+                                                     BorderBrush="{StaticResource PreviewBrushBorder}" BorderThickness="1"
+                                                     AutomationProperties.Name="{localization:PreviewMessage Workspace_Inspector_Code_Results_Name}">
+                                                <ListBox.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <TextBlock Margin="5,3" FontFamily="Consolas" FontSize="11"
+                                                                   Foreground="{StaticResource PreviewBrushTextSecondary}"
+                                                                   Text="{Binding DisplayText}" TextTrimming="CharacterEllipsis" />
+                                                    </DataTemplate>
+                                                </ListBox.ItemTemplate>
+                                            </ListBox>
+                                            <TextBox x:Name="CodeTextBox" Grid.Row="3" Margin="0,8,0,0" Padding="8"
+                                                     IsReadOnly="True" AcceptsReturn="True" AcceptsTab="True" TextWrapping="NoWrap"
+                                                     HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"
+                                                     FontFamily="Consolas" FontSize="11" Style="{StaticResource PreviewTextBox}"
+                                                     Text="{Binding Context.Code, Mode=OneWay}"
+                                                     AutomationProperties.Name="{localization:PreviewMessage Workspace_Inspector_Code_Editor_Name}" />
+                                            <TextBlock Grid.RowSpan="4" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                       Margin="12" TextAlignment="Center" TextWrapping="Wrap"
+                                                       Foreground="{StaticResource PreviewBrushTextMuted}"
+                                                       Visibility="{Binding IsCodeEmpty, Converter={StaticResource BooleanToVisibility}}"
+                                                       Text="{localization:PreviewMessage Workspace_Inspector_Code_Empty}" />
+                                        </Grid>
+                                    </TabItem>
+                                    <TabItem Style="{StaticResource WorkspaceToolTab}" Header="{localization:PreviewMessage Workspace_Inspector_Record_Tab}">
+                                        <Grid>
+                                            <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                                                <ItemsControl ItemsSource="{Binding Context.Metadata}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Border Margin="0,0,4,7" Padding="8" Background="{StaticResource PreviewBrushSurfaceInteractive}"
+                                                                BorderBrush="{StaticResource PreviewBrushBorder}" BorderThickness="1" CornerRadius="4">
+                                                            <StackPanel>
+                                                                <TextBlock FontSize="11" Foreground="{StaticResource PreviewBrushTextMuted}" Text="{Binding Label}" />
+                                                                <TextBlock Margin="0,3,0,0" Foreground="{StaticResource PreviewBrushTextPrimary}" TextWrapping="Wrap" Text="{Binding Value}" />
+                                                                <TextBlock Margin="0,3,0,0" FontSize="10" Foreground="{StaticResource PreviewBrushAccentBlue}" Text="{Binding Source}" />
+                                                            </StackPanel>
+                                                        </Border>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
+                                            </ScrollViewer>
+                                            <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Margin="12"
+                                                       TextAlignment="Center" TextWrapping="Wrap"
+                                                       Foreground="{StaticResource PreviewBrushTextMuted}"
+                                                       Visibility="{Binding IsMetadataEmpty, Converter={StaticResource BooleanToVisibility}}"
+                                                       Text="{localization:PreviewMessage Workspace_Inspector_Record_Empty}" />
+                                        </Grid>
+                                    </TabItem>
+                                    <TabItem Style="{StaticResource WorkspaceToolTab}" Header="{localization:PreviewMessage Workspace_Inspector_Related_Tab}">
+                                        <Grid>
+                                            <Grid.RowDefinitions><RowDefinition Height="*" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
+                                            <ListBox ItemsSource="{Binding Context.Relations}" SelectedItem="{Binding SelectedRelation}"
+                                                     Background="Transparent" BorderBrush="{StaticResource PreviewBrushBorder}" BorderThickness="1">
+                                                <ListBox.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <StackPanel Margin="7,5">
+                                                            <TextBlock Foreground="{StaticResource PreviewBrushTextPrimary}" TextWrapping="Wrap" Text="{Binding Title}" />
+                                                            <TextBlock Margin="0,3,0,0" FontSize="10" Foreground="{StaticResource PreviewBrushWarning}" Text="{Binding Relationship}" />
+                                                            <TextBlock Margin="0,2,0,0" FontSize="10" Foreground="{StaticResource PreviewBrushTextMuted}" Text="{Binding Detail}" />
+                                                            <TextBlock Margin="0,2,0,0" FontSize="10" Foreground="{StaticResource PreviewBrushAccentBlue}" Text="{Binding Source}" />
+                                                        </StackPanel>
+                                                    </DataTemplate>
+                                                </ListBox.ItemTemplate>
+                                            </ListBox>
+                                            <Button Grid.Row="1" Margin="0,8,0,0" HorizontalAlignment="Left"
+                                                    Style="{StaticResource PreviewButtonPrimary}" Command="{Binding NavigateRelationCommand}"
+                                                    Content="{localization:PreviewMessage Workspace_Inspector_Navigate_Action}" />
+                                            <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Margin="12"
+                                                       TextAlignment="Center" TextWrapping="Wrap"
+                                                       Foreground="{StaticResource PreviewBrushTextMuted}"
+                                                       Visibility="{Binding IsRelationsEmpty, Converter={StaticResource BooleanToVisibility}}"
+                                                       Text="{localization:PreviewMessage Workspace_Inspector_Related_Empty}" />
+                                        </Grid>
+                                    </TabItem>
+                                    <TabItem Style="{StaticResource WorkspaceToolTab}" Header="{localization:PreviewMessage Workspace_Inspector_Npc_Tab}">
+                                        <Grid>
+                                            <Grid.RowDefinitions><RowDefinition Height="*" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
+                                            <ListBox ItemsSource="{Binding Context.Npcs}" SelectedItem="{Binding SelectedNpc}"
+                                                     Background="Transparent" BorderBrush="{StaticResource PreviewBrushBorder}" BorderThickness="1">
+                                                <ListBox.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <StackPanel Margin="7,5">
+                                                            <TextBlock Foreground="{StaticResource PreviewBrushTextPrimary}" Text="{Binding Name}" />
+                                                            <TextBlock Margin="0,3,0,0" FontSize="10" Foreground="{StaticResource PreviewBrushTextMuted}" Text="{Binding Gender}" />
+                                                            <TextBlock Margin="0,2,0,0" FontSize="10" Foreground="{StaticResource PreviewBrushAccentBlue}" Text="{Binding VoiceType}" />
+                                                        </StackPanel>
+                                                    </DataTemplate>
+                                                </ListBox.ItemTemplate>
+                                            </ListBox>
+                                            <Button Grid.Row="1" Margin="0,8,0,0" HorizontalAlignment="Left"
+                                                    Style="{StaticResource PreviewButtonPrimary}" Command="{Binding NavigateNpcCommand}"
+                                                    Content="{localization:PreviewMessage Workspace_Inspector_Navigate_Action}" />
+                                            <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Margin="12"
+                                                       TextAlignment="Center" TextWrapping="Wrap"
+                                                       Foreground="{StaticResource PreviewBrushTextMuted}"
+                                                       Visibility="{Binding IsNpcsEmpty, Converter={StaticResource BooleanToVisibility}}"
+                                                       Text="{localization:PreviewMessage Workspace_Inspector_Npc_Empty}" />
+                                        </Grid>
+                                    </TabItem>
+                                    <TabItem Style="{StaticResource WorkspaceToolTab}" Header="{localization:PreviewMessage Workspace_Inspector_Asset_Tab}">
+                                        <StackPanel>
+                                            <Border Height="220" Background="{StaticResource PreviewBrushSurfaceCanvas}"
+                                                    BorderBrush="{StaticResource PreviewBrushBorder}" BorderThickness="1" CornerRadius="4">
+                                                <Image Margin="8" Stretch="Uniform"
+                                                       Source="{Binding Context.Asset, Converter={StaticResource PreviewAssetImageConverter}}" />
+                                            </Border>
+                                            <TextBlock Margin="0,8,0,0" Foreground="{StaticResource PreviewBrushTextPrimary}"
+                                                       Text="{Binding Context.Asset.DisplayName}" />
+                                            <TextBlock Margin="0,3,0,0" FontSize="11" Foreground="{StaticResource PreviewBrushTextMuted}"
+                                                       Text="{Binding Context.Asset.Dimensions}" />
+                                            <TextBlock Margin="12" TextAlignment="Center" TextWrapping="Wrap"
+                                                       Foreground="{StaticResource PreviewBrushTextMuted}"
+                                                       Visibility="{Binding IsAssetEmpty, Converter={StaticResource BooleanToVisibility}}"
+                                                       Text="{localization:PreviewMessage Workspace_Inspector_Asset_Empty}" />
+                                        </StackPanel>
+                                    </TabItem>
+                                </TabControl>
+                            </Grid>
                         </TabItem>
                         <TabItem Style="{StaticResource WorkspaceToolTab}" Header="{localization:PreviewMessage Workspace_Tools_Title}">
                             <Grid DataContext="{Binding Tools}">

--- a/Phoenix_Translator/UIManagement/Preview/PreviewTranslationWorkspaceView.xaml.cs
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewTranslationWorkspaceView.xaml.cs
@@ -1,7 +1,47 @@
+using System;
+using System.Globalization;
+using System.IO;
 using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Media.Imaging;
+using PhoenixTranslator.ApplicationLayer;
 
 namespace PhoenixTranslator.UIManagement.Preview
 {
+    /// <summary>
+    /// Decodes a validated bounded asset snapshot for WPF display without retaining its stream.
+    /// </summary>
+    public sealed class PreviewAssetImageConverter : IValueConverter
+    {
+        /// <inheritdoc />
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var asset = value as PreviewAssetContext;
+            if (asset == null || asset.Content.Length == 0)
+            {
+                return null;
+            }
+
+            using (var stream = new MemoryStream(asset.Content, false))
+            {
+                var image = new BitmapImage();
+                image.BeginInit();
+                image.CacheOption = BitmapCacheOption.OnLoad;
+                image.DecodePixelWidth = 512;
+                image.StreamSource = stream;
+                image.EndInit();
+                image.Freeze();
+                return image;
+            }
+        }
+
+        /// <inheritdoc />
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
     /// <summary>
     /// Presents the keyboard-first preview translation workspace.
     /// </summary>
@@ -21,6 +61,23 @@ namespace PhoenixTranslator.UIManagement.Preview
         internal void FocusInitialControl()
         {
             SearchBox.Focus();
+        }
+
+        private void CodeResultSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var viewModel = (DataContext as PreviewTranslationWorkspaceViewModel)?.Inspectors;
+            PreviewCodeSearchResult result = viewModel?.SelectedCodeResult;
+            if (result == null || result.LineNumber <= 0 || result.LineNumber > CodeTextBox.LineCount)
+            {
+                return;
+            }
+
+            int lineIndex = result.LineNumber - 1;
+            int start = CodeTextBox.GetCharacterIndexFromLineIndex(lineIndex);
+            int length = CodeTextBox.GetLineLength(lineIndex);
+            CodeTextBox.Select(start, length);
+            CodeTextBox.ScrollToLine(lineIndex);
+            CodeTextBox.Focus();
         }
     }
 }


### PR DESCRIPTION
## Summary

- dock code, record, relationship, NPC, and visual-asset context beside the selected translation entry
- label parser-owned data by its YD525 repository boundary and navigate relationships through stable entry keys
- cancel stale selection work, serialize parser context access, and validate bounded project-local image assets
- distinguish loading, ready, empty, cancelled, and failed states with stable English localization IDs
- bump the application version to 2.0.0.15

## Validation

- Release x64 solution build with Visual Studio 2022 MSBuild
- 42 deterministic preset and workspace tests
- visual smoke test at the 1100 × 700 DIP minimum with the synthetic mixed-review-quality XML project

## Known baseline

The build retains six existing legacy compiler warnings; this change adds no new warnings.

Closes #59
