### PR TITLE
Improve large-project responsiveness

### DIFF
--- a/PhoenixTranslator.PresetTests/Program.cs
+++ b/PhoenixTranslator.PresetTests/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -19,8 +20,14 @@ namespace PhoenixTranslator.PresetTests
 {
     internal static class Program
     {
-        private static int Main()
+        private static int Main(string[] args)
         {
+            if (args != null && args.Any(argument =>
+                string.Equals(argument, "--performance", StringComparison.OrdinalIgnoreCase)))
+            {
+                return RunPerformanceValidation();
+            }
+
             var tests = new Dictionary<string, Action>
             {
                 { nameof(PreservesCustomSettingsOnLoad), PreservesCustomSettingsOnLoad },
@@ -47,6 +54,8 @@ namespace PhoenixTranslator.PresetTests
                 { nameof(HandlesPreviewTranslationFailures), HandlesPreviewTranslationFailures },
                 { nameof(CancelsPreviewTranslationWork), CancelsPreviewTranslationWork },
                 { nameof(FiltersLargePreviewTranslationProject), FiltersLargePreviewTranslationProject },
+                { nameof(CancelsLargeQualityValidation), CancelsLargeQualityValidation },
+                { nameof(CancelsLargeRevisionComparison), CancelsLargeRevisionComparison },
                 { nameof(LoadsAndNavigatesPreviewContext), LoadsAndNavigatesPreviewContext },
                 { nameof(DiscardsStalePreviewContext), DiscardsStalePreviewContext },
                 { nameof(DistinguishesEmptyAndFailedPreviewContext), DistinguishesEmptyAndFailedPreviewContext },
@@ -778,6 +787,175 @@ namespace PhoenixTranslator.PresetTests
             viewModel.Dispose();
         }
 
+        private static void CancelsLargeQualityValidation()
+        {
+            var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+            bool cancelled = false;
+            try
+            {
+                new PreviewQualityAnalyzer().Analyze(CreatePerformanceEntries(10000), cancellation.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                cancelled = true;
+            }
+
+            AssertEqual(true, cancelled,
+                "Large-project quality validation must honor cooperative cancellation.");
+        }
+
+        private static void CancelsLargeRevisionComparison()
+        {
+            var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+            bool cancelled = false;
+            try
+            {
+                new PreviewProjectComparisonService().Compare(
+                    CreatePerformanceEntries(10000),
+                    CreatePerformanceEntries(10000),
+                    cancellation.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                cancelled = true;
+            }
+
+            AssertEqual(true, cancelled,
+                "Large-project revision comparison must honor cooperative cancellation.");
+        }
+
+        private static int RunPerformanceValidation()
+        {
+            Console.WriteLine("Phoenix Translator preview performance validation");
+            Console.WriteLine("Runtime,{0}", Environment.Version);
+            Console.WriteLine("LogicalProcessors,{0}", Environment.ProcessorCount);
+            Console.WriteLine("Profile,Entries,OpenMs,FilterMs,ValidationMs,ComparisonMs,Result");
+
+            int failures = 0;
+            failures += RunPerformanceProfile("small", 1000, 500, 100, 500, 500) ? 0 : 1;
+            failures += RunPerformanceProfile("medium", 25000, 1500, 250, 2000, 1500) ? 0 : 1;
+            failures += RunPerformanceProfile("large", 100000, 5000, 750, 7000, 5000) ? 0 : 1;
+            failures += ValidateRepeatedLifecycle() ? 0 : 1;
+            return failures == 0 ? 0 : 1;
+        }
+
+        private static bool RunPerformanceProfile(
+            string name,
+            int entryCount,
+            long openBudget,
+            long filterBudget,
+            long validationBudget,
+            long comparisonBudget)
+        {
+            IReadOnlyList<PreviewTranslationEntry> entries = CreatePerformanceEntries(entryCount);
+            var project = new FakePreviewTranslationProject(entries);
+            var shell = new PreviewShellViewModel(() => { });
+            var workspace = new PreviewTranslationWorkspaceViewModel(
+                () => project.Path,
+                () => { },
+                shell,
+                path => project);
+
+            long openMilliseconds = MeasureMilliseconds(
+                () => workspace.OpenProjectAsync(project.Path).GetAwaiter().GetResult());
+            long filterMilliseconds = MeasureMilliseconds(() => workspace.SearchText = "source " + (entryCount - 1));
+            workspace.SearchText = string.Empty;
+            long validationMilliseconds = MeasureMilliseconds(
+                () => new PreviewQualityAnalyzer().Analyze(entries));
+            long comparisonMilliseconds = MeasureMilliseconds(
+                () => new PreviewProjectComparisonService().Compare(entries, entries));
+            workspace.Dispose();
+
+            bool passed = openMilliseconds <= openBudget && filterMilliseconds <= filterBudget &&
+                validationMilliseconds <= validationBudget && comparisonMilliseconds <= comparisonBudget;
+            Console.WriteLine(string.Format(
+                CultureInfo.InvariantCulture,
+                "{0},{1},{2},{3},{4},{5},{6}",
+                name,
+                entryCount,
+                openMilliseconds,
+                filterMilliseconds,
+                validationMilliseconds,
+                comparisonMilliseconds,
+                passed ? "PASS" : "FAIL"));
+            return passed;
+        }
+
+        private static IReadOnlyList<PreviewTranslationEntry> CreatePerformanceEntries(int count)
+        {
+            return Enumerable.Range(0, count)
+                .Select(index => new PreviewTranslationEntry(
+                    index.ToString(CultureInfo.InvariantCulture),
+                    index % 4 == 0 ? "MCM" : index % 4 == 1 ? "XML" : index % 4 == 2 ? "PEX" : "ESP",
+                    "RECORD_" + index.ToString(CultureInfo.InvariantCulture),
+                    "Synthetic source " + index.ToString(CultureInfo.InvariantCulture) + " {0}",
+                    index % 5 == 0 ? string.Empty : "Synthetic target " + index.ToString(CultureInfo.InvariantCulture) + " {0}",
+                    index % 7 == 0 ? 40 : 100))
+                .ToList();
+        }
+
+        private static long MeasureMilliseconds(Action action)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            action();
+            stopwatch.Stop();
+            return stopwatch.ElapsedMilliseconds;
+        }
+
+        private static bool ValidateRepeatedLifecycle()
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            long managedBefore = GC.GetTotalMemory(true);
+            using (Process process = Process.GetCurrentProcess())
+            {
+                process.Refresh();
+                long privateBefore = process.PrivateMemorySize64;
+                int handlesBefore = process.HandleCount;
+                RunLifecycleCycles(5, 100000);
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+                process.Refresh();
+                long managedDelta = Math.Max(0, GC.GetTotalMemory(true) - managedBefore);
+                long privateDelta = Math.Max(0, process.PrivateMemorySize64 - privateBefore);
+                int handleDelta = Math.Max(0, process.HandleCount - handlesBefore);
+                bool passed = managedDelta <= 64L * 1024 * 1024 &&
+                    privateDelta <= 64L * 1024 * 1024 && handleDelta <= 16;
+                Console.WriteLine(
+                    "Lifecycle,5x100000,ManagedDeltaBytes={0},PrivateDeltaBytes={1},HandleDelta={2},{3}",
+                    managedDelta,
+                    privateDelta,
+                    handleDelta,
+                    passed ? "PASS" : "FAIL");
+                return passed;
+            }
+        }
+
+        private static void RunLifecycleCycles(int cycles, int entryCount)
+        {
+            for (int cycle = 0; cycle < cycles; cycle++)
+            {
+                IReadOnlyList<PreviewTranslationEntry> entries = CreatePerformanceEntries(entryCount);
+                var project = new FakePreviewTranslationProject(entries);
+                var shell = new PreviewShellViewModel(() => { });
+                var workspace = new PreviewTranslationWorkspaceViewModel(
+                    () => project.Path,
+                    () => { },
+                    shell,
+                    path => project);
+                workspace.OpenProjectAsync(project.Path).GetAwaiter().GetResult();
+                project.Translate(entries[cycle % entries.Count], CancellationToken.None);
+                new PreviewQualityAnalyzer().Analyze(entries);
+                new PreviewProjectComparisonService().Compare(entries, entries);
+                project.Export("synthetic-output", CancellationToken.None);
+                workspace.Dispose();
+            }
+        }
+
         private static void LoadsAndNavigatesPreviewContext()
         {
             var first = CreateEntry("first", "needle", string.Empty);
@@ -1087,6 +1265,7 @@ namespace PhoenixTranslator.PresetTests
                 workspace.OpenProjectAsync(project.Path).GetAwaiter().GetResult();
                 var cancelled = new PreviewReviewQualityViewModel(shell, workspace, new PreviewQualityAnalyzer(),
                     new PreviewReviewStateStore(stateDirectory), count => false, () => { });
+                cancelled.RevalidateAsync().GetAwaiter().GetResult();
 
                 cancelled.ApproveScopeCommand.Execute(null);
                 AssertEqual(PreviewReviewState.Unreviewed, entries[0].ReviewState,
@@ -1095,6 +1274,7 @@ namespace PhoenixTranslator.PresetTests
 
                 var review = new PreviewReviewQualityViewModel(shell, workspace, new PreviewQualityAnalyzer(),
                     new PreviewReviewStateStore(stateDirectory), count => count == 2, () => { });
+                review.RevalidateAsync().GetAwaiter().GetResult();
                 review.ApproveScopeCommand.Execute(null);
                 AssertEqual(PreviewReviewState.Approved, entries[0].ReviewState,
                     "Confirmed bulk approval must update the visible eligible scope.");
@@ -1167,6 +1347,7 @@ namespace PhoenixTranslator.PresetTests
                 workspace.OpenProjectAsync(project.Path).GetAwaiter().GetResult();
                 var review = new PreviewReviewQualityViewModel(shell, workspace, new PreviewQualityAnalyzer(),
                     new PreviewReviewStateStore(stateDirectory), count => true, () => { });
+                review.RevalidateAsync().GetAwaiter().GetResult();
                 shell.CurrentDestination = PreviewShellDestination.Quality;
                 review.SelectedFinding = review.Findings.Single(finding => finding.RuleId == "technical-string");
 

--- a/Phoenix_Translator/Application/PreviewHistoryUpdateViewModel.cs
+++ b/Phoenix_Translator/Application/PreviewHistoryUpdateViewModel.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 
@@ -61,6 +62,7 @@ namespace PhoenixTranslator.ApplicationLayer
         private string _previousRevisionName;
         private bool _isBusy;
         private List<UpdateSnapshot> _undoSnapshots;
+        private CancellationTokenSource _comparisonCancellation;
 
         /// <summary>
         /// Creates the combined history and project-update workflow.
@@ -113,6 +115,9 @@ namespace PhoenixTranslator.ApplicationLayer
 
             OpenProjectCommand = workspace.OpenProjectCommand;
             CompareRevisionCommand = new PreviewShellCommand(parameter => CompareSelectedRevision(), parameter => HasProject && !IsBusy);
+            CancelComparisonCommand = new PreviewShellCommand(
+                parameter => CancelComparison(),
+                parameter => IsBusy && _comparisonCancellation != null);
             ReuseSelectedCommand = new PreviewShellCommand(parameter => ReuseSelected(), parameter => CanReuseSelected && !IsBusy);
             ReuseVisibleCommand = new PreviewShellCommand(parameter => ReuseVisible(), parameter => ReusableVisibleCount > 0 && !IsBusy);
             KeepCurrentCommand = new PreviewShellCommand(parameter => KeepCurrent(), parameter => IsSelectedConflict && !IsBusy);
@@ -142,6 +147,9 @@ namespace PhoenixTranslator.ApplicationLayer
 
         /// <summary>Gets the command that selects and compares a previous revision.</summary>
         public ICommand CompareRevisionCommand { get; private set; }
+
+        /// <summary>Gets the command that cooperatively cancels an active revision comparison.</summary>
+        public ICommand CancelComparisonCommand { get; private set; }
 
         /// <summary>Gets the command that explicitly reuses the selected prior target.</summary>
         public ICommand ReuseSelectedCommand { get; private set; }
@@ -276,6 +284,7 @@ namespace PhoenixTranslator.ApplicationLayer
         /// <inheritdoc />
         public void Dispose()
         {
+            _comparisonCancellation?.Cancel();
             _workspace.ProjectChanged -= WorkspaceProjectChanged;
             _shell.PropertyChanged -= ShellPropertyChanged;
             _previousProject?.Dispose();
@@ -295,15 +304,20 @@ namespace PhoenixTranslator.ApplicationLayer
                 return;
             }
 
+            var cancellation = new CancellationTokenSource();
+            _comparisonCancellation = cancellation;
             SetBusy(true);
             _shell.SetOperation("Update_Comparison_Progress", 20);
             IPreviewTranslationProject previousProject = null;
             try
             {
-                previousProject = await Task.Run(() => _openProject(path));
+                previousProject = await Task.Run(() => _openProject(path), cancellation.Token);
+                cancellation.Token.ThrowIfCancellationRequested();
                 IReadOnlyList<PreviewTranslationEntry> currentEntries = _workspace.ProjectEntries;
                 IReadOnlyList<PreviewProjectComparisonItem> comparison = await Task.Run(
-                    () => _comparisonService.Compare(currentEntries, previousProject.Entries));
+                    () => _comparisonService.Compare(currentEntries, previousProject.Entries, cancellation.Token),
+                    cancellation.Token);
+                cancellation.Token.ThrowIfCancellationRequested();
                 _previousProject?.Dispose();
                 _previousProject = previousProject;
                 previousProject = null;
@@ -315,6 +329,9 @@ namespace PhoenixTranslator.ApplicationLayer
                 AppendProjectHistory("Compared", _previousRevisionName);
                 _shell.ShowNotification(PreviewShellNotificationSeverity.Success, "Update_Comparison_Completed");
             }
+            catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+            {
+            }
             catch (Exception exception) when (exception is IOException || exception is UnauthorizedAccessException ||
                 exception is InvalidDataException || exception is InvalidOperationException)
             {
@@ -324,8 +341,18 @@ namespace PhoenixTranslator.ApplicationLayer
             {
                 previousProject?.Dispose();
                 _shell.CompleteOperation();
+                if (ReferenceEquals(_comparisonCancellation, cancellation))
+                {
+                    _comparisonCancellation = null;
+                }
+                cancellation.Dispose();
                 SetBusy(false);
             }
+        }
+
+        private void CancelComparison()
+        {
+            _comparisonCancellation?.Cancel();
         }
 
         private void ReuseSelected()
@@ -549,6 +576,7 @@ namespace PhoenixTranslator.ApplicationLayer
         private void RaiseCommandAvailability()
         {
             ((PreviewShellCommand)CompareRevisionCommand).RaiseCanExecuteChanged();
+            ((PreviewShellCommand)CancelComparisonCommand).RaiseCanExecuteChanged();
             ((PreviewShellCommand)ReuseSelectedCommand).RaiseCanExecuteChanged();
             ((PreviewShellCommand)ReuseVisibleCommand).RaiseCanExecuteChanged();
             ((PreviewShellCommand)KeepCurrentCommand).RaiseCanExecuteChanged();

--- a/Phoenix_Translator/Application/PreviewProjectComparison.cs
+++ b/Phoenix_Translator/Application/PreviewProjectComparison.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace PhoenixTranslator.ApplicationLayer
 {
@@ -109,10 +110,12 @@ namespace PhoenixTranslator.ApplicationLayer
         /// </summary>
         /// <param name="currentEntries">The active project entries.</param>
         /// <param name="previousEntries">The selected previous revision entries.</param>
+        /// <param name="cancellationToken">Cancels comparison between stable entry identities.</param>
         /// <returns>Stable ordered comparison results.</returns>
         internal IReadOnlyList<PreviewProjectComparisonItem> Compare(
             IReadOnlyList<PreviewTranslationEntry> currentEntries,
-            IReadOnlyList<PreviewTranslationEntry> previousEntries)
+            IReadOnlyList<PreviewTranslationEntry> previousEntries,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             if (currentEntries == null)
             {
@@ -125,10 +128,13 @@ namespace PhoenixTranslator.ApplicationLayer
             }
 
             var ambiguousKeys = new HashSet<string>(StringComparer.Ordinal);
-            Dictionary<string, PreviewTranslationEntry> current = IndexEntries(currentEntries, ambiguousKeys);
-            Dictionary<string, PreviewTranslationEntry> previous = IndexEntries(previousEntries, ambiguousKeys);
+            Dictionary<string, PreviewTranslationEntry> current = IndexEntries(
+                currentEntries, ambiguousKeys, cancellationToken);
+            Dictionary<string, PreviewTranslationEntry> previous = IndexEntries(
+                previousEntries, ambiguousKeys, cancellationToken);
             return current.Keys.Union(previous.Keys, StringComparer.Ordinal)
                 .OrderBy(key => key, StringComparer.Ordinal)
+                .Select(key => ThrowIfCancelled(key, cancellationToken))
                 .Select(key => ambiguousKeys.Contains(key)
                     ? new PreviewProjectComparisonItem(
                         key, PreviewRevisionComparisonState.Conflict, Get(current, key), Get(previous, key))
@@ -138,11 +144,13 @@ namespace PhoenixTranslator.ApplicationLayer
 
         private static Dictionary<string, PreviewTranslationEntry> IndexEntries(
             IEnumerable<PreviewTranslationEntry> entries,
-            ISet<string> ambiguousKeys)
+            ISet<string> ambiguousKeys,
+            CancellationToken cancellationToken)
         {
             var indexed = new Dictionary<string, PreviewTranslationEntry>(StringComparer.Ordinal);
             foreach (PreviewTranslationEntry entry in entries)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (entry == null || string.IsNullOrEmpty(entry.Key))
                 {
                     continue;
@@ -159,6 +167,12 @@ namespace PhoenixTranslator.ApplicationLayer
             }
 
             return indexed;
+        }
+
+        private static string ThrowIfCancelled(string key, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return key;
         }
 
         private static PreviewTranslationEntry Get(

--- a/Phoenix_Translator/Application/PreviewQualityAnalyzer.cs
+++ b/Phoenix_Translator/Application/PreviewQualityAnalyzer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace PhoenixTranslator.ApplicationLayer
 {
@@ -22,8 +23,11 @@ namespace PhoenixTranslator.ApplicationLayer
         /// Analyzes normalized entries without changing their content.
         /// </summary>
         /// <param name="entries">The project entries to inspect.</param>
+        /// <param name="cancellationToken">Cancels validation between normalized entries.</param>
         /// <returns>A stable ordered set of normalized findings.</returns>
-        internal IReadOnlyList<PreviewQualityFinding> Analyze(IReadOnlyList<PreviewTranslationEntry> entries)
+        internal IReadOnlyList<PreviewQualityFinding> Analyze(
+            IReadOnlyList<PreviewTranslationEntry> entries,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             if (entries == null)
             {
@@ -31,16 +35,34 @@ namespace PhoenixTranslator.ApplicationLayer
             }
 
             var findings = new List<PreviewQualityFinding>();
-            var inconsistentSources = new HashSet<string>(
-                entries.Where(entry => !string.IsNullOrWhiteSpace(entry.SourceText))
-                    .GroupBy(entry => entry.SourceText, StringComparer.Ordinal)
-                    .Where(group => group.Select(entry => entry.TargetText ?? string.Empty)
-                        .Distinct(StringComparer.Ordinal).Count() > 1)
-                    .Select(group => group.Key),
-                StringComparer.Ordinal);
+            var firstTargets = new Dictionary<string, string>(StringComparer.Ordinal);
+            var inconsistentSources = new HashSet<string>(StringComparer.Ordinal);
+            foreach (PreviewTranslationEntry entry in entries)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (string.IsNullOrWhiteSpace(entry.SourceText))
+                {
+                    continue;
+                }
+
+                string target = entry.TargetText ?? string.Empty;
+                string firstTarget;
+                if (firstTargets.TryGetValue(entry.SourceText, out firstTarget))
+                {
+                    if (!string.Equals(firstTarget, target, StringComparison.Ordinal))
+                    {
+                        inconsistentSources.Add(entry.SourceText);
+                    }
+                }
+                else
+                {
+                    firstTargets.Add(entry.SourceText, target);
+                }
+            }
 
             foreach (PreviewTranslationEntry entry in entries)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (string.IsNullOrWhiteSpace(entry.TargetText))
                 {
                     findings.Add(Create(entry, "untranslated", PreviewFindingSeverity.Error,
@@ -78,12 +100,33 @@ namespace PhoenixTranslator.ApplicationLayer
                 }
             }
 
-            return findings
-                .OrderByDescending(finding => finding.Severity)
-                .ThenBy(finding => finding.Entry.Type, StringComparer.OrdinalIgnoreCase)
-                .ThenBy(finding => finding.Entry.Key, StringComparer.Ordinal)
-                .ThenBy(finding => finding.RuleId, StringComparer.Ordinal)
-                .ToList();
+            findings.Sort((left, right) => CompareFindings(left, right, cancellationToken));
+            cancellationToken.ThrowIfCancellationRequested();
+            return findings;
+        }
+
+        private static int CompareFindings(
+            PreviewQualityFinding left,
+            PreviewQualityFinding right,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            int comparison = right.Severity.CompareTo(left.Severity);
+            if (comparison != 0)
+            {
+                return comparison;
+            }
+
+            comparison = StringComparer.OrdinalIgnoreCase.Compare(left.Entry.Type, right.Entry.Type);
+            if (comparison != 0)
+            {
+                return comparison;
+            }
+
+            comparison = StringComparer.Ordinal.Compare(left.Entry.Key, right.Entry.Key);
+            return comparison != 0
+                ? comparison
+                : StringComparer.Ordinal.Compare(left.RuleId, right.RuleId);
         }
 
         private static PreviewQualityFinding Create(

--- a/Phoenix_Translator/Application/PreviewReviewQualityViewModel.cs
+++ b/Phoenix_Translator/Application/PreviewReviewQualityViewModel.cs
@@ -4,6 +4,8 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Input;
 
 namespace PhoenixTranslator.ApplicationLayer
@@ -29,6 +31,8 @@ namespace PhoenixTranslator.ApplicationLayer
         private string _selectedReviewFilter;
         private string _selectedSeverityFilter;
         private string _selectedFindingTypeFilter;
+        private CancellationTokenSource _validationCancellation;
+        private bool _isValidating;
 
         /// <summary>
         /// Creates a review and quality workflow over the active translation workspace.
@@ -84,7 +88,12 @@ namespace PhoenixTranslator.ApplicationLayer
             UndoBulkCommand = new PreviewShellCommand(parameter => UndoBulk(), parameter => _lastBulkStates != null);
             AcknowledgeFindingCommand = new PreviewShellCommand(parameter => AcknowledgeFinding(), CanAcknowledgeFinding);
             GoToEntryCommand = new PreviewShellCommand(parameter => GoToEntry(), parameter => SelectedFinding != null);
-            RevalidateCommand = new PreviewShellCommand(parameter => RebuildFindings());
+            RevalidateCommand = new PreviewShellCommand(
+                parameter => StartValidation(0),
+                parameter => HasProject && !IsValidating);
+            CancelValidationCommand = new PreviewShellCommand(
+                parameter => CancelValidation(),
+                parameter => IsValidating);
             OpenProjectCommand = _translationWorkspace.OpenProjectCommand;
             OpenLegacyWorkspaceCommand = new PreviewShellCommand(parameter => _openLegacyWorkspace());
 
@@ -333,6 +342,11 @@ namespace PhoenixTranslator.ApplicationLayer
         public ICommand RevalidateCommand { get; private set; }
 
         /// <summary>
+        /// Gets the command that cooperatively cancels the active quality validation.
+        /// </summary>
+        public ICommand CancelValidationCommand { get; private set; }
+
+        /// <summary>
         /// Gets the shared command that opens a supported translation project.
         /// </summary>
         public ICommand OpenProjectCommand { get; private set; }
@@ -342,9 +356,30 @@ namespace PhoenixTranslator.ApplicationLayer
         /// </summary>
         public ICommand OpenLegacyWorkspaceCommand { get; private set; }
 
+        /// <summary>
+        /// Gets whether quality validation is running outside the UI thread.
+        /// </summary>
+        public bool IsValidating
+        {
+            get => _isValidating;
+            private set
+            {
+                if (_isValidating == value)
+                {
+                    return;
+                }
+
+                _isValidating = value;
+                OnPropertyChanged();
+                RaiseCommandAvailability();
+            }
+        }
+
         /// <inheritdoc />
         public void Dispose()
         {
+            _validationCancellation?.Cancel();
+            _validationCancellation = null;
             _shell.PropertyChanged -= ShellPropertyChanged;
             _translationWorkspace.ProjectChanged -= TranslationWorkspaceProjectChanged;
             UnsubscribeEntries();
@@ -388,7 +423,7 @@ namespace PhoenixTranslator.ApplicationLayer
                 _acknowledgedFindingIds.UnionWith(snapshot.AcknowledgedFindingIds);
             }
 
-            RebuildFindings();
+            StartValidation(0);
             OnPropertyChanged(nameof(HasProject));
             RaiseCommandAvailability();
         }
@@ -407,7 +442,7 @@ namespace PhoenixTranslator.ApplicationLayer
         {
             if (e.PropertyName == nameof(PreviewTranslationEntry.TargetText))
             {
-                RebuildFindings();
+                StartValidation(150);
                 PersistState();
             }
             else if (e.PropertyName == nameof(PreviewTranslationEntry.ReviewState))
@@ -416,11 +451,62 @@ namespace PhoenixTranslator.ApplicationLayer
             }
         }
 
-        private void RebuildFindings()
+        /// <summary>
+        /// Rebuilds normalized findings on a worker thread and discards stale results.
+        /// </summary>
+        /// <param name="delayMilliseconds">The debounce delay before validation starts.</param>
+        /// <returns>A task that completes when this validation request is applied or superseded.</returns>
+        internal async Task RevalidateAsync(int delayMilliseconds = 0)
         {
-            _allFindings = HasProject
-                ? _analyzer.Analyze(_translationWorkspace.ProjectEntries)
-                : new List<PreviewQualityFinding>();
+            _validationCancellation?.Cancel();
+            var cancellation = new CancellationTokenSource();
+            _validationCancellation = cancellation;
+            IsValidating = true;
+
+            try
+            {
+                if (delayMilliseconds > 0)
+                {
+                    await Task.Delay(delayMilliseconds, cancellation.Token);
+                }
+
+                IReadOnlyList<PreviewTranslationEntry> entries = HasProject
+                    ? _translationWorkspace.ProjectEntries.ToList()
+                    : new List<PreviewTranslationEntry>();
+                IReadOnlyList<PreviewQualityFinding> findings = await Task.Run(
+                    () => _analyzer.Analyze(entries, cancellation.Token),
+                    cancellation.Token);
+                cancellation.Token.ThrowIfCancellationRequested();
+                _allFindings = findings;
+                ApplyFindings();
+            }
+            catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+            {
+            }
+            finally
+            {
+                if (ReferenceEquals(_validationCancellation, cancellation))
+                {
+                    _validationCancellation = null;
+                    IsValidating = false;
+                }
+
+                cancellation.Dispose();
+            }
+        }
+
+        private async void StartValidation(int delayMilliseconds)
+        {
+            await RevalidateAsync(delayMilliseconds);
+        }
+
+        private void CancelValidation()
+        {
+            _validationCancellation?.Cancel();
+        }
+
+        private void ApplyFindings()
+        {
             foreach (PreviewQualityFinding finding in _allFindings.Where(finding =>
                 _acknowledgedFindingIds.Contains(finding.StableId)))
             {
@@ -621,6 +707,8 @@ namespace PhoenixTranslator.ApplicationLayer
             RaiseCanExecuteChanged(UndoBulkCommand);
             RaiseCanExecuteChanged(AcknowledgeFindingCommand);
             RaiseCanExecuteChanged(GoToEntryCommand);
+            RaiseCanExecuteChanged(RevalidateCommand);
+            RaiseCanExecuteChanged(CancelValidationCommand);
         }
 
         private static void RaiseCanExecuteChanged(ICommand command)

--- a/Phoenix_Translator/Properties/AssemblyInfo.cs
+++ b/Phoenix_Translator/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Windows;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.0.0.18")]
-[assembly: AssemblyFileVersion("2.0.0.18")]
+[assembly: AssemblyVersion("2.0.0.19")]
+[assembly: AssemblyFileVersion("2.0.0.19")]

--- a/Phoenix_Translator/Properties/Resources.resx
+++ b/Phoenix_Translator/Properties/Resources.resx
@@ -363,6 +363,7 @@
   <data name="Quality_Resolution_Resolved" xml:space="preserve"><value>Resolved</value><comment>The underlying condition no longer exists.</comment></data>
   <data name="Quality_FindingCount" xml:space="preserve"><value>{0} findings</value><comment>Visible finding count. Placeholders: {0}=non-negative integer.</comment></data>
   <data name="Quality_Revalidate_Action" xml:space="preserve"><value>_Run validation</value><comment>Rebuilds normalized findings without changing translation content and defines its access key.</comment></data>
+  <data name="Quality_Validation_Progress" xml:space="preserve"><value>Validating…</value><comment>Visible progress state while quality validation runs outside the UI thread.</comment></data>
   <data name="Quality_FindingDetails_Title" xml:space="preserve"><value>Finding details</value><comment>Heading for the selected finding metadata.</comment></data>
   <data name="Quality_Source_Label" xml:space="preserve"><value>Diagnostic source</value><comment>Metadata label for the component that emitted a finding.</comment></data>
   <data name="Quality_Resolution_Label" xml:space="preserve"><value>Resolution</value><comment>Metadata label for the finding resolution.</comment></data>

--- a/Phoenix_Translator/UIManagement/Preview/PreviewAdvancedToolsView.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewAdvancedToolsView.xaml
@@ -75,7 +75,10 @@
                         <StackPanel><TextBlock Style="{StaticResource AdvancedHeading}" Text="{localization:PreviewMessage Advanced_Pipeline_Title}" />
                             <TextBlock Foreground="{StaticResource PreviewBrushTextSecondary}" Text="{localization:PreviewMessage Advanced_Pipeline_Description}" TextWrapping="Wrap" /></StackPanel>
                         <ListBox Grid.Row="1" Margin="0,16" MinHeight="260" ItemsSource="{Binding PipelineEntries}" SelectedItem="{Binding SelectedPipelineEntry}" ItemContainerStyle="{StaticResource AdvancedPipelineItem}"
-                                 Background="{StaticResource PreviewBrushSurfaceCanvas}" BorderBrush="{StaticResource PreviewBrushBorder}" AutomationProperties.Name="{localization:PreviewMessage Accessibility_Advanced_Pipeline_Name}">
+                                 Background="{StaticResource PreviewBrushSurfaceCanvas}" BorderBrush="{StaticResource PreviewBrushBorder}"
+                                 ScrollViewer.CanContentScroll="True" VirtualizingPanel.IsVirtualizing="True"
+                                 VirtualizingPanel.VirtualizationMode="Recycling"
+                                 AutomationProperties.Name="{localization:PreviewMessage Accessibility_Advanced_Pipeline_Name}">
                             <ListBox.ItemTemplate><DataTemplate><Grid Margin="8,5"><Grid.ColumnDefinitions><ColumnDefinition Width="Auto" /><ColumnDefinition Width="16" /><ColumnDefinition Width="*" /><ColumnDefinition Width="160" /></Grid.ColumnDefinitions>
                                 <CheckBox IsChecked="{Binding IsEnabled}" VerticalAlignment="Center" AutomationProperties.Name="{Binding Name}" />
                                 <TextBlock Grid.Column="2" VerticalAlignment="Center" Foreground="{StaticResource PreviewBrushTextPrimary}" Text="{Binding Name}" />

--- a/Phoenix_Translator/UIManagement/Preview/PreviewHistoryUpdateView.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewHistoryUpdateView.xaml
@@ -80,7 +80,8 @@
                                    Text="{localization:PreviewMessage History_Timeline_Title}" />
                         <ListBox x:Name="HistoryTimeline" ItemsSource="{Binding HistoryEntries}" SelectedItem="{Binding SelectedHistoryEntry}"
                                  ItemContainerStyle="{StaticResource HistoryListItem}" Background="Transparent"
-                                 BorderThickness="0" VirtualizingPanel.IsVirtualizing="True"
+                                 BorderThickness="0" ScrollViewer.CanContentScroll="True"
+                                 VirtualizingPanel.IsVirtualizing="True"
                                  VirtualizingPanel.VirtualizationMode="Recycling"
                                  AutomationProperties.Name="{localization:PreviewMessage Accessibility_History_Timeline_Name}">
                             <ListBox.ItemTemplate>
@@ -146,6 +147,10 @@
                                 Command="{Binding OpenProjectCommand}" Content="{localization:PreviewMessage Workspace_Open_Action}" />
                         <Button Style="{StaticResource PreviewButtonPrimary}" Command="{Binding CompareRevisionCommand}"
                                 Content="{localization:PreviewMessage Update_Compare_Action}" />
+                        <Button Margin="8,0,0,0" Style="{StaticResource PreviewButtonSecondary}"
+                                Command="{Binding CancelComparisonCommand}"
+                                Content="{localization:PreviewMessage Common_Action_Cancel}"
+                                Visibility="{Binding IsBusy, Converter={StaticResource BooleanToVisibility}}" />
                     </StackPanel>
                 </Grid>
             </Border>
@@ -165,6 +170,7 @@
                         </StackPanel>
                         <ListBox ItemsSource="{Binding ComparisonItems}" SelectedItem="{Binding SelectedComparisonItem}"
                                  ItemContainerStyle="{StaticResource HistoryListItem}" Background="Transparent" BorderThickness="0"
+                                 ScrollViewer.CanContentScroll="True"
                                  VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling"
                                  AutomationProperties.Name="{localization:PreviewMessage Accessibility_Update_Comparison_Name}">
                             <ListBox.ItemTemplate>

--- a/Phoenix_Translator/UIManagement/Preview/PreviewReviewQualityView.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewReviewQualityView.xaml
@@ -85,12 +85,20 @@
                           Visibility="{Binding IsQualityMode, Converter={StaticResource BooleanToVisibility}}"
                           AutomationProperties.Name="{localization:PreviewMessage Quality_Filter_Type_Name}" />
                 <StackPanel Grid.Column="6" Orientation="Horizontal">
+                    <TextBlock Margin="0,0,10,0" VerticalAlignment="Center"
+                               Foreground="{StaticResource PreviewBrushTextMuted}"
+                               Text="{localization:PreviewMessage Quality_Validation_Progress}"
+                               Visibility="{Binding IsValidating, Converter={StaticResource BooleanToVisibility}}" />
                     <Button Margin="0,0,8,0" Style="{StaticResource PreviewButtonSecondary}"
                             Command="{Binding OpenProjectCommand}"
                             Content="{localization:PreviewMessage Workspace_Open_Action}" />
                     <Button Style="{StaticResource PreviewButtonSecondary}" Command="{Binding RevalidateCommand}"
                             Content="{localization:PreviewMessage Quality_Revalidate_Action}"
                             Visibility="{Binding IsQualityMode, Converter={StaticResource BooleanToVisibility}}" />
+                    <Button Margin="8,0,0,0" Style="{StaticResource PreviewButtonSecondary}"
+                            Command="{Binding CancelValidationCommand}"
+                            Content="{localization:PreviewMessage Common_Action_Cancel}"
+                            Visibility="{Binding IsValidating, Converter={StaticResource BooleanToVisibility}}" />
                 </StackPanel>
             </Grid>
         </Border>

--- a/Phoenix_Translator/UIManagement/Preview/PreviewShellServicesView.xaml
+++ b/Phoenix_Translator/UIManagement/Preview/PreviewShellServicesView.xaml
@@ -103,7 +103,9 @@
                         </WrapPanel>
                         <ListBox Grid.Row="1" ItemsSource="{Binding Entries}" Background="Transparent"
                                  BorderBrush="{StaticResource PreviewBrushBorder}" BorderThickness="1"
-                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                 ScrollViewer.CanContentScroll="True" VirtualizingPanel.IsVirtualizing="True"
+                                 VirtualizingPanel.VirtualizationMode="Recycling">
                             <ListBox.ItemTemplate>
                                 <DataTemplate>
                                     <Grid Margin="8,6">

--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -1,0 +1,70 @@
+# Preview performance and large-project validation
+
+This contract defines repeatable Release x64 validation for the preview workflows. Synthetic fixtures contain
+no private project data and complement, rather than replace, the licensed reference corpus.
+
+## Workload profiles
+
+| Profile | Entries | Typical use |
+| --- | ---: | --- |
+| Small | 1,000 | One focused MCM, XML, PEX, or ESP/ESM project |
+| Medium | 25,000 | A large single-format mod or mixed translation pass |
+| Large | 100,000 | A deliberately demanding mixed-format project |
+
+Generated entries use stable identities, four format labels, placeholders, untranslated targets, and
+low-confidence records. Reference-corpus revisions must be recorded separately when parser and export timings
+are measured.
+
+## Budgets
+
+Budgets apply on documented desktop hardware after one warm-up run. Every measurement records the source
+revision, Release x64 configuration, operating system, processor, logical processor count, and physical memory.
+
+| Interaction | Small | Medium | Large |
+| --- | ---: | ---: | ---: |
+| Shell visible and interactive | 3 s | 3 s | 3 s |
+| Generated project open | 500 ms | 1.5 s | 5 s |
+| Reference-corpus project open on SSD | 2 s | 8 s | 30 s |
+| Search or filter result | 100 ms | 250 ms | 750 ms |
+| Quality validation | 500 ms | 2 s | 7 s |
+| Revision comparison | 500 ms | 1.5 s | 5 s |
+| Reference-corpus export on SSD | 2 s | 10 s | 45 s |
+| Selection or navigation response | 100 ms | 100 ms | 100 ms |
+| Cooperative cancellation latency | 250 ms | 250 ms | 250 ms |
+
+Record real parser and export values with the fixture revision and storage type because archive layout and
+storage throughput dominate them. UI-thread dispatch gaps should remain below 100 ms while parser, validation,
+comparison, provider, or export work is active.
+
+After five open, close, validate, compare, and export cycles, force a full collection only for measurement. The
+retained private-byte increase must remain below 64 MiB and the process-handle increase below 16. A repeatable
+increase across two fresh processes is a failure even when it remains within those limits.
+
+## Automated measurement
+
+1. Restore dependencies and build `PhoenixTranslator.sln` as Release x64.
+2. Close other CPU- or disk-intensive applications and run one warm-up measurement.
+3. Run `scripts/Measure-PreviewPerformance.ps1` again. Optionally pass `-ReportPath` to retain the output.
+4. Attach the report to the relevant issue or pull request. Do not commit machine-specific reports.
+
+The runner measures generated-project open, filtering, quality validation, and stable-identity revision
+comparison for every profile. It exits with a failure when a budget is missed. Normal regression tests also
+verify that validation and comparison honor a pre-cancelled token.
+
+## UI and lifecycle validation
+
+Use Windows Performance Recorder or the Visual Studio profiler for operations that miss a budget. Separate UI
+thread activity from parser, provider, storage, and comparison work before assigning ownership. During each
+profile:
+
+1. Open and navigate the project, then search and change filters while background work is active.
+2. Cancel translation, validation, comparison, and export after work has started and record response latency.
+3. Confirm progress remains visible, no partial translation or export is committed, and the prior usable state
+   remains available.
+4. Repeat five complete cycles and record private bytes, managed heap size, process handles, and UI-thread gaps.
+5. Capture a profile for every missed budget and create a focused follow-up in the repository that owns the
+   measured bottleneck.
+
+Large preview entry, review, finding, history, comparison, provider-pipeline, and diagnostics collections use
+WPF recycling virtualization with logical scrolling. Do not place these controls inside an unbounded vertical
+panel, because doing so disables effective container virtualization.

--- a/scripts/Measure-PreviewPerformance.ps1
+++ b/scripts/Measure-PreviewPerformance.ps1
@@ -1,0 +1,43 @@
+param(
+    [string]$ReportPath
+)
+
+$ErrorActionPreference = 'Stop'
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$runner = Join-Path $repositoryRoot 'PhoenixTranslator.PresetTests\bin\x64\Release\PhoenixTranslator.PresetTests.exe'
+
+if (-not (Test-Path -LiteralPath $runner)) {
+    throw 'Build the Release x64 solution before measuring preview performance.'
+}
+
+$processor = Get-CimInstance Win32_Processor | Select-Object -First 1
+$computer = Get-CimInstance Win32_ComputerSystem
+$revision = git -C $repositoryRoot rev-parse HEAD
+$workingTreeDirty = -not [string]::IsNullOrWhiteSpace((git -C $repositoryRoot status --porcelain))
+$lines = @(
+    "TimestampUtc,$([DateTime]::UtcNow.ToString('o'))"
+    "Revision,$revision"
+    "WorkingTreeDirty,$workingTreeDirty"
+    "Configuration,Release x64"
+    "OperatingSystem,$([Environment]::OSVersion.VersionString)"
+    "Processor,$($processor.Name.Trim())"
+    "LogicalProcessors,$($computer.NumberOfLogicalProcessors)"
+    "MemoryBytes,$($computer.TotalPhysicalMemory)"
+)
+
+$measurement = & $runner --performance 2>&1
+$exitCode = $LASTEXITCODE
+$lines += $measurement
+$lines | Write-Output
+
+if (-not [string]::IsNullOrWhiteSpace($ReportPath)) {
+    $resolvedReportPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($ReportPath)
+    $reportDirectory = Split-Path -Parent $resolvedReportPath
+    if (-not (Test-Path -LiteralPath $reportDirectory)) {
+        New-Item -ItemType Directory -Path $reportDirectory | Out-Null
+    }
+
+    $lines | Set-Content -LiteralPath $resolvedReportPath -Encoding UTF8
+}
+
+exit $exitCode


### PR DESCRIPTION
## Summary

- move preview quality validation off the UI thread with debounced stale-result cancellation
- add cooperative cancellation to quality validation and revision comparison
- enable recycling virtualization and logical scrolling for large preview collections
- define small, medium, and large workload budgets with a repeatable Release x64 measurement script
- validate five repeated 100,000-entry lifecycle cycles for retained memory and handles
- bump Phoenix Translator to 2.0.0.19

## Validation

- Release x64 solution build
- preview message catalogue verification
- preview icon catalogue verification
- 53 preset regression tests
- performance profiles: 1,000, 25,000, and 100,000 entries
- five 100,000-entry lifecycle cycles: 1,463,104 managed bytes retained, 143,360 private bytes retained, 0 handles retained

Closes #35
