### PR TITLE
Build the Advanced Tools workspace

### DIFF
--- a/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
+++ b/PhoenixTranslator.PresetTests/PhoenixTranslator.PresetTests.csproj
@@ -108,6 +108,12 @@
     <Compile Include="..\Phoenix_Translator\Application\PreviewShellServicesViewModel.cs">
       <Link>PreviewShellServicesViewModel.cs</Link>
     </Compile>
+    <Compile Include="..\Phoenix_Translator\Application\PreviewAdvancedToolsModel.cs">
+      <Link>PreviewAdvancedToolsModel.cs</Link>
+    </Compile>
+    <Compile Include="..\Phoenix_Translator\Application\PreviewAdvancedToolsViewModel.cs">
+      <Link>PreviewAdvancedToolsViewModel.cs</Link>
+    </Compile>
     <Compile Include="..\Phoenix_Translator\Application\PreviewShellViewModel.cs">
       <Link>PreviewShellViewModel.cs</Link>
     </Compile>

--- a/PhoenixTranslator.PresetTests/Program.cs
+++ b/PhoenixTranslator.PresetTests/Program.cs
@@ -67,7 +67,11 @@ namespace PhoenixTranslator.PresetTests
                 { nameof(SearchesSettingsByLegacyTerminology), SearchesSettingsByLegacyTerminology },
                 { nameof(ProtectsSettingsSecrets), ProtectsSettingsSecrets },
                 { nameof(TestsProviderWithoutSavingSettings), TestsProviderWithoutSavingSettings },
-                { nameof(ClearsStagedCredentialWhenProviderChanges), ClearsStagedCredentialWhenProviderChanges }
+                { nameof(ClearsStagedCredentialWhenProviderChanges), ClearsStagedCredentialWhenProviderChanges },
+                { nameof(StagesAndAppliesProviderPipeline), StagesAndAppliesProviderPipeline },
+                { nameof(ValidatesCustomProviderDrafts), ValidatesCustomProviderDrafts },
+                { nameof(CancelsCustomProviderConnectivityTest), CancelsCustomProviderConnectivityTest },
+                { nameof(GuardsReadOnlyDatabaseStatements), GuardsReadOnlyDatabaseStatements }
             };
             int failures = 0;
             foreach (KeyValuePair<string, Action> test in tests)
@@ -1480,6 +1484,67 @@ namespace PhoenixTranslator.PresetTests
             settings.Dispose();
         }
 
+        private static void StagesAndAppliesProviderPipeline()
+        {
+            var store = new RecordingAdvancedToolsStore();
+            var tools = new PreviewAdvancedToolsViewModel(store, new PreviewShellViewModel(() => { }), () => true, readOnly => { });
+            PreviewPipelineEntry second = tools.PipelineEntries[1];
+            tools.SelectedPipelineEntry = second;
+            tools.MoveUpCommand.Execute(null);
+            second.IsEnabled = true;
+
+            AssertEqual(0, store.SavePipelineCalls, "Pipeline editing must remain staged before apply.");
+            tools.ApplyPipelineCommand.Execute(null);
+            AssertEqual(1, store.SavePipelineCalls, "Applying must cross the persistence boundary exactly once.");
+            AssertEqual(2, store.SavedPipeline[0].Key, "Applying must preserve the staged provider order.");
+            AssertEqual(true, store.SavedPipeline[0].IsEnabled, "Applying must preserve staged enablement.");
+            tools.Dispose();
+        }
+
+        private static void ValidatesCustomProviderDrafts()
+        {
+            var valid = new PreviewCustomProviderDraft
+            {
+                Name = "Fixture provider",
+                Endpoint = "https://provider.invalid/v1",
+                ResponseField = "choices[0].message.content"
+            };
+            AssertEqual(null, PreviewAdvancedToolsViewModel.ValidateCustomProvider(valid),
+                "A complete HTTPS provider draft must be valid.");
+            valid.Endpoint = "http://provider.invalid/v1";
+            AssertEqual("Advanced_Custom_Validation_Endpoint", PreviewAdvancedToolsViewModel.ValidateCustomProvider(valid),
+                "Plain HTTP must be limited to local endpoints.");
+            valid.Endpoint = "http://127.0.0.1:1234/v1";
+            AssertEqual(null, PreviewAdvancedToolsViewModel.ValidateCustomProvider(valid),
+                "A loopback HTTP provider must remain supported.");
+        }
+
+        private static void CancelsCustomProviderConnectivityTest()
+        {
+            var store = new RecordingAdvancedToolsStore { BlockProviderTest = true };
+            var tools = new PreviewAdvancedToolsViewModel(store, new PreviewShellViewModel(() => { }), () => true, readOnly => { });
+            tools.CustomProvider.Name = "Fixture provider";
+            tools.CustomProvider.Endpoint = "https://provider.invalid/v1";
+            tools.CustomProvider.ResponseField = "translation";
+            tools.TestCustomProviderCommand.Execute(null);
+            AssertEqual(true, SpinWait.SpinUntil(() => tools.IsTesting, 1000), "The provider test must start asynchronously.");
+            tools.CancelCustomProviderTestCommand.Execute(null);
+            AssertEqual(true, SpinWait.SpinUntil(() => !tools.IsTesting, 1000), "Cancellation must complete the provider test.");
+            AssertEqual(PreviewMessageCatalog.Get("Advanced_Custom_Test_Cancelled"), tools.StatusText,
+                "Cancellation must expose a sanitized status.");
+            tools.Dispose();
+        }
+
+        private static void GuardsReadOnlyDatabaseStatements()
+        {
+            AssertEqual(true, PreviewDatabaseStatementGuard.IsReadOnly(" SELECT * FROM Dictionary"),
+                "A SELECT query must be allowed in read-only mode.");
+            AssertEqual(false, PreviewDatabaseStatementGuard.IsReadOnly("DELETE FROM Dictionary"),
+                "A mutation must be rejected in read-only mode.");
+            AssertEqual(false, PreviewDatabaseStatementGuard.IsReadOnly("SELECT * FROM Dictionary; DELETE FROM Dictionary"),
+                "A second statement must be rejected in read-only mode.");
+        }
+
         private static TranslationPresetCoordinator CreateCoordinator(RecordingStore store)
         {
             return new TranslationPresetCoordinator(new TranslationPresetService(), store);
@@ -1713,6 +1778,43 @@ namespace PhoenixTranslator.PresetTests
                 LastTestCredential = providerCredential;
                 return Task.FromResult(new PreviewProviderTestResult(PreviewProviderTestStatus.Succeeded));
             }
+        }
+
+        private sealed class RecordingAdvancedToolsStore : IPreviewAdvancedToolsStore
+        {
+            internal int SavePipelineCalls { get; private set; }
+            internal IReadOnlyList<PreviewPipelineEntry> SavedPipeline { get; private set; }
+            internal bool BlockProviderTest { get; set; }
+
+            public IReadOnlyList<PreviewPipelineEntry> LoadPipeline()
+            {
+                return new[]
+                {
+                    new PreviewPipelineEntry(1, "First", "Cloud AI", true, false),
+                    new PreviewPipelineEntry(2, "Second", "Local AI", false, false)
+                };
+            }
+
+            public void SavePipeline(IReadOnlyList<PreviewPipelineEntry> entries)
+            {
+                SavePipelineCalls++;
+                SavedPipeline = entries.Select(entry => entry.Clone()).ToArray();
+            }
+
+            public async Task<PreviewProviderTestResult> TestCustomProviderAsync(
+                PreviewCustomProviderDraft draft,
+                CancellationToken cancellationToken)
+            {
+                if (BlockProviderTest)
+                {
+                    await Task.Delay(Timeout.Infinite, cancellationToken);
+                }
+                return new PreviewProviderTestResult(PreviewProviderTestStatus.Succeeded);
+            }
+
+            public void SaveCustomProvider(PreviewCustomProviderDraft draft) { }
+            public IReadOnlyList<KeyValuePair<string, long>> ReadTokenUsage() { return new[] { new KeyValuePair<string, long>("Fixture", 12) }; }
+            public void ClearTokenUsage() { }
         }
     }
 }

--- a/Phoenix_Translator/Application/LegacyPreviewAdvancedToolsStore.cs
+++ b/Phoenix_Translator/Application/LegacyPreviewAdvancedToolsStore.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using PhoenixEngine;
+using PhoenixEngine.Platform;
+using PhoenixEngine.Translate;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>Adapts legacy engine configuration to the guarded Advanced Tools boundary.</summary>
+    internal sealed class LegacyPreviewAdvancedToolsStore : IPreviewAdvancedToolsStore
+    {
+        private static readonly HttpClient ProviderProbeClient = CreateProviderProbeClient();
+
+        /// <inheritdoc />
+        public IReadOnlyList<PreviewPipelineEntry> LoadPipeline()
+        {
+            if (Phoenix.Config?.PlatformConfigs == null)
+            {
+                return new List<PreviewPipelineEntry>();
+            }
+
+            return Phoenix.Config.PlatformConfigs.Select(pair => new PreviewPipelineEntry(
+                pair.Key,
+                GetName(pair.Key, pair.Value),
+                GetGroup(pair.Value),
+                pair.Value.Enable,
+                pair.Value.CustomInFo != null)).ToList();
+        }
+
+        /// <inheritdoc />
+        public void SavePipeline(IReadOnlyList<PreviewPipelineEntry> entries)
+        {
+            if (entries == null) throw new ArgumentNullException(nameof(entries));
+            Dictionary<int, PlatformConfig> current = Phoenix.Config.PlatformConfigs;
+            if (current == null || entries.Count != current.Count || entries.Any(entry => !current.ContainsKey(entry.Key)))
+            {
+                throw new InvalidOperationException("The provider pipeline changed while edits were staged.");
+            }
+
+            var ordered = new Dictionary<int, PlatformConfig>();
+            foreach (PreviewPipelineEntry entry in entries)
+            {
+                PlatformConfig config = current[entry.Key];
+                config.Enable = entry.IsEnabled;
+                ordered.Add(entry.Key, config);
+            }
+            Phoenix.Config.PlatformConfigs = ordered;
+            Phoenix.SaveConfig();
+        }
+
+        /// <inheritdoc />
+        public async Task<PreviewProviderTestResult> TestCustomProviderAsync(
+            PreviewCustomProviderDraft draft,
+            CancellationToken cancellationToken)
+        {
+            if (draft == null) throw new ArgumentNullException(nameof(draft));
+            Uri endpoint;
+            if (!Uri.TryCreate(draft.Endpoint, UriKind.Absolute, out endpoint))
+            {
+                return new PreviewProviderTestResult(PreviewProviderTestStatus.Rejected);
+            }
+            if (endpoint.Scheme == Uri.UriSchemeHttp && !IPAddress.IsLoopback(ResolveAddress(endpoint.Host)))
+            {
+                return new PreviewProviderTestResult(PreviewProviderTestStatus.Rejected);
+            }
+
+            using (var request = new HttpRequestMessage(HttpMethod.Head, endpoint))
+            using (HttpResponseMessage response = await ProviderProbeClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken).ConfigureAwait(false))
+            {
+                return response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.MethodNotAllowed
+                    ? new PreviewProviderTestResult(PreviewProviderTestStatus.Succeeded)
+                    : new PreviewProviderTestResult(PreviewProviderTestStatus.Rejected);
+            }
+        }
+
+        /// <inheritdoc />
+        public void SaveCustomProvider(PreviewCustomProviderDraft draft)
+        {
+            if (draft == null) throw new ArgumentNullException(nameof(draft));
+            int key = Phoenix.Config.PlatformConfigs.Count == 0 ? 1 : Phoenix.Config.PlatformConfigs.Keys.Max() + 1;
+            while (Phoenix.Config.PlatformConfigs.ContainsKey(key)) key++;
+            var custom = new CustomPlatformInFo
+            {
+                CustomID = key,
+                Name = draft.Name.Trim(),
+                Url = draft.Endpoint.Trim(),
+                IsPost = draft.UsePost,
+                Type = ParseGroup(draft.Group),
+                QueryRule = new ReqQueryRuleItem { ByJson = true, FieldName = draft.ResponseField.Trim() }
+            };
+            var request = new CustomReqCore();
+            request.SetUrl(custom.Url);
+            request.SetHeader(draft.Headers ?? string.Empty);
+            request.SetPayLoad(draft.Payload ?? string.Empty);
+            custom.Header = draft.Headers ?? string.Empty;
+            custom.PayLoad = draft.Payload ?? string.Empty;
+            custom.Url_Tags = CreateTags(request.GetUrlKeyValues());
+            custom.Header_Tags = CreateTags(request.GetHeaderKeyValues());
+            custom.PayLoad_Tags = CreateTags(request.GetPayLoadKeyValues());
+            Phoenix.Config.PlatformConfigs.Add(key, new PlatformConfig(PlatformType.CustomPlatform)
+            {
+                Enable = false,
+                Model = draft.Model?.Trim() ?? string.Empty,
+                CustomInFo = custom
+            });
+            Phoenix.SaveConfig();
+        }
+
+        /// <inheritdoc />
+        public IReadOnlyList<KeyValuePair<string, long>> ReadTokenUsage()
+        {
+            return new[]
+            {
+                Pair("ChatGPT", DeFine.GlobalLocalSetting.ChatGPTTokenUsage),
+                Pair("Gemini", DeFine.GlobalLocalSetting.GeminiTokenUsage),
+                Pair("Cohere", DeFine.GlobalLocalSetting.CohereTokenUsage),
+                Pair("DeepSeek", DeFine.GlobalLocalSetting.DeepSeekTokenUsage),
+                Pair("Local AI", DeFine.GlobalLocalSetting.LocalAITokenUsage)
+            };
+        }
+
+        /// <inheritdoc />
+        public void ClearTokenUsage()
+        {
+            DeFine.GlobalLocalSetting.ChatGPTTokenUsage = 0;
+            DeFine.GlobalLocalSetting.GeminiTokenUsage = 0;
+            DeFine.GlobalLocalSetting.CohereTokenUsage = 0;
+            DeFine.GlobalLocalSetting.DeepSeekTokenUsage = 0;
+            DeFine.GlobalLocalSetting.LocalAITokenUsage = 0;
+            DeFine.GlobalLocalSetting.SaveConfig();
+        }
+
+        private static HttpClient CreateProviderProbeClient()
+        {
+            return new HttpClient(new HttpClientHandler { AllowAutoRedirect = false })
+            {
+                Timeout = TimeSpan.FromSeconds(8),
+                MaxResponseContentBufferSize = 1024
+            };
+        }
+
+        private static IPAddress ResolveAddress(string host)
+        {
+            IPAddress parsed;
+            if (IPAddress.TryParse(host, out parsed)) return parsed;
+            if (string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase)) return IPAddress.Loopback;
+            return IPAddress.None;
+        }
+
+        private static KeyValuePair<string, long> Pair(string name, int value)
+        {
+            return new KeyValuePair<string, long>(name, Math.Max(0, value));
+        }
+
+        private static List<ReqReplaceTag> CreateTags(IEnumerable<ReqCustomKeyValue> values)
+        {
+            return values.Select(value => new ReqReplaceTag(value.Key, value.Value)).ToList();
+        }
+
+        private static string GetName(int key, PlatformConfig config)
+        {
+            if (!string.IsNullOrWhiteSpace(config.CustomInFo?.Name)) return config.CustomInFo.Name;
+            return config.Platform == PlatformType.LMLocalAI ? "LM Studio" : config.Platform.ToString();
+        }
+
+        private static string GetGroup(PlatformConfig config)
+        {
+            if (config.CustomInFo != null) return FormatGroup(config.CustomInFo.Type);
+            switch (config.Platform)
+            {
+                case PlatformType.ChatGpt:
+                case PlatformType.Gemini:
+                case PlatformType.DeepSeek: return "Cloud AI";
+                case PlatformType.LMLocalAI: return "Local AI";
+                case PlatformType.HumanTranslation: return "Interactive";
+                default: return "Traditional";
+            }
+        }
+
+        private static string FormatGroup(CustomPlatformType type)
+        {
+            switch (type)
+            {
+                case CustomPlatformType.CloudAI: return "Cloud AI";
+                case CustomPlatformType.LocalAI: return "Local AI";
+                case CustomPlatformType.Traditional: return "Traditional";
+                default: return "Interactive";
+            }
+        }
+
+        private static CustomPlatformType ParseGroup(string group)
+        {
+            if (string.Equals(group, "Local AI", StringComparison.Ordinal)) return CustomPlatformType.LocalAI;
+            if (string.Equals(group, "Traditional", StringComparison.Ordinal)) return CustomPlatformType.Traditional;
+            return CustomPlatformType.CloudAI;
+        }
+    }
+}

--- a/Phoenix_Translator/Application/PreviewAdvancedToolsModel.cs
+++ b/Phoenix_Translator/Application/PreviewAdvancedToolsModel.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>Validates SQL accepted by the guarded read-only database surface.</summary>
+    internal static class PreviewDatabaseStatementGuard
+    {
+        /// <summary>Checks whether a statement is a single read-only SELECT query.</summary>
+        /// <param name="sql">The user-entered SQL statement.</param>
+        /// <returns><c>true</c> only for one SELECT statement without a second statement delimiter.</returns>
+        internal static bool IsReadOnly(string sql)
+        {
+            if (string.IsNullOrWhiteSpace(sql)) return false;
+            string statement = sql.TrimStart();
+            int delimiter = statement.IndexOf(';');
+            if (delimiter >= 0 && !string.IsNullOrWhiteSpace(statement.Substring(delimiter + 1))) return false;
+            return statement.StartsWith("SELECT", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    /// <summary>Identifies one intent-oriented Advanced Tools page.</summary>
+    internal enum PreviewAdvancedToolsPage
+    {
+        ProviderPipeline,
+        CustomProvider,
+        TerminologyDatabase,
+        Telemetry,
+        Presets
+    }
+
+    /// <summary>Describes one staged provider-pipeline entry without secret values.</summary>
+    internal sealed class PreviewPipelineEntry : INotifyPropertyChanged
+    {
+        private bool _isEnabled;
+
+        internal PreviewPipelineEntry(int key, string name, string group, bool isEnabled, bool isCustom)
+        {
+            Key = key;
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Group = group ?? throw new ArgumentNullException(nameof(group));
+            _isEnabled = isEnabled;
+            IsCustom = isCustom;
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>Gets the stable engine configuration key.</summary>
+        public int Key { get; private set; }
+
+        /// <summary>Gets the safe provider display name.</summary>
+        public string Name { get; private set; }
+
+        /// <summary>Gets the semantic provider group.</summary>
+        public string Group { get; private set; }
+
+        /// <summary>Gets whether the entry represents a custom provider.</summary>
+        public bool IsCustom { get; private set; }
+
+        /// <summary>Gets or sets whether the staged provider is enabled.</summary>
+        public bool IsEnabled
+        {
+            get => _isEnabled;
+            set
+            {
+                if (_isEnabled == value)
+                {
+                    return;
+                }
+
+                _isEnabled = value;
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsEnabled)));
+            }
+        }
+
+        internal PreviewPipelineEntry Clone()
+        {
+            return new PreviewPipelineEntry(Key, Name, Group, IsEnabled, IsCustom);
+        }
+    }
+
+    /// <summary>Contains a staged custom-provider definition without credentials or response content.</summary>
+    internal sealed class PreviewCustomProviderDraft : INotifyPropertyChanged
+    {
+        private string _name = string.Empty;
+        private string _group = "Cloud AI";
+        private string _endpoint = string.Empty;
+        private string _model = string.Empty;
+        private string _responseField = string.Empty;
+        private string _headers = string.Empty;
+        private string _payload = string.Empty;
+        private bool _usePost = true;
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public string Name { get => _name; set => Set(ref _name, value); }
+        public string Group { get => _group; set => Set(ref _group, value); }
+        public string Endpoint { get => _endpoint; set => Set(ref _endpoint, value); }
+        public string Model { get => _model; set => Set(ref _model, value); }
+        public string ResponseField { get => _responseField; set => Set(ref _responseField, value); }
+        public string Headers { get => _headers; set => Set(ref _headers, value); }
+        public string Payload { get => _payload; set => Set(ref _payload, value); }
+        public bool UsePost { get => _usePost; set => Set(ref _usePost, value); }
+
+        internal PreviewCustomProviderDraft Clone()
+        {
+            return new PreviewCustomProviderDraft
+            {
+                Name = Name,
+                Group = Group,
+                Endpoint = Endpoint,
+                Model = Model,
+                ResponseField = ResponseField,
+                Headers = Headers,
+                Payload = Payload,
+                UsePost = UsePost
+            };
+        }
+
+        private void Set<T>(ref T field, T value, [CallerMemberName] string propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+            {
+                return;
+            }
+
+            field = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+
+    /// <summary>Provides safe persistence and operation boundaries for the Advanced Tools workspace.</summary>
+    internal interface IPreviewAdvancedToolsStore
+    {
+        IReadOnlyList<PreviewPipelineEntry> LoadPipeline();
+        void SavePipeline(IReadOnlyList<PreviewPipelineEntry> entries);
+        Task<PreviewProviderTestResult> TestCustomProviderAsync(
+            PreviewCustomProviderDraft draft,
+            CancellationToken cancellationToken);
+        void SaveCustomProvider(PreviewCustomProviderDraft draft);
+        IReadOnlyList<KeyValuePair<string, long>> ReadTokenUsage();
+        void ClearTokenUsage();
+    }
+}

--- a/Phoenix_Translator/Application/PreviewAdvancedToolsViewModel.cs
+++ b/Phoenix_Translator/Application/PreviewAdvancedToolsViewModel.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace PhoenixTranslator.ApplicationLayer
+{
+    /// <summary>Coordinates staged, guarded Advanced Tools operations independently from WPF.</summary>
+    internal sealed class PreviewAdvancedToolsViewModel : INotifyPropertyChanged, IDisposable
+    {
+        private readonly IPreviewAdvancedToolsStore _store;
+        private readonly Func<bool> _confirmDatabaseMutation;
+        private readonly Action<bool> _openDatabase;
+        private readonly PreviewShellViewModel _shell;
+        private PreviewAdvancedToolsPage _selectedPage;
+        private PreviewPipelineEntry _selectedPipelineEntry;
+        private CancellationTokenSource _testCancellation;
+        private string _statusText = string.Empty;
+        private bool _isTesting;
+        private bool _isTelemetryPaused;
+
+        internal PreviewAdvancedToolsViewModel(
+            IPreviewAdvancedToolsStore store,
+            PreviewShellViewModel shell,
+            Func<bool> confirmDatabaseMutation,
+            Action<bool> openDatabase)
+        {
+            _store = store ?? throw new ArgumentNullException(nameof(store));
+            _shell = shell ?? throw new ArgumentNullException(nameof(shell));
+            _confirmDatabaseMutation = confirmDatabaseMutation ?? throw new ArgumentNullException(nameof(confirmDatabaseMutation));
+            _openDatabase = openDatabase ?? throw new ArgumentNullException(nameof(openDatabase));
+            Pages = new[]
+            {
+                PreviewAdvancedToolsPage.ProviderPipeline,
+                PreviewAdvancedToolsPage.CustomProvider,
+                PreviewAdvancedToolsPage.TerminologyDatabase,
+                PreviewAdvancedToolsPage.Telemetry,
+                PreviewAdvancedToolsPage.Presets
+            };
+            PipelineEntries = new ObservableCollection<PreviewPipelineEntry>();
+            TokenUsage = new ObservableCollection<KeyValuePair<string, long>>();
+            CustomProvider = new PreviewCustomProviderDraft();
+            CustomProvider.PropertyChanged += CustomProviderPropertyChanged;
+            MoveUpCommand = new PreviewShellCommand(p => MoveSelected(-1), p => CanMove(-1));
+            MoveDownCommand = new PreviewShellCommand(p => MoveSelected(1), p => CanMove(1));
+            ApplyPipelineCommand = new PreviewShellCommand(p => ApplyPipeline(), p => ValidatePipeline());
+            CancelPipelineCommand = new PreviewShellCommand(p => ReloadPipeline());
+            TestCustomProviderCommand = new PreviewShellCommand(async p => await TestCustomProviderAsync(), p => CanTestCustomProvider);
+            CancelCustomProviderTestCommand = new PreviewShellCommand(p => CancelCustomProviderTest(), p => IsTesting);
+            SaveCustomProviderCommand = new PreviewShellCommand(p => SaveCustomProvider(), p => IsCustomProviderValid && !IsTesting);
+            OpenDatabaseReadOnlyCommand = new PreviewShellCommand(p => OpenDatabase(false));
+            OpenDatabaseMutationCommand = new PreviewShellCommand(p => OpenDatabase(true));
+            PauseTelemetryCommand = new PreviewShellCommand(p => ToggleTelemetryPause());
+            ClearTelemetryCommand = new PreviewShellCommand(p => ClearTelemetry());
+            RefreshTelemetryCommand = new PreviewShellCommand(p => RefreshTelemetry(), p => !IsTelemetryPaused);
+            ReloadPipeline();
+            RefreshTelemetry();
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        public IReadOnlyList<PreviewAdvancedToolsPage> Pages { get; private set; }
+        public ObservableCollection<PreviewPipelineEntry> PipelineEntries { get; private set; }
+        public ObservableCollection<KeyValuePair<string, long>> TokenUsage { get; private set; }
+        public PreviewCustomProviderDraft CustomProvider { get; private set; }
+        public IReadOnlyList<string> ProviderGroups { get; } = new[] { "Cloud AI", "Local AI", "Traditional", "Interactive" };
+
+        public PreviewAdvancedToolsPage SelectedPage
+        {
+            get => _selectedPage;
+            set { if (_selectedPage != value) { _selectedPage = value; OnPropertyChanged(); RaisePageProperties(); } }
+        }
+
+        public PreviewPipelineEntry SelectedPipelineEntry
+        {
+            get => _selectedPipelineEntry;
+            set { _selectedPipelineEntry = value; OnPropertyChanged(); RaiseCommands(); }
+        }
+
+        public bool IsPipelineVisible => SelectedPage == PreviewAdvancedToolsPage.ProviderPipeline;
+        public bool IsCustomProviderVisible => SelectedPage == PreviewAdvancedToolsPage.CustomProvider;
+        public bool IsDatabaseVisible => SelectedPage == PreviewAdvancedToolsPage.TerminologyDatabase;
+        public bool IsTelemetryVisible => SelectedPage == PreviewAdvancedToolsPage.Telemetry;
+        public bool IsPresetsVisible => SelectedPage == PreviewAdvancedToolsPage.Presets;
+        public bool IsTesting { get => _isTesting; private set { _isTesting = value; OnPropertyChanged(); OnPropertyChanged(nameof(CanTestCustomProvider)); RaiseCommands(); } }
+        public bool IsTelemetryPaused { get => _isTelemetryPaused; private set { _isTelemetryPaused = value; OnPropertyChanged(); OnPropertyChanged(nameof(TelemetryPauseText)); RaiseCommands(); } }
+        public string TelemetryPauseText => IsTelemetryPaused ? PreviewMessageCatalog.Get("Advanced_Telemetry_Resume_Action") : PreviewMessageCatalog.Get("Advanced_Telemetry_Pause_Action");
+        public string StatusText { get => _statusText; private set { _statusText = value ?? string.Empty; OnPropertyChanged(); OnPropertyChanged(nameof(HasStatus)); } }
+        public bool HasStatus => !string.IsNullOrWhiteSpace(StatusText);
+        public bool IsCustomProviderValid => ValidateCustomProvider(CustomProvider) == null;
+        public bool CanTestCustomProvider => IsCustomProviderValid && !IsTesting;
+
+        public ICommand MoveUpCommand { get; private set; }
+        public ICommand MoveDownCommand { get; private set; }
+        public ICommand ApplyPipelineCommand { get; private set; }
+        public ICommand CancelPipelineCommand { get; private set; }
+        public ICommand TestCustomProviderCommand { get; private set; }
+        public ICommand CancelCustomProviderTestCommand { get; private set; }
+        public ICommand SaveCustomProviderCommand { get; private set; }
+        public ICommand OpenDatabaseReadOnlyCommand { get; private set; }
+        public ICommand OpenDatabaseMutationCommand { get; private set; }
+        public ICommand PauseTelemetryCommand { get; private set; }
+        public ICommand ClearTelemetryCommand { get; private set; }
+        public ICommand RefreshTelemetryCommand { get; private set; }
+        public ICommand OpenDiagnosticsCommand => _shell.OpenShellServicesCommand;
+        public ICommand OpenLegacyProviderToolsCommand => _shell.OpenLegacyWorkspaceCommand;
+
+        internal static string ValidateCustomProvider(PreviewCustomProviderDraft draft)
+        {
+            if (draft == null || string.IsNullOrWhiteSpace(draft.Name) || draft.Name.Length > 80)
+            {
+                return "Advanced_Custom_Validation_Name";
+            }
+            Uri endpoint;
+            if (!Uri.TryCreate(draft.Endpoint, UriKind.Absolute, out endpoint) ||
+                (endpoint.Scheme != Uri.UriSchemeHttp && endpoint.Scheme != Uri.UriSchemeHttps))
+            {
+                return "Advanced_Custom_Validation_Endpoint";
+            }
+            IPAddress address;
+            bool isLocal = string.Equals(endpoint.Host, "localhost", StringComparison.OrdinalIgnoreCase) ||
+                (IPAddress.TryParse(endpoint.Host, out address) && IPAddress.IsLoopback(address));
+            if (endpoint.Scheme == Uri.UriSchemeHttp && !isLocal)
+            {
+                return "Advanced_Custom_Validation_Endpoint";
+            }
+            if (string.IsNullOrWhiteSpace(draft.ResponseField) || draft.ResponseField.Length > 200)
+            {
+                return "Advanced_Custom_Validation_Response";
+            }
+            return null;
+        }
+
+        private bool ValidatePipeline()
+        {
+            return PipelineEntries.Count > 0 &&
+                PipelineEntries.Select(entry => entry.Key).Distinct().Count() == PipelineEntries.Count;
+        }
+
+        private void ReloadPipeline()
+        {
+            PipelineEntries.Clear();
+            foreach (PreviewPipelineEntry entry in _store.LoadPipeline())
+            {
+                PipelineEntries.Add(entry.Clone());
+            }
+            SelectedPipelineEntry = PipelineEntries.FirstOrDefault();
+            StatusText = PreviewMessageCatalog.Get("Advanced_Pipeline_Cancelled_Status");
+        }
+
+        private void ApplyPipeline()
+        {
+            try
+            {
+                _store.SavePipeline(PipelineEntries.ToList());
+                StatusText = PreviewMessageCatalog.Get("Advanced_Pipeline_Applied_Status");
+                _shell.ShowNotification(PreviewShellNotificationSeverity.Success, "Advanced_Pipeline_Applied_Status");
+            }
+            catch (Exception)
+            {
+                StatusText = PreviewMessageCatalog.Get("Advanced_Operation_Failed_Status");
+            }
+        }
+
+        private bool CanMove(int offset)
+        {
+            int index = SelectedPipelineEntry == null ? -1 : PipelineEntries.IndexOf(SelectedPipelineEntry);
+            return index >= 0 && index + offset >= 0 && index + offset < PipelineEntries.Count;
+        }
+
+        private void MoveSelected(int offset)
+        {
+            int index = PipelineEntries.IndexOf(SelectedPipelineEntry);
+            if (index < 0 || index + offset < 0 || index + offset >= PipelineEntries.Count) return;
+            PipelineEntries.Move(index, index + offset);
+            RaiseCommands();
+        }
+
+        private async Task TestCustomProviderAsync()
+        {
+            string error = ValidateCustomProvider(CustomProvider);
+            if (error != null) { StatusText = PreviewMessageCatalog.Get(error); return; }
+            var cancellation = new CancellationTokenSource();
+            _testCancellation = cancellation;
+            IsTesting = true;
+            StatusText = PreviewMessageCatalog.Get("Advanced_Custom_Test_Running");
+            try
+            {
+                PreviewProviderTestResult result = await _store.TestCustomProviderAsync(CustomProvider.Clone(), cancellation.Token);
+                StatusText = PreviewMessageCatalog.Get(result.Status == PreviewProviderTestStatus.Succeeded
+                    ? "Advanced_Custom_Test_Succeeded" : "Advanced_Custom_Test_Failed");
+            }
+            catch (OperationCanceledException) when (cancellation.IsCancellationRequested) { StatusText = PreviewMessageCatalog.Get("Advanced_Custom_Test_Cancelled"); }
+            catch (Exception) { StatusText = PreviewMessageCatalog.Get("Advanced_Custom_Test_Failed"); }
+            finally
+            {
+                if (ReferenceEquals(_testCancellation, cancellation)) _testCancellation = null;
+                cancellation.Dispose();
+                IsTesting = false;
+            }
+        }
+
+        private void CancelCustomProviderTest() { _testCancellation?.Cancel(); }
+
+        private void SaveCustomProvider()
+        {
+            string error = ValidateCustomProvider(CustomProvider);
+            if (error != null) { StatusText = PreviewMessageCatalog.Get(error); return; }
+            try
+            {
+                _store.SaveCustomProvider(CustomProvider.Clone());
+                ReloadPipeline();
+                SelectedPage = PreviewAdvancedToolsPage.ProviderPipeline;
+                StatusText = PreviewMessageCatalog.Get("Advanced_Custom_Saved_Status");
+            }
+            catch (Exception)
+            {
+                StatusText = PreviewMessageCatalog.Get("Advanced_Operation_Failed_Status");
+            }
+        }
+
+        private void OpenDatabase(bool mutation)
+        {
+            if (mutation && !_confirmDatabaseMutation()) return;
+            _openDatabase(!mutation);
+        }
+
+        private void ToggleTelemetryPause()
+        {
+            IsTelemetryPaused = !IsTelemetryPaused;
+            if (!IsTelemetryPaused) RefreshTelemetry();
+        }
+
+        private void RefreshTelemetry()
+        {
+            if (IsTelemetryPaused) return;
+            TokenUsage.Clear();
+            foreach (KeyValuePair<string, long> item in _store.ReadTokenUsage()) TokenUsage.Add(item);
+        }
+
+        private void ClearTelemetry()
+        {
+            _store.ClearTokenUsage();
+            RefreshTelemetry();
+            StatusText = PreviewMessageCatalog.Get("Advanced_Telemetry_Cleared_Status");
+        }
+
+        private void RaisePageProperties()
+        {
+            OnPropertyChanged(nameof(IsPipelineVisible)); OnPropertyChanged(nameof(IsCustomProviderVisible));
+            OnPropertyChanged(nameof(IsDatabaseVisible)); OnPropertyChanged(nameof(IsTelemetryVisible));
+            OnPropertyChanged(nameof(IsPresetsVisible));
+        }
+
+        private void RaiseCommands()
+        {
+            foreach (PreviewShellCommand command in new[] { MoveUpCommand, MoveDownCommand, ApplyPipelineCommand,
+                TestCustomProviderCommand, CancelCustomProviderTestCommand, SaveCustomProviderCommand,
+                RefreshTelemetryCommand }.OfType<PreviewShellCommand>()) command.RaiseCanExecuteChanged();
+        }
+
+        private void CustomProviderPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            OnPropertyChanged(nameof(IsCustomProviderValid));
+            OnPropertyChanged(nameof(CanTestCustomProvider));
+            RaiseCommands();
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string name = null) { PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name)); }
+        public void Dispose()
+        {
+            CustomProvider.PropertyChanged -= CustomProviderPropertyChanged;
+            CancelCustomProviderTest();
+            _testCancellation?.Dispose();
+        }
+    }
+}

--- a/Phoenix_Translator/Application/PreviewShellViewModel.cs
+++ b/Phoenix_Translator/Application/PreviewShellViewModel.cs
@@ -137,6 +137,7 @@ namespace PhoenixTranslator.ApplicationLayer
                 OnPropertyChanged(nameof(IsReviewQualityWorkspaceVisible));
                 OnPropertyChanged(nameof(IsHistoryUpdateWorkspaceVisible));
                 OnPropertyChanged(nameof(IsSettingsWorkspaceVisible));
+                OnPropertyChanged(nameof(IsAdvancedToolsWorkspaceVisible));
                 OnPropertyChanged(nameof(IsPreviewFallbackVisible));
             }
         }
@@ -180,6 +181,9 @@ namespace PhoenixTranslator.ApplicationLayer
         /// </summary>
         public bool IsSettingsWorkspaceVisible => _currentDestination == PreviewShellDestination.Settings;
 
+        /// <summary>Gets whether the categorized Advanced Tools workspace owns the current page.</summary>
+        public bool IsAdvancedToolsWorkspaceVisible => _currentDestination == PreviewShellDestination.AdvancedTools;
+
         /// <summary>
         /// Gets whether the selected destination still uses the shared preview fallback page.
         /// </summary>
@@ -188,7 +192,8 @@ namespace PhoenixTranslator.ApplicationLayer
             !IsTranslationWorkspaceVisible &&
             !IsReviewQualityWorkspaceVisible &&
             !IsHistoryUpdateWorkspaceVisible &&
-            !IsSettingsWorkspaceVisible;
+            !IsSettingsWorkspaceVisible &&
+            !IsAdvancedToolsWorkspaceVisible;
 
         /// <summary>
         /// Gets the product version shown independently from dependency versions.

--- a/Phoenix_Translator/PhoenixTranslator.csproj
+++ b/Phoenix_Translator/PhoenixTranslator.csproj
@@ -128,6 +128,9 @@
     <Compile Include="Application\PreviewDialogService.cs" />
     <Compile Include="Application\PreviewDiagnosticService.cs" />
     <Compile Include="Application\PreviewShellServicesViewModel.cs" />
+    <Compile Include="Application\PreviewAdvancedToolsModel.cs" />
+    <Compile Include="Application\PreviewAdvancedToolsViewModel.cs" />
+    <Compile Include="Application\LegacyPreviewAdvancedToolsStore.cs" />
     <Compile Include="Application\PreviewShellViewModel.cs" />
     <Compile Include="Application\PreviewTranslationEntry.cs" />
     <Compile Include="Application\PreviewTranslationProject.cs" />
@@ -245,6 +248,9 @@
     </Compile>
     <Compile Include="UIManagement\Preview\PreviewSettingsView.xaml.cs">
       <DependentUpon>PreviewSettingsView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="UIManagement\Preview\PreviewAdvancedToolsView.xaml.cs">
+      <DependentUpon>PreviewAdvancedToolsView.xaml</DependentUpon>
     </Compile>
     <Compile Include="UIManagement\Preview\PreviewTranslationWorkspaceView.xaml.cs">
       <DependentUpon>PreviewTranslationWorkspaceView.xaml</DependentUpon>
@@ -391,6 +397,10 @@
     <Page Include="UIManagement\Preview\PreviewSettingsView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="UIManagement\Preview\PreviewAdvancedToolsView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="UIManagement\Preview\PreviewTranslationWorkspaceView.xaml">
       <SubType>Designer</SubType>

--- a/Phoenix_Translator/Properties/AssemblyInfo.cs
+++ b/Phoenix_Translator/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Windows;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.0.0.16")]
-[assembly: AssemblyFileVersion("2.0.0.16")]
+[assembly: AssemblyVersion("2.0.0.17")]
+[assembly: AssemblyFileVersion("2.0.0.17")]

--- a/Phoenix_Translator/Properties/Resources.resx
+++ b/Phoenix_Translator/Properties/Resources.resx
@@ -591,4 +591,69 @@
   <data name="Common_Action_Remove" xml:space="preserve"><value>_Remove</value><comment>Access-key action that removes a reference without deleting underlying content.</comment></data>
   <data name="Accessibility_Projects_Recent_Name" xml:space="preserve"><value>Recent projects</value><comment>Accessible name for the recent-project list.</comment></data>
   <data name="Accessibility_Projects_Active_Name" xml:space="preserve"><value>Active project summary</value><comment>Accessible name for the active project region.</comment></data>
+  <data name="Advanced_Title" xml:space="preserve"><value>Advanced tools</value><comment>Accessible title for the Advanced Tools workspace.</comment></data>
+  <data name="Accessibility_Advanced_Tabs_Name" xml:space="preserve"><value>Advanced tool categories</value><comment>Accessible name for Advanced Tools category tabs.</comment></data>
+  <data name="Accessibility_Advanced_Pipeline_Name" xml:space="preserve"><value>Provider pipeline</value><comment>Accessible name for the provider pipeline list.</comment></data>
+  <data name="Advanced_Tab_Pipeline" xml:space="preserve"><value>Provider pipeline</value><comment>Advanced Tools pipeline tab.</comment></data>
+  <data name="Advanced_Tab_CustomProvider" xml:space="preserve"><value>Custom provider</value><comment>Advanced Tools custom provider tab.</comment></data>
+  <data name="Advanced_Tab_Database" xml:space="preserve"><value>Terminology database</value><comment>Advanced Tools database tab.</comment></data>
+  <data name="Advanced_Tab_Telemetry" xml:space="preserve"><value>Token telemetry</value><comment>Advanced Tools telemetry tab.</comment></data>
+  <data name="Advanced_Tab_Presets" xml:space="preserve"><value>Preset guide</value><comment>Advanced Tools preset explanation tab.</comment></data>
+  <data name="Advanced_Diagnostics_Action" xml:space="preserve"><value>_Diagnostics</value><comment>Opens safe application diagnostics from Advanced Tools.</comment></data>
+  <data name="Advanced_Legacy_Action" xml:space="preserve"><value>Legacy provider _tools</value><comment>Opens the workflow-specific legacy provider fallback.</comment></data>
+  <data name="Advanced_Pipeline_Title" xml:space="preserve"><value>Provider execution pipeline</value><comment>Provider pipeline card title.</comment></data>
+  <data name="Advanced_Pipeline_Description" xml:space="preserve"><value>Enable providers and arrange their execution order. Changes remain staged until you apply them.</value><comment>Provider pipeline staged editing explanation.</comment></data>
+  <data name="Advanced_Pipeline_Applied_Status" xml:space="preserve"><value>The provider pipeline was validated and applied.</value><comment>Provider pipeline apply success status.</comment></data>
+  <data name="Advanced_Pipeline_Cancelled_Status" xml:space="preserve"><value>The provider pipeline matches the saved configuration.</value><comment>Provider pipeline reload status.</comment></data>
+  <data name="Common_Action_MoveUp" xml:space="preserve"><value>Move _up</value><comment>Moves a selected item earlier.</comment></data>
+  <data name="Common_Action_MoveDown" xml:space="preserve"><value>Move _down</value><comment>Moves a selected item later.</comment></data>
+  <data name="Common_Action_Cancel" xml:space="preserve"><value>_Cancel</value><comment>Cancels or discards a staged operation.</comment></data>
+  <data name="Common_Action_Apply" xml:space="preserve"><value>_Apply</value><comment>Applies staged changes.</comment></data>
+  <data name="Common_Action_Refresh" xml:space="preserve"><value>_Refresh</value><comment>Refreshes current values.</comment></data>
+  <data name="Advanced_Custom_Title" xml:space="preserve"><value>Custom provider editor</value><comment>Custom provider editor title.</comment></data>
+  <data name="Advanced_Custom_Description" xml:space="preserve"><value>Define the provider identity and response mapping, validate connectivity without translation content, then save it disabled for deliberate pipeline placement.</value><comment>Staged custom provider workflow explanation.</comment></data>
+  <data name="Advanced_Custom_Name_Label" xml:space="preserve"><value>Provider name</value><comment>Custom provider name field label.</comment></data>
+  <data name="Advanced_Custom_Group_Label" xml:space="preserve"><value>Provider group</value><comment>Custom provider group field label.</comment></data>
+  <data name="Advanced_Custom_Endpoint_Label" xml:space="preserve"><value>HTTPS or local endpoint</value><comment>Custom provider endpoint field label.</comment></data>
+  <data name="Advanced_Custom_Model_Label" xml:space="preserve"><value>Model (optional)</value><comment>Custom provider model field label.</comment></data>
+  <data name="Advanced_Custom_ResponseField_Label" xml:space="preserve"><value>JSON response field</value><comment>Custom provider response mapping field label.</comment></data>
+  <data name="Advanced_Custom_Headers_Label" xml:space="preserve"><value>Request headers</value><comment>Custom provider request headers field label.</comment></data>
+  <data name="Advanced_Custom_Payload_Label" xml:space="preserve"><value>Request payload</value><comment>Custom provider request payload field label.</comment></data>
+  <data name="Advanced_Custom_Placeholders_Hint" xml:space="preserve"><value>Use existing Phoenix placeholders as values: {API_KEY}, {AI_Prompt}, {AI_Model}, {SourceStr}, {P_From}, and {P_To}.</value><comment>Custom provider request mapping guidance.</comment></data>
+  <data name="Advanced_Custom_UsePost_Label" xml:space="preserve"><value>Use POST for provider requests</value><comment>Custom provider request method option.</comment></data>
+  <data name="Advanced_Custom_Privacy" xml:space="preserve"><value>The connectivity test sends no credential, prompt, translation text, payload, or response body to diagnostics.</value><comment>Custom provider test privacy explanation.</comment></data>
+  <data name="Advanced_Custom_Test_Action" xml:space="preserve"><value>_Test connectivity</value><comment>Starts a bounded custom provider connectivity test.</comment></data>
+  <data name="Advanced_Custom_Save_Action" xml:space="preserve"><value>_Save provider</value><comment>Saves the validated custom provider.</comment></data>
+  <data name="Advanced_Custom_Validation_Name" xml:space="preserve"><value>Enter a provider name with no more than 80 characters.</value><comment>Safe custom provider name validation.</comment></data>
+  <data name="Advanced_Custom_Validation_Endpoint" xml:space="preserve"><value>Enter an absolute HTTPS endpoint or a local HTTP endpoint.</value><comment>Safe custom provider endpoint validation.</comment></data>
+  <data name="Advanced_Custom_Validation_Response" xml:space="preserve"><value>Enter the JSON field that contains the translated response.</value><comment>Safe custom provider response mapping validation.</comment></data>
+  <data name="Advanced_Custom_Test_Running" xml:space="preserve"><value>Testing provider connectivity…</value><comment>Custom provider test running status.</comment></data>
+  <data name="Advanced_Custom_Test_Succeeded" xml:space="preserve"><value>The endpoint accepted a bounded connectivity probe.</value><comment>Custom provider connectivity success.</comment></data>
+  <data name="Advanced_Custom_Test_Failed" xml:space="preserve"><value>The endpoint rejected or could not complete the bounded connectivity probe.</value><comment>Custom provider connectivity failure.</comment></data>
+  <data name="Advanced_Custom_Test_Cancelled" xml:space="preserve"><value>The provider connectivity test was cancelled.</value><comment>Custom provider connectivity cancellation.</comment></data>
+  <data name="Advanced_Custom_Saved_Status" xml:space="preserve"><value>The custom provider was saved disabled and added to the pipeline.</value><comment>Custom provider save success.</comment></data>
+  <data name="Advanced_Operation_Failed_Status" xml:space="preserve"><value>The advanced operation could not be completed. The saved configuration was not intentionally changed.</value><comment>Safe generic Advanced Tools operation failure.</comment></data>
+  <data name="Advanced_Database_Title" xml:space="preserve"><value>Guarded terminology database</value><comment>Advanced terminology database title.</comment></data>
+  <data name="Advanced_Database_Description" xml:space="preserve"><value>Browse terminology data in read-only mode. Enter mutation mode only for deliberate maintenance operations.</value><comment>Database access boundary explanation.</comment></data>
+  <data name="Advanced_Database_MutationWarning" xml:space="preserve"><value>Mutation mode can permanently update or delete terminology records. It is separate from ordinary terminology editing and requires confirmation.</value><comment>Database mutation warning.</comment></data>
+  <data name="Advanced_Database_ReadOnly_Action" xml:space="preserve"><value>Open _read-only</value><comment>Opens database tool with mutations blocked.</comment></data>
+  <data name="Advanced_Database_Mutation_Action" xml:space="preserve"><value>Enter _mutation mode</value><comment>Requests guarded database mutation access.</comment></data>
+  <data name="Advanced_Database_Mutation_ConfirmationTitle" xml:space="preserve"><value>Enter database mutation mode?</value><comment>Database mutation confirmation title.</comment></data>
+  <data name="Advanced_Database_Mutation_Confirmation" xml:space="preserve"><value>Mutation mode can permanently change terminology data. Continue only if you intend to maintain the database directly.</value><comment>Database mutation confirmation message.</comment></data>
+  <data name="Advanced_Telemetry_Title" xml:space="preserve"><value>Token telemetry</value><comment>Token telemetry title.</comment></data>
+  <data name="Advanced_Telemetry_Description" xml:space="preserve"><value>Inspect provider token totals without prompts, translations, credentials, endpoints, or response payloads.</value><comment>Privacy-safe token telemetry explanation.</comment></data>
+  <data name="Advanced_Telemetry_Pause_Action" xml:space="preserve"><value>_Pause updates</value><comment>Pauses token telemetry refresh.</comment></data>
+  <data name="Advanced_Telemetry_Resume_Action" xml:space="preserve"><value>_Resume updates</value><comment>Resumes token telemetry refresh.</comment></data>
+  <data name="Advanced_Telemetry_Clear_Action" xml:space="preserve"><value>_Clear totals</value><comment>Clears persisted token totals.</comment></data>
+  <data name="Advanced_Telemetry_Cleared_Status" xml:space="preserve"><value>Token totals were cleared.</value><comment>Token telemetry clear success.</comment></data>
+  <data name="Advanced_Presets_Title" xml:space="preserve"><value>Translation preset trade-offs</value><comment>Textual preset guide title.</comment></data>
+  <data name="Advanced_Presets_Description" xml:space="preserve"><value>Use these descriptions with the numeric settings. Color and chart shape are never required to understand the trade-offs.</value><comment>Accessible preset guide explanation.</comment></data>
+  <data name="Advanced_Preset_Balanced_Title" xml:space="preserve"><value>Balanced — recommended default</value><comment>Balanced preset title.</comment></data>
+  <data name="Advanced_Preset_Balanced_Description" xml:space="preserve"><value>High quality with good throughput. Uses moderate context and standard bucket sizes for everyday projects.</value><comment>Balanced preset text explanation.</comment></data>
+  <data name="Advanced_Preset_Quality_Title" xml:space="preserve"><value>Quality first — more context, lower throughput</value><comment>Quality preset title.</comment></data>
+  <data name="Advanced_Preset_Quality_Description" xml:space="preserve"><value>Preserves more conversational context and stricter link grouping. Best for nuanced content, but uses more time and provider capacity.</value><comment>Quality preset text explanation.</comment></data>
+  <data name="Advanced_Preset_Speed_Title" xml:space="preserve"><value>Speed first — less context, higher throughput</value><comment>Speed preset title.</comment></data>
+  <data name="Advanced_Preset_Speed_Description" xml:space="preserve"><value>Uses larger batches and aggressive deduplication. Best for broad first passes, with less contextual nuance.</value><comment>Speed preset text explanation.</comment></data>
+  <data name="Advanced_Preset_Custom_Title" xml:space="preserve"><value>Custom — explicit expert control</value><comment>Custom preset title.</comment></data>
+  <data name="Advanced_Preset_Custom_Description" xml:space="preserve"><value>Preserves individually chosen engine values. Review context, bucket, concurrency, and throttling settings together before large runs.</value><comment>Custom preset text explanation.</comment></data>
 </root>

--- a/Phoenix_Translator/UIManagement/Main/DataBaseView.xaml.cs
+++ b/Phoenix_Translator/UIManagement/Main/DataBaseView.xaml.cs
@@ -21,6 +21,18 @@ namespace PhoenixTranslator
 {
     public partial class DataBaseView : Window
     {
+        private bool _isReadOnlyMode;
+
+        /// <summary>Restricts the database tool to read-only statements and disables mutation controls.</summary>
+        /// <param name="isReadOnly">Whether database mutations must be blocked.</param>
+        public void SetReadOnlyMode(bool isReadOnly)
+        {
+            _isReadOnlyMode = isReadOnly;
+            DeleteBtn.IsEnabled = !isReadOnly;
+            DeleteBtn.Visibility = isReadOnly ? Visibility.Collapsed : Visibility.Visible;
+            MainGrid.IsReadOnly = isReadOnly;
+            Title = isReadOnly ? "Database Viewer (read-only)" : "Database Viewer";
+        }
         private string _TableName;
 
         private Dictionary<int, long> _RowIds = new Dictionary<int, long>();
@@ -91,6 +103,11 @@ namespace PhoenixTranslator
         private string LastQuery = "";
         private void RunQuery(string UserSql)
         {
+            if (_isReadOnlyMode && !ApplicationLayer.PreviewDatabaseStatementGuard.IsReadOnly(UserSql))
+            {
+                SetStatus("Read-only mode accepts SELECT statements only.", false);
+                return;
+            }
             try
             {
                 LastQuery = UserSql;

--- a/Phoenix_Translator/UIManagement/Preview/PreviewAdvancedToolsView.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewAdvancedToolsView.xaml
@@ -1,0 +1,151 @@
+<UserControl x:Class="PhoenixTranslator.UIManagement.Preview.PreviewAdvancedToolsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:localization="clr-namespace:PhoenixTranslator.UIManagement.Localization"
+             AutomationProperties.Name="{localization:PreviewMessage Advanced_Title}">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries><ResourceDictionary Source="/Themes/PreviewControlStyles.xaml" /></ResourceDictionary.MergedDictionaries>
+            <BooleanToVisibilityConverter x:Key="BooleanToVisibility" />
+            <Style x:Key="AdvancedCard" TargetType="Border">
+                <Setter Property="Margin" Value="0,0,0,12" /><Setter Property="Padding" Value="18" />
+                <Setter Property="Background" Value="{StaticResource PreviewBrushSurfacePrimary}" />
+                <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushBorder}" /><Setter Property="BorderThickness" Value="1" />
+                <Setter Property="CornerRadius" Value="5" />
+            </Style>
+            <Style x:Key="AdvancedTab" TargetType="ListBoxItem">
+                <Setter Property="Padding" Value="14,9" /><Setter Property="Margin" Value="0,0,4,0" />
+                <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextSecondary}" /><Setter Property="Background" Value="Transparent" />
+                <Setter Property="FocusVisualStyle" Value="{StaticResource PreviewFocusVisual}" />
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True"><Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceInteractive}" /></Trigger>
+                    <Trigger Property="IsSelected" Value="True"><Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceInteractive}" />
+                        <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" /><Setter Property="BorderBrush" Value="{StaticResource PreviewBrushAccentGold}" />
+                        <Setter Property="BorderThickness" Value="0,0,0,3" /></Trigger>
+                </Style.Triggers>
+            </Style>
+            <Style x:Key="AdvancedHeading" TargetType="TextBlock"><Setter Property="FontSize" Value="16" /><Setter Property="FontWeight" Value="SemiBold" />
+                <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" /><Setter Property="Margin" Value="0,0,0,8" /></Style>
+            <Style x:Key="AdvancedLabel" TargetType="TextBlock"><Setter Property="Foreground" Value="{StaticResource PreviewBrushTextSecondary}" />
+                <Setter Property="Margin" Value="0,0,0,5" /></Style>
+            <Style x:Key="AdvancedPipelineItem" TargetType="ListBoxItem">
+                <Setter Property="Padding" Value="0" /><Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                <Setter Property="Foreground" Value="{StaticResource PreviewBrushTextPrimary}" /><Setter Property="Background" Value="Transparent" />
+                <Setter Property="FocusVisualStyle" Value="{StaticResource PreviewFocusVisual}" />
+                <Style.Triggers><Trigger Property="IsMouseOver" Value="True"><Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceInteractive}" /></Trigger>
+                    <Trigger Property="IsSelected" Value="True"><Setter Property="Background" Value="{StaticResource PreviewBrushSurfaceInteractive}" />
+                        <Setter Property="BorderBrush" Value="{StaticResource PreviewBrushAccentGold}" /><Setter Property="BorderThickness" Value="3,0,0,0" /></Trigger></Style.Triggers>
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Grid>
+        <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="12" /><RowDefinition Height="*" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
+        <Border Style="{StaticResource AdvancedCard}" Margin="0" Padding="6">
+            <Grid><Grid.ColumnDefinitions><ColumnDefinition /><ColumnDefinition Width="12" /><ColumnDefinition Width="Auto" /><ColumnDefinition Width="8" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+            <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
+                <ListBox x:Name="PageTabs" ItemsSource="{Binding Pages}" SelectedItem="{Binding SelectedPage}" ItemContainerStyle="{StaticResource AdvancedTab}"
+                         Background="Transparent" BorderThickness="0" AutomationProperties.Name="{localization:PreviewMessage Accessibility_Advanced_Tabs_Name}">
+                    <ListBox.ItemsPanel><ItemsPanelTemplate><StackPanel Orientation="Horizontal" /></ItemsPanelTemplate></ListBox.ItemsPanel>
+                    <ListBox.ItemTemplate><DataTemplate><TextBlock FontWeight="SemiBold"><TextBlock.Style><Style TargetType="TextBlock">
+                        <Setter Property="Text" Value="{localization:PreviewMessage Advanced_Tab_Pipeline}" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding}" Value="CustomProvider"><Setter Property="Text" Value="{localization:PreviewMessage Advanced_Tab_CustomProvider}" /></DataTrigger>
+                            <DataTrigger Binding="{Binding}" Value="TerminologyDatabase"><Setter Property="Text" Value="{localization:PreviewMessage Advanced_Tab_Database}" /></DataTrigger>
+                            <DataTrigger Binding="{Binding}" Value="Telemetry"><Setter Property="Text" Value="{localization:PreviewMessage Advanced_Tab_Telemetry}" /></DataTrigger>
+                            <DataTrigger Binding="{Binding}" Value="Presets"><Setter Property="Text" Value="{localization:PreviewMessage Advanced_Tab_Presets}" /></DataTrigger>
+                        </Style.Triggers></Style></TextBlock.Style></TextBlock></DataTemplate></ListBox.ItemTemplate>
+                </ListBox>
+            </ScrollViewer>
+            <Button Grid.Column="2" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding OpenDiagnosticsCommand}" Content="{localization:PreviewMessage Advanced_Diagnostics_Action}" />
+            <Button Grid.Column="4" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding OpenLegacyProviderToolsCommand}" Content="{localization:PreviewMessage Advanced_Legacy_Action}" />
+            </Grid>
+        </Border>
+        <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+            <Grid>
+                <StackPanel Visibility="{Binding IsPipelineVisible, Converter={StaticResource BooleanToVisibility}}">
+                    <Border Style="{StaticResource AdvancedCard}"><Grid><Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="*" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
+                        <StackPanel><TextBlock Style="{StaticResource AdvancedHeading}" Text="{localization:PreviewMessage Advanced_Pipeline_Title}" />
+                            <TextBlock Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{localization:PreviewMessage Advanced_Pipeline_Description}" TextWrapping="Wrap" /></StackPanel>
+                        <ListBox Grid.Row="1" Margin="0,16" MinHeight="260" ItemsSource="{Binding PipelineEntries}" SelectedItem="{Binding SelectedPipelineEntry}" ItemContainerStyle="{StaticResource AdvancedPipelineItem}"
+                                 Background="{StaticResource PreviewBrushSurfaceCanvas}" BorderBrush="{StaticResource PreviewBrushBorder}" AutomationProperties.Name="{localization:PreviewMessage Accessibility_Advanced_Pipeline_Name}">
+                            <ListBox.ItemTemplate><DataTemplate><Grid Margin="8,5"><Grid.ColumnDefinitions><ColumnDefinition Width="Auto" /><ColumnDefinition Width="16" /><ColumnDefinition Width="*" /><ColumnDefinition Width="160" /></Grid.ColumnDefinitions>
+                                <CheckBox IsChecked="{Binding IsEnabled}" VerticalAlignment="Center" AutomationProperties.Name="{Binding Name}" />
+                                <TextBlock Grid.Column="2" VerticalAlignment="Center" Foreground="{StaticResource PreviewBrushTextPrimary}" Text="{Binding Name}" />
+                                <TextBlock Grid.Column="3" VerticalAlignment="Center" Foreground="{StaticResource PreviewBrushTextMuted}" Text="{Binding Group}" /></Grid></DataTemplate></ListBox.ItemTemplate>
+                        </ListBox>
+                        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+                            <Button Margin="0,0,8,0" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding MoveUpCommand}" Content="{localization:PreviewMessage Common_Action_MoveUp}" />
+                            <Button Margin="0,0,20,0" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding MoveDownCommand}" Content="{localization:PreviewMessage Common_Action_MoveDown}" />
+                            <Button Margin="0,0,8,0" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding CancelPipelineCommand}" Content="{localization:PreviewMessage Common_Action_Cancel}" />
+                            <Button Style="{StaticResource PreviewButtonPrimary}" Command="{Binding ApplyPipelineCommand}" Content="{localization:PreviewMessage Common_Action_Apply}" />
+                        </StackPanel></Grid></Border>
+                </StackPanel>
+                <StackPanel Visibility="{Binding IsCustomProviderVisible, Converter={StaticResource BooleanToVisibility}}">
+                    <Border Style="{StaticResource AdvancedCard}"><StackPanel>
+                        <TextBlock Style="{StaticResource AdvancedHeading}" Text="{localization:PreviewMessage Advanced_Custom_Title}" />
+                        <TextBlock Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{localization:PreviewMessage Advanced_Custom_Description}" TextWrapping="Wrap" Margin="0,0,0,16" />
+                        <Grid><Grid.ColumnDefinitions><ColumnDefinition /><ColumnDefinition Width="16" /><ColumnDefinition /></Grid.ColumnDefinitions>
+                            <StackPanel><TextBlock Style="{StaticResource AdvancedLabel}" Text="{localization:PreviewMessage Advanced_Custom_Name_Label}" />
+                                <TextBox x:Name="CustomProviderName" Style="{StaticResource PreviewTextBox}" Text="{Binding CustomProvider.Name, UpdateSourceTrigger=PropertyChanged}" /></StackPanel>
+                            <StackPanel Grid.Column="2"><TextBlock Style="{StaticResource AdvancedLabel}" Text="{localization:PreviewMessage Advanced_Custom_Group_Label}" />
+                                <ComboBox Style="{StaticResource PreviewComboBox}" ItemsSource="{Binding ProviderGroups}" SelectedItem="{Binding CustomProvider.Group}" /></StackPanel>
+                        </Grid>
+                        <TextBlock Margin="0,14,0,5" Style="{StaticResource AdvancedLabel}" Text="{localization:PreviewMessage Advanced_Custom_Endpoint_Label}" />
+                        <TextBox Style="{StaticResource PreviewTextBox}" Text="{Binding CustomProvider.Endpoint, UpdateSourceTrigger=PropertyChanged}" />
+                        <Grid Margin="0,14,0,0"><Grid.ColumnDefinitions><ColumnDefinition /><ColumnDefinition Width="16" /><ColumnDefinition /></Grid.ColumnDefinitions>
+                            <StackPanel><TextBlock Style="{StaticResource AdvancedLabel}" Text="{localization:PreviewMessage Advanced_Custom_Model_Label}" />
+                                <TextBox Style="{StaticResource PreviewTextBox}" Text="{Binding CustomProvider.Model, UpdateSourceTrigger=PropertyChanged}" /></StackPanel>
+                            <StackPanel Grid.Column="2"><TextBlock Style="{StaticResource AdvancedLabel}" Text="{localization:PreviewMessage Advanced_Custom_ResponseField_Label}" />
+                                <TextBox Style="{StaticResource PreviewTextBox}" Text="{Binding CustomProvider.ResponseField, UpdateSourceTrigger=PropertyChanged}" /></StackPanel>
+                        </Grid>
+                        <Grid Margin="0,14,0,0"><Grid.ColumnDefinitions><ColumnDefinition /><ColumnDefinition Width="16" /><ColumnDefinition /></Grid.ColumnDefinitions>
+                            <StackPanel><TextBlock Style="{StaticResource AdvancedLabel}" Text="{localization:PreviewMessage Advanced_Custom_Headers_Label}" />
+                                <TextBox Height="92" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" Style="{StaticResource PreviewTextBox}" Text="{Binding CustomProvider.Headers, UpdateSourceTrigger=PropertyChanged}" /></StackPanel>
+                            <StackPanel Grid.Column="2"><TextBlock Style="{StaticResource AdvancedLabel}" Text="{localization:PreviewMessage Advanced_Custom_Payload_Label}" />
+                                <TextBox Height="92" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" Style="{StaticResource PreviewTextBox}" Text="{Binding CustomProvider.Payload, UpdateSourceTrigger=PropertyChanged}" /></StackPanel>
+                        </Grid>
+                        <TextBlock Margin="0,8,0,0" Foreground="{StaticResource PreviewBrushTextMuted}" Text="{localization:PreviewMessage Advanced_Custom_Placeholders_Hint}" TextWrapping="Wrap" />
+                        <CheckBox Margin="0,14,0,0" Foreground="{StaticResource PreviewBrushTextPrimary}" IsChecked="{Binding CustomProvider.UsePost}" Content="{localization:PreviewMessage Advanced_Custom_UsePost_Label}" />
+                        <TextBlock Margin="0,14,0,0" Foreground="{StaticResource PreviewBrushTextMuted}" Text="{localization:PreviewMessage Advanced_Custom_Privacy}" TextWrapping="Wrap" />
+                        <StackPanel Margin="0,18,0,0" Orientation="Horizontal" HorizontalAlignment="Right">
+                            <Button Margin="0,0,8,0" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding CancelCustomProviderTestCommand}" Content="{localization:PreviewMessage Common_Action_Cancel}" />
+                            <Button Margin="0,0,8,0" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding TestCustomProviderCommand}" Content="{localization:PreviewMessage Advanced_Custom_Test_Action}" />
+                            <Button Style="{StaticResource PreviewButtonPrimary}" Command="{Binding SaveCustomProviderCommand}" Content="{localization:PreviewMessage Advanced_Custom_Save_Action}" />
+                        </StackPanel>
+                    </StackPanel></Border>
+                </StackPanel>
+                <StackPanel Visibility="{Binding IsDatabaseVisible, Converter={StaticResource BooleanToVisibility}}">
+                    <Border Style="{StaticResource AdvancedCard}"><StackPanel><TextBlock Style="{StaticResource AdvancedHeading}" Text="{localization:PreviewMessage Advanced_Database_Title}" />
+                        <TextBlock Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{localization:PreviewMessage Advanced_Database_Description}" TextWrapping="Wrap" />
+                        <Border Margin="0,18" Padding="14" Background="{StaticResource PreviewBrushSurfaceInteractive}" BorderBrush="{StaticResource PreviewBrushWarning}" BorderThickness="3,0,0,0">
+                            <TextBlock Foreground="{StaticResource PreviewBrushTextPrimary}" Text="{localization:PreviewMessage Advanced_Database_MutationWarning}" TextWrapping="Wrap" /></Border>
+                        <StackPanel Orientation="Horizontal"><Button Margin="0,0,8,0" Style="{StaticResource PreviewButtonPrimary}" Command="{Binding OpenDatabaseReadOnlyCommand}" Content="{localization:PreviewMessage Advanced_Database_ReadOnly_Action}" />
+                            <Button Style="{StaticResource PreviewButtonDanger}" Command="{Binding OpenDatabaseMutationCommand}" Content="{localization:PreviewMessage Advanced_Database_Mutation_Action}" /></StackPanel>
+                    </StackPanel></Border>
+                </StackPanel>
+                <StackPanel Visibility="{Binding IsTelemetryVisible, Converter={StaticResource BooleanToVisibility}}">
+                    <Border Style="{StaticResource AdvancedCard}"><StackPanel><TextBlock Style="{StaticResource AdvancedHeading}" Text="{localization:PreviewMessage Advanced_Telemetry_Title}" />
+                        <TextBlock Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{localization:PreviewMessage Advanced_Telemetry_Description}" TextWrapping="Wrap" />
+                        <ItemsControl Margin="0,18" ItemsSource="{Binding TokenUsage}"><ItemsControl.ItemTemplate><DataTemplate><Grid Margin="0,5"><Grid.ColumnDefinitions><ColumnDefinition /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                            <TextBlock Foreground="{StaticResource PreviewBrushTextPrimary}" Text="{Binding Key}" /><TextBlock Grid.Column="1" Foreground="{StaticResource PreviewBrushAccentGold}" Text="{Binding Value, StringFormat={}{0:N0} tokens}" /></Grid></DataTemplate></ItemsControl.ItemTemplate></ItemsControl>
+                        <StackPanel Orientation="Horizontal"><Button Margin="0,0,8,0" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding RefreshTelemetryCommand}" Content="{localization:PreviewMessage Common_Action_Refresh}" />
+                            <Button Margin="0,0,8,0" Style="{StaticResource PreviewButtonSecondary}" Command="{Binding PauseTelemetryCommand}" Content="{Binding TelemetryPauseText}" />
+                            <Button Style="{StaticResource PreviewButtonDanger}" Command="{Binding ClearTelemetryCommand}" Content="{localization:PreviewMessage Advanced_Telemetry_Clear_Action}" /></StackPanel>
+                    </StackPanel></Border>
+                </StackPanel>
+                <StackPanel Visibility="{Binding IsPresetsVisible, Converter={StaticResource BooleanToVisibility}}">
+                    <Border Style="{StaticResource AdvancedCard}"><StackPanel><TextBlock Style="{StaticResource AdvancedHeading}" Text="{localization:PreviewMessage Advanced_Presets_Title}" />
+                        <TextBlock Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{localization:PreviewMessage Advanced_Presets_Description}" TextWrapping="Wrap" Margin="0,0,0,16" />
+                        <TextBlock FontWeight="SemiBold" Foreground="{StaticResource PreviewBrushAccentGold}" Text="{localization:PreviewMessage Advanced_Preset_Balanced_Title}" /><TextBlock Margin="0,4,0,14" Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{localization:PreviewMessage Advanced_Preset_Balanced_Description}" TextWrapping="Wrap" />
+                        <TextBlock FontWeight="SemiBold" Foreground="{StaticResource PreviewBrushAccentGold}" Text="{localization:PreviewMessage Advanced_Preset_Quality_Title}" /><TextBlock Margin="0,4,0,14" Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{localization:PreviewMessage Advanced_Preset_Quality_Description}" TextWrapping="Wrap" />
+                        <TextBlock FontWeight="SemiBold" Foreground="{StaticResource PreviewBrushAccentGold}" Text="{localization:PreviewMessage Advanced_Preset_Speed_Title}" /><TextBlock Margin="0,4,0,14" Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{localization:PreviewMessage Advanced_Preset_Speed_Description}" TextWrapping="Wrap" />
+                        <TextBlock FontWeight="SemiBold" Foreground="{StaticResource PreviewBrushAccentGold}" Text="{localization:PreviewMessage Advanced_Preset_Custom_Title}" /><TextBlock Margin="0,4,0,0" Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{localization:PreviewMessage Advanced_Preset_Custom_Description}" TextWrapping="Wrap" />
+                    </StackPanel></Border>
+                </StackPanel>
+            </Grid>
+        </ScrollViewer>
+        <Border Grid.Row="3" Margin="0,12,0,0" Padding="12,8" Background="{StaticResource PreviewBrushSurfaceInteractive}" Visibility="{Binding HasStatus, Converter={StaticResource BooleanToVisibility}}" AutomationProperties.LiveSetting="Polite">
+            <TextBlock Foreground="{StaticResource PreviewBrushTextPrimary}" Text="{Binding StatusText}" TextWrapping="Wrap" />
+        </Border>
+    </Grid>
+</UserControl>

--- a/Phoenix_Translator/UIManagement/Preview/PreviewAdvancedToolsView.xaml.cs
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewAdvancedToolsView.xaml.cs
@@ -1,0 +1,32 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace PhoenixTranslator.UIManagement.Preview
+{
+    /// <summary>Hosts the categorized Advanced Tools workspace.</summary>
+    public partial class PreviewAdvancedToolsView : UserControl
+    {
+        /// <summary>Creates the Advanced Tools view.</summary>
+        public PreviewAdvancedToolsView()
+        {
+            InitializeComponent();
+        }
+
+        /// <summary>Moves keyboard focus to the selected Advanced Tools page.</summary>
+        public void FocusInitialControl()
+        {
+            Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Input, new System.Action(() =>
+            {
+                if (PageTabs.ItemContainerGenerator.ContainerFromIndex(PageTabs.SelectedIndex) is ListBoxItem item)
+                {
+                    Keyboard.Focus(item);
+                }
+                else
+                {
+                    Keyboard.Focus(PageTabs);
+                }
+            }));
+        }
+    }
+}

--- a/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml
@@ -215,9 +215,15 @@
                         Visibility="{Binding DataContext.IsSettingsWorkspaceVisible,
                             RelativeSource={RelativeSource AncestorType={x:Type Window}},
                             Converter={StaticResource BooleanToVisibility}}" />
+                <preview:PreviewAdvancedToolsView x:Name="AdvancedToolsWorkspace" Grid.Row="2"
+                        Visibility="{Binding DataContext.IsAdvancedToolsWorkspaceVisible,
+                            RelativeSource={RelativeSource AncestorType={x:Type Window}},
+                            Converter={StaticResource BooleanToVisibility}}" />
                 <preview:PreviewShellServicesView x:Name="ShellServicesWorkspace" Grid.Row="2"
                         Panel.ZIndex="20"
-                        Visibility="{Binding IsShellServicesVisible, Converter={StaticResource BooleanToVisibility}}" />
+                        Visibility="{Binding DataContext.IsShellServicesVisible,
+                            RelativeSource={RelativeSource AncestorType={x:Type Window}},
+                            Converter={StaticResource BooleanToVisibility}}" />
             </Grid>
         </Grid>
 

--- a/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml.cs
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewShellWindow.xaml.cs
@@ -23,6 +23,7 @@ namespace PhoenixTranslator.UIManagement.Preview
         private readonly PreviewReviewQualityViewModel _reviewQualityViewModel;
         private readonly PreviewHistoryUpdateViewModel _historyUpdateViewModel;
         private readonly PreviewSettingsViewModel _settingsViewModel;
+        private readonly PreviewAdvancedToolsViewModel _advancedToolsViewModel;
         private readonly PreviewDiagnosticService _diagnostics;
         private readonly IPreviewDialogService _dialogService;
         private readonly PreviewShellServicesViewModel _shellServicesViewModel;
@@ -91,12 +92,18 @@ namespace PhoenixTranslator.UIManagement.Preview
                 ConfirmSettingsReset,
                 ConfirmSettingsDiscard,
                 OpenLegacyWorkspace);
+            _advancedToolsViewModel = new PreviewAdvancedToolsViewModel(
+                new LegacyPreviewAdvancedToolsStore(),
+                _shellViewModel,
+                ConfirmDatabaseMutation,
+                OpenDatabase);
             DataContext = _shellViewModel;
             ProjectHub.DataContext = _projectHubViewModel;
             TranslationWorkspace.DataContext = _translationWorkspaceViewModel;
             ReviewQualityWorkspace.DataContext = _reviewQualityViewModel;
             HistoryUpdateWorkspace.DataContext = _historyUpdateViewModel;
             SettingsWorkspace.DataContext = _settingsViewModel;
+            AdvancedToolsWorkspace.DataContext = _advancedToolsViewModel;
             ShellServicesWorkspace.DataContext = _shellServicesViewModel;
             ShellServicesWorkspace.CloseRequested += ShellServicesCloseRequested;
             _shellViewModel.PropertyChanged += ShellViewModelPropertyChanged;
@@ -269,6 +276,23 @@ namespace PhoenixTranslator.UIManagement.Preview
                 PreviewDialogSeverity.Warning);
         }
 
+        private bool ConfirmDatabaseMutation()
+        {
+            return ShowConfirmation(
+                PreviewMessageCatalog.Get("Advanced_Database_Mutation_Confirmation"),
+                PreviewMessageCatalog.Get("Advanced_Database_Mutation_ConfirmationTitle"),
+                PreviewDialogSeverity.Destructive);
+        }
+
+        private void OpenDatabase(bool isReadOnly)
+        {
+            DeFine.CloseDataBaseView();
+            DeFine.DataBaseView = new DataBaseView();
+            DeFine.DataBaseView.SetReadOnlyMode(isReadOnly);
+            DeFine.DataBaseView.Owner = this;
+            DeFine.DataBaseView.Show();
+        }
+
         private void OpenLegacyWorkspace()
         {
             if (_legacyWorkspace == null)
@@ -355,6 +379,9 @@ namespace PhoenixTranslator.UIManagement.Preview
                 case PreviewShellDestination.Settings:
                     SettingsWorkspace.FocusInitialControl();
                     break;
+                case PreviewShellDestination.AdvancedTools:
+                    AdvancedToolsWorkspace.FocusInitialControl();
+                    break;
                 default:
                     PrimaryNavigation.Focus();
                     break;
@@ -406,6 +433,7 @@ namespace PhoenixTranslator.UIManagement.Preview
             }
 
             _settingsViewModel.Dispose();
+            _advancedToolsViewModel.Dispose();
             ShellServicesWorkspace.CloseRequested -= ShellServicesCloseRequested;
             _shellViewModel.PropertyChanged -= ShellViewModelPropertyChanged;
             _projectHubViewModel.Dispose();


### PR DESCRIPTION
## Summary

- replace the generic Advanced Tools fallback with a categorized WPF workspace
- stage, validate, reorder, enable, disable, apply, and cancel provider pipeline changes
- add a cancellable custom provider editor with safe connectivity probing and existing Phoenix request mappings
- separate read-only terminology browsing from explicitly confirmed mutation mode
- relocate token telemetry and accessible preset explanations
- correct the shell-services overlay binding found during visual validation
- bump Phoenix Translator to 2.0.0.17

## Validation

- Release x64 solution build
- 50 regression tests
- preview message verification
- `git diff --check`
- UI Automation and visual inspection at 1100 × 700 and 1280 × 800

Closes #60